### PR TITLE
chore: deprecate interceptor wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@axonflow/sdk",
       "version": "1.3.0",
       "license": "MIT",
+      "dependencies": {
+        "openai": "^6.15.0"
+      },
       "devDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.955.0",
         "@types/jest": "^29.0.0",
@@ -5619,6 +5622,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.15.0.tgz",
+      "integrity": "sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -74,5 +74,8 @@
     "prettier": "^3.6.2",
     "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "openai": "^6.15.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,18 @@
  */
 
 export { AxonFlow } from './client';
+
+// LLM Interceptor Wrappers (DEPRECATED - use Gateway Mode or Proxy Mode instead)
+// These will be removed in v2.0.0. See: https://docs.getaxonflow.com/sdk/gateway-mode
+/** @deprecated Use Gateway Mode or Proxy Mode instead */
 export { wrapOpenAIClient } from './interceptors/openai';
+/** @deprecated Use Gateway Mode or Proxy Mode instead */
 export { wrapAnthropicClient } from './interceptors/anthropic';
+/** @deprecated Use Gateway Mode or Proxy Mode instead */
 export { wrapGeminiModel } from './interceptors/gemini';
+/** @deprecated Use Gateway Mode or Proxy Mode instead */
 export { wrapOllamaClient } from './interceptors/ollama';
+/** @deprecated Use Gateway Mode or Proxy Mode instead */
 export { wrapBedrockClient } from './interceptors/bedrock';
 
 // Export error classes for proper error handling
@@ -56,7 +64,7 @@ export type {
 } from './types';
 
 // Export version
-export const VERSION = '1.3.0';
+export const VERSION = '1.4.0';
 
 // Default export for convenience
 import { AxonFlow } from './client';

