### PR TITLE
fix(ci): restore NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,3 +32,5 @@ jobs:
 
     - name: Publish to npm
       run: npm publish --provenance --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Restore the NODE_AUTH_TOKEN env var that was accidentally removed. Uses NPM_TOKEN secret.