### PR TITLE
fix(map): add mapTimeout config and fix plan_id parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **MAP Timeout Configuration** - New `mapTimeout` config option (default: 120000ms) for Multi-Agent Planning operations
+  - MAP operations involve multiple LLM calls and can take 30-60+ seconds
+  - `generatePlan()` now uses the longer MAP timeout
+
+### Fixed
+
+- **Plan ID Parsing** - Fixed `plan_id` extraction to check both top-level and nested `data.plan_id`
+
 ## [1.4.1] - 2025-12-22
 
 ### Deprecated

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,7 @@ export class AxonFlow {
     tenant: string;
     debug: boolean;
     timeout: number;
+    mapTimeout: number;
     retry: { enabled: boolean; maxAttempts: number; delay: number };
     cache: { enabled: boolean; ttl: number };
   };
@@ -65,6 +66,7 @@ export class AxonFlow {
       tenant: config.tenant || 'default',
       debug: config.debug || false,
       timeout: config.timeout || 30000,
+      mapTimeout: config.mapTimeout || 120000, // 2 minutes for MAP operations
       retry: {
         enabled: config.retry?.enabled !== false,
         maxAttempts: config.retry?.maxAttempts || 3,
@@ -663,11 +665,12 @@ export class AxonFlow {
       headers['X-License-Key'] = this.config.licenseKey;
     }
 
+    // Use mapTimeout for MAP operations (default 2 minutes)
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
-      signal: AbortSignal.timeout(this.config.timeout),
+      signal: AbortSignal.timeout(this.config.mapTimeout),
     });
 
     if (!response.ok) {
@@ -683,12 +686,15 @@ export class AxonFlow {
       throw new Error(`Plan generation failed: ${agentResponse.error}`);
     }
 
+    // plan_id can be at top level or inside data
+    const planId = agentResponse.plan_id || agentResponse.data?.plan_id;
+
     if (this.config.debug) {
-      debugLog('Plan generated', { planId: agentResponse.plan_id });
+      debugLog('Plan generated', { planId });
     }
 
     return {
-      planId: agentResponse.plan_id,
+      planId,
       steps: agentResponse.data?.steps || [],
       domain: agentResponse.data?.domain || domain || 'generic',
       complexity: agentResponse.data?.complexity || 0,
@@ -721,11 +727,12 @@ export class AxonFlow {
       headers['X-License-Key'] = this.config.licenseKey;
     }
 
+    // Use mapTimeout for MAP operations (default 2 minutes)
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
-      signal: AbortSignal.timeout(this.config.timeout),
+      signal: AbortSignal.timeout(this.config.mapTimeout),
     });
 
     if (!response.ok) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,6 +46,13 @@ export interface AxonFlowConfig {
   timeout?: number;
 
   /**
+   * Timeout for Multi-Agent Planning (MAP) operations in milliseconds.
+   * MAP operations can take longer as they involve multiple LLM calls.
+   * Default: 120000 (2 minutes)
+   */
+  mapTimeout?: number;
+
+  /**
    * Retry configuration
    */
   retry?: {


### PR DESCRIPTION
## Summary
- Add `mapTimeout` config option (default: 120000ms / 2 minutes)
- Fix `plan_id` extraction to check both top-level and nested `data.plan_id`
- Update `generatePlan()` to use the longer MAP timeout

## Why
MAP (Multi-Agent Planning) operations involve multiple LLM calls and can take 30-60+ seconds. The default 30s timeout causes timeouts for complex queries.

Additionally, the Agent API returns `plan_id` nested in `data.plan_id`, which wasn't being extracted correctly.

## Test plan
- [x] All 226 unit tests pass
- [x] MAP example tested successfully against staging

## CHANGELOG
Updated with [Unreleased] section.