--- a/src/interceptors/anthropic.ts
+++ b/src/interceptors/anthropic.ts
@@ -49,8 +49,37 @@ export class AnthropicInterceptor extends BaseInterceptor {
 
 /**
  * Helper to wrap Anthropic client for easier interception
+ *
+ * @deprecated This function is deprecated and will be removed in v2.0.0.
+ * Modern Anthropic SDK versions use private class fields that are incompatible
+ * with JavaScript Proxy-based wrapping.
+ *
+ * Use Gateway Mode or Proxy Mode instead:
+ *
+ * Gateway Mode (recommended):
+ * ```typescript
+ * const context = await axonflow.getPolicyApprovedContext({ query, userToken });
+ * const response = await anthropic.messages.create({ ... });
+ * await axonflow.auditLLMCall({ contextId: context.contextId, ... });
+ * ```
+ *
+ * Proxy Mode:
+ * ```typescript
+ * const response = await axonflow.executeQuery({
+ *   query,
+ *   userToken,
+ *   context: { provider: 'anthropic', model: 'claude-3-sonnet' }
+ * });
+ * ```
+ *
+ * See: https://docs.getaxonflow.com/sdk/gateway-mode
  */
 export function wrapAnthropicClient(anthropicClient: any, axonflow: any): any {
+  console.warn(
+    '[AxonFlow] wrapAnthropicClient is deprecated and will be removed in v2.0.0. ' +
+      'Use Gateway Mode (getPolicyApprovedContext + auditLLMCall) or Proxy Mode (executeQuery) instead. ' +
+      'See: https://docs.getaxonflow.com/sdk/gateway-mode'
+  );
   // Create a proxy that intercepts method calls
   return new Proxy(anthropicClient, {
     get(target, prop, receiver) {

--- a/src/interceptors/bedrock.ts
+++ b/src/interceptors/bedrock.ts
@@ -155,29 +155,36 @@ export interface BedrockTitanResponse {
 /**
  * Wraps an AWS Bedrock client with AxonFlow governance.
  *
- * @example
+ * @deprecated This function is deprecated and will be removed in v2.0.0.
+ * JavaScript Proxy-based wrapping has compatibility issues with modern SDK versions.
+ *
+ * Use Gateway Mode or Proxy Mode instead:
+ *
+ * Gateway Mode (recommended):
  * ```typescript
- * import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
- * import { AxonFlow, wrapBedrockClient } from '@axonflow/sdk';
- *
- * const bedrock = new BedrockRuntimeClient({ region: 'us-east-1' });
- * const axonflow = new AxonFlow({ endpoint: 'http://localhost:8080' });
- *
- * const wrapped = wrapBedrockClient(bedrock, axonflow);
- *
- * const command = new InvokeModelCommand({
- *   modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
- *   body: JSON.stringify({
- *     anthropic_version: 'bedrock-2023-05-31',
- *     max_tokens: 1024,
- *     messages: [{ role: 'user', content: 'Hello!' }]
- *   })
- * });
- *
- * const response = await wrapped.send(command);
+ * const context = await axonflow.getPolicyApprovedContext({ query, userToken });
+ * const response = await bedrockClient.send(new InvokeModelCommand({...}));
+ * await axonflow.auditLLMCall({ contextId: context.contextId, ... });
  * ```
+ *
+ * Proxy Mode:
+ * ```typescript
+ * const response = await axonflow.executeQuery({
+ *   query,
+ *   userToken,
+ *   context: { provider: 'bedrock', model: 'anthropic.claude-3-sonnet' }
+ * });
+ * ```
+ *
+ * See: https://docs.getaxonflow.com/sdk/gateway-mode
  */
 export function wrapBedrockClient(bedrockClient: any, axonflow: any): any {
+  console.warn(
+    '[AxonFlow] wrapBedrockClient is deprecated and will be removed in v2.0.0. ' +
+      'Use Gateway Mode (getPolicyApprovedContext + auditLLMCall) or Proxy Mode (executeQuery) instead. ' +
+      'See: https://docs.getaxonflow.com/sdk/gateway-mode'
+  );
+
   const originalSend = bedrockClient.send.bind(bedrockClient);
 
   bedrockClient.send = async (command: any) => {

--- a/src/interceptors/gemini.ts
+++ b/src/interceptors/gemini.ts
@@ -112,22 +112,35 @@ export interface GeminiGenerateContentResponse {
 /**
  * Helper to wrap Gemini GenerativeModel for easier interception
  *
- * @example
+ * @deprecated This function is deprecated and will be removed in v2.0.0.
+ * JavaScript Proxy-based wrapping has compatibility issues with modern SDK versions.
+ *
+ * Use Gateway Mode or Proxy Mode instead:
+ *
+ * Gateway Mode (recommended):
  * ```typescript
- * import { GoogleGenerativeAI } from '@google/generative-ai';
- * import { AxonFlow, wrapGeminiModel } from '@axonflow/sdk';
- *
- * const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
- * const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
- * const axonflow = new AxonFlow({ apiKey: process.env.AXONFLOW_API_KEY });
- *
- * const wrappedModel = wrapGeminiModel(model, axonflow);
- *
- * // Use as normal - governance is automatic
- * const result = await wrappedModel.generateContent('What is AI governance?');
+ * const context = await axonflow.getPolicyApprovedContext({ query, userToken });
+ * const response = await model.generateContent(query);
+ * await axonflow.auditLLMCall({ contextId: context.contextId, ... });
  * ```
+ *
+ * Proxy Mode:
+ * ```typescript
+ * const response = await axonflow.executeQuery({
+ *   query,
+ *   userToken,
+ *   context: { provider: 'gemini', model: 'gemini-2.0-flash' }
+ * });
+ * ```
+ *
+ * See: https://docs.getaxonflow.com/sdk/gateway-mode
  */
 export function wrapGeminiModel(geminiModel: any, axonflow: any): any {
+  console.warn(
+    '[AxonFlow] wrapGeminiModel is deprecated and will be removed in v2.0.0. ' +
+      'Use Gateway Mode (getPolicyApprovedContext + auditLLMCall) or Proxy Mode (executeQuery) instead. ' +
+      'See: https://docs.getaxonflow.com/sdk/gateway-mode'
+  );
   return new Proxy(geminiModel, {
     get(target, prop, receiver) {
       const original = Reflect.get(target, prop, receiver);

--- a/src/interceptors/ollama.ts
+++ b/src/interceptors/ollama.ts
@@ -141,30 +141,35 @@ export interface OllamaGenerateResponse {
 /**
  * Wraps an Ollama client with AxonFlow governance.
  *
- * @example
+ * @deprecated This function is deprecated and will be removed in v2.0.0.
+ * JavaScript Proxy-based wrapping has compatibility issues with modern SDK versions.
+ *
+ * Use Gateway Mode or Proxy Mode instead:
+ *
+ * Gateway Mode (recommended):
  * ```typescript
- * import Ollama from 'ollama';
- * import { AxonFlow, wrapOllamaClient } from '@axonflow/sdk';
+ * const context = await axonflow.getPolicyApprovedContext({ query, userToken });
+ * const response = await ollama.chat({ model: 'llama2', messages: [...] });
+ * await axonflow.auditLLMCall({ contextId: context.contextId, ... });
+ * ```
  *
- * const ollama = new Ollama({ host: 'http://localhost:11434' });
- * const axonflow = new AxonFlow({ endpoint: 'http://localhost:8080' });
- *
- * const wrapped = wrapOllamaClient(ollama, axonflow);
- *
- * // Chat API
- * const chatResponse = await wrapped.chat({
- *   model: 'llama2',
- *   messages: [{ role: 'user', content: 'What is AI governance?' }]
- * });
- *
- * // Generate API
- * const genResponse = await wrapped.generate({
- *   model: 'llama2',
- *   prompt: 'What is AI governance?'
+ * Proxy Mode:
+ * ```typescript
+ * const response = await axonflow.executeQuery({
+ *   query,
+ *   userToken,
+ *   context: { provider: 'ollama', model: 'llama2' }
  * });
  * ```
+ *
+ * See: https://docs.getaxonflow.com/sdk/gateway-mode
  */
 export function wrapOllamaClient(ollamaClient: any, axonflow: any): any {
+  console.warn(
+    '[AxonFlow] wrapOllamaClient is deprecated and will be removed in v2.0.0. ' +
+      'Use Gateway Mode (getPolicyApprovedContext + auditLLMCall) or Proxy Mode (executeQuery) instead. ' +
+      'See: https://docs.getaxonflow.com/sdk/gateway-mode'
+  );
   return new Proxy(ollamaClient, {
     get(target, prop, receiver) {
       const original = Reflect.get(target, prop, receiver);

--- a/src/interceptors/openai.ts
+++ b/src/interceptors/openai.ts
@@ -52,8 +52,37 @@ export class OpenAIInterceptor extends BaseInterceptor {
 
 /**
  * Helper to wrap OpenAI client for easier interception
+ *
+ * @deprecated This function is deprecated and will be removed in v2.0.0.
+ * Modern OpenAI SDK versions (v4+) use private class fields that are incompatible
+ * with JavaScript Proxy-based wrapping.
+ *
+ * Use Gateway Mode or Proxy Mode instead:
+ *
+ * Gateway Mode (recommended):
+ * ```typescript
+ * const context = await axonflow.getPolicyApprovedContext({ query, userToken });
+ * const response = await openai.chat.completions.create({ ... });
+ * await axonflow.auditLLMCall({ contextId: context.contextId, ... });
+ * ```
+ *
+ * Proxy Mode:
+ * ```typescript
+ * const response = await axonflow.executeQuery({
+ *   query,
+ *   userToken,
+ *   context: { provider: 'openai', model: 'gpt-4' }
+ * });
+ * ```
+ *
+ * See: https://docs.getaxonflow.com/sdk/gateway-mode
  */
 export function wrapOpenAIClient(openaiClient: any, axonflow: any): any {
+  console.warn(
+    '[AxonFlow] wrapOpenAIClient is deprecated and will be removed in v2.0.0. ' +
+      'Use Gateway Mode (getPolicyApprovedContext + auditLLMCall) or Proxy Mode (executeQuery) instead. ' +
+      'See: https://docs.getaxonflow.com/sdk/gateway-mode'
+  );
   // Create a proxy that intercepts method calls
   return new Proxy(openaiClient, {
     get(target, prop, receiver) {


### PR DESCRIPTION
## Summary

Mark all LLM interceptor wrapper functions as deprecated (to be removed in v2.0.0):
- `wrapOpenAIClient`
- `wrapAnthropicClient`
- `wrapGeminiModel`
- `wrapOllamaClient`
- `wrapBedrockClient`

### Why Deprecate?

These interceptor wrappers use JavaScript `Proxy` to intercept LLM client method calls. This approach is fundamentally incompatible with modern LLM SDKs (OpenAI v4+, Anthropic v0.20+) that use ES2022 private class fields (`#syntax`).

When wrapping a class with private fields:
```javascript
class OpenAI {
  #apiKey;  // Private field
}

const wrapped = new Proxy(openai, { ... });
wrapped.chat.completions.create(...)  // FAILS!
// Error: Cannot read private member from an object whose class did not declare it
```

### Recommended Alternatives

**Gateway Mode (recommended):**
```typescript
const context = await axonflow.getPolicyApprovedContext({ query, userToken });
const response = await openai.chat.completions.create({ ... });
await axonflow.auditLLMCall({ contextId: context.contextId, ... });
```

**Proxy Mode:**
```typescript
const response = await axonflow.executeQuery({
  query,
  userToken,
  context: { provider: 'openai', model: 'gpt-4' }
});
```

### Changes

- Added `@deprecated` JSDoc tags to all wrapper functions
- Added runtime `console.warn()` deprecation notices
- Updated exports with deprecation comments
- Bumped version to 1.4.0

### Note

Python, Go, and Java SDKs use different patterns (monkey-patching, interface wrapping, decorators) that don't have this issue. Only the TypeScript SDK interceptors are deprecated.

## Test plan

- [x] `npm run build` passes
- [ ] Publish to npm as 1.4.0