### PR TITLE
test: add self-hosted zero-config mode tests

### DIFF
--- a/tests/selfhosted-zero-config.test.ts
+++ b/tests/selfhosted-zero-config.test.ts
@@ -30,7 +30,8 @@ function getSelfHostedConfig() {
 }
 
 const config = getSelfHostedConfig();
-const shouldRun = config.isLocalhost || process.env.RUN_E2E_TESTS === '1';
+// Only run these tests if explicitly enabled - they require a running agent
+const shouldRun = process.env.RUN_E2E_TESTS === '1';
 const describeE2E = shouldRun ? describe : describe.skip;
 
 describeE2E('Self-Hosted Zero-Config Mode Tests', () => {


### PR DESCRIPTION
## Summary

Add comprehensive tests for the zero-configuration self-hosted mode where users can run AxonFlow without any API keys, license keys, or credentials.

This tests the "first run" experience:
1. User starts the agent with `SELF_HOSTED_MODE=true` and `SELF_HOSTED_MODE_ACKNOWLEDGED=I_UNDERSTAND_NO_AUTH`
2. User connects the SDK with no credentials
3. SDK requests succeed without authentication errors

## Test Coverage

| Category | Tests |
|----------|-------|
| Client Initialization | 4 tests - empty/undefined credentials, localhost vs non-localhost |
| Gateway Mode | 3 tests - pre-check with empty/whitespace tokens, full flow |
| Proxy Mode | 2 tests - executeQuery with empty token |
| Policy Enforcement | 2 tests - SQL injection and PII still blocked |
| Health Check | 1 test - health check without credentials |
| First-Time User | 1 test - complete first-time user flow |

## How to Run

```bash
# Against local self-hosted agent
AXONFLOW_AGENT_URL=http://localhost:8080 npm run test:e2e
```

## Related

- getaxonflow/axonflow-enterprise#682 - Issue: Zero-config self-hosted mode tests
- getaxonflow/axonflow-enterprise#683 - Agent-level tests (merged)