### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2025-12-22
+
+### Deprecated
+- **`protect()` method**: Now shows deprecation warning at runtime (#14)
+  - Root cause: `extractRequest()` uses `aiCall.toString()` which returns JS source code, not runtime values
+  - This causes `response.choices[0]` to be undefined
+  - Will be removed in v2.0.0
+  - Use Gateway Mode (`getPolicyApprovedContext` + `auditLLMCall`) or Proxy Mode (`executeQuery`) instead
+
+### Changed
+- Updated README with Gateway Mode and Proxy Mode examples (removed all `protect()` examples)
+- Updated module docstring with recommended patterns and approval check example
+
+## [1.4.0] - 2025-12-19
+
+### Deprecated
+- **LLM Interceptor wrappers**: All interceptor functions now show deprecation warnings (#10)
+  - `wrapOpenAIClient()`
+  - `wrapAnthropicClient()`
+  - `wrapGeminiModel()`
+  - `wrapOllamaClient()`
+  - `wrapBedrockClient()`
+  - Will be removed in v2.0.0
+  - Use Gateway Mode or Proxy Mode instead
+
+### Changed
+- Added `@deprecated` JSDoc annotations to all interceptor exports
+- Updated documentation to recommend Gateway/Proxy Mode patterns
+
 ## [1.3.0] - 2025-12-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export type {
 } from './types';
 
 // Export version
-export const VERSION = '1.4.0';
+export const VERSION = '1.4.1';
 
 // Default export for convenience
 import { AxonFlow } from './client';


### PR DESCRIPTION
## Summary
Release v1.4.1 with version bump and CHANGELOG updates.

## Changes
- Bump version to 1.4.1 in `package.json` and `src/index.ts`
- Add CHANGELOG entry for v1.4.0 (interceptor deprecation)
- Add CHANGELOG entry for v1.4.1 (protect() deprecation)

## Release Notes

### v1.4.1
- **Deprecated**: `protect()` method now shows runtime warning
- Root cause: `extractRequest()` returns JS source code, not runtime values
- Migration: Use Gateway Mode or Proxy Mode instead

### v1.4.0  
- **Deprecated**: All LLM interceptor wrappers (`wrapOpenAIClient`, etc.)
- Migration: Use Gateway Mode or Proxy Mode instead

## After Merge
1. Create GitHub release with tag v1.4.1
2. Publish to npm