### PR TITLE
fix(ci): use OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,3 @@ jobs:
 
     - name: Publish to npm
       run: npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Switch to npm Trusted Publishing (OIDC) instead of using NPM_TOKEN secret.

Trusted Publisher is now configured on npm for this repository.

## Changes

- Remove `NODE_AUTH_TOKEN` env var from publish step
- OIDC authentication happens automatically via `id-token: write` permission