### PR TITLE
fix: deprecate protect() method - returns agent response instead of LLM response

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,38 @@ const axonflow = new AxonFlow({
 });
 
 // Use Gateway Mode for self-hosted
+const prompt = 'Test with self-hosted AxonFlow';
+
 const ctx = await axonflow.getPolicyApprovedContext({
   userToken: 'user-123',
-  query: 'Test with self-hosted AxonFlow'
+  query: prompt
 });
 
-if (ctx.approved) {
-  const response = await openai.chat.completions.create({
-    model: 'gpt-4',
-    messages: [{ role: 'user', content: 'Test with self-hosted AxonFlow' }]
-  });
-  console.log(response.choices[0].message.content);
+if (!ctx.approved) {
+  throw new Error(`Blocked: ${ctx.blockReason}`);
 }
+
+const startTime = Date.now();
+const response = await openai.chat.completions.create({
+  model: 'gpt-4',
+  messages: [{ role: 'user', content: prompt }]
+});
+
+// Don't forget to audit!
+await axonflow.auditLLMCall({
+  contextId: ctx.contextId,
+  responseSummary: response.choices[0].message.content?.substring(0, 100) || '',
+  provider: 'openai',
+  model: 'gpt-4',
+  tokenUsage: {
+    promptTokens: response.usage?.prompt_tokens || 0,
+    completionTokens: response.usage?.completion_tokens || 0,
+    totalTokens: response.usage?.total_tokens || 0
+  },
+  latencyMs: Date.now() - startTime
+});
+
+console.log(response.choices[0].message.content);
 ```
 
 **Self-hosted deployment:**
@@ -284,17 +304,24 @@ const axonflow = new AxonFlow({
 
 function ChatComponent() {
   const [response, setResponse] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (prompt: string) => {
-    // Use Proxy Mode for simple integrations
-    const result = await axonflow.executeQuery({
-      userToken: 'user-123',
-      query: prompt,
-      requestType: 'chat'
-    });
+    setError(null);
+    try {
+      // Use Proxy Mode for simple integrations
+      // Note: In production, get userToken from your auth context
+      const result = await axonflow.executeQuery({
+        userToken: 'user-123', // Replace with actual user token
+        query: prompt,
+        requestType: 'chat'
+      });
 
-    if (result.success) {
-      setResponse(result.data);
+      if (result.success) {
+        setResponse(result.data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
     }
   };
 
@@ -359,7 +386,8 @@ export default async function handler(req, res) {
     if (error instanceof PolicyViolationError) {
       return res.status(403).json({ error: error.blockReason });
     }
-    res.status(500).json({ error: error.message });
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(500).json({ error: message });
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -122,7 +122,7 @@ export class AxonFlow {
    *   responseSummary: response.choices[0].message.content,
    *   provider: 'openai',
    *   model: 'gpt-4',
-   *   tokenUsage: { ... },
+   *   tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
    *   latencyMs: 250
    * });
    * ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@
  *   query: 'What is the capital of France?'
  * });
  *
+ * if (!ctx.approved) {
+ *   throw new Error(`Blocked: ${ctx.blockReason}`);
+ * }
+ *
  * // 2. Make your own LLM call
  * const response = await openai.chat.completions.create({
  *   model: 'gpt-4',


### PR DESCRIPTION
## Summary
- Deprecates the `protect()` method with a console warning
- Updates docstrings to recommend Gateway Mode or Proxy Mode
- Updates README to remove all `protect()` examples
- Documents the proper patterns for LLM integration

## Problem

The `protect()` method has a fundamental design flaw reported by @gzak:
1. `extractRequest()` calls `aiCall.toString()` which returns JavaScript source code
2. This code is sent to the agent as "query" instead of the actual prompt
3. Agent returns its response format, not the LLM response
4. `protect()` returns agent data instead of executing original call

This causes `response.choices[0]` to be undefined when using `protect()`.

## Test plan
- [x] All existing tests pass (213 passed)
- [x] Deprecation warning shows when using `protect()`
- [x] Gateway Mode example works correctly
- [x] Proxy Mode example works correctly

## Recommended Patterns

### Gateway Mode (Recommended)
\`\`\`typescript
// 1. Pre-check
const ctx = await axonflow.getPolicyApprovedContext({...});

// 2. Direct LLM call
const response = await openai.chat.completions.create({...});

// 3. Audit
await axonflow.auditLLMCall({contextId: ctx.contextId, ...});
\`\`\`

### Proxy Mode
\`\`\`typescript
const response = await axonflow.executeQuery({...});
\`\`\`

Closes #13