### PR TITLE
feat(types): add require_approval action for HITL workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -34,13 +34,24 @@ export type PolicyTier = 'system' | 'organization' | 'tenant';
 
 /**
  * Override action for policy overrides
+ * - block: Immediately block the request
+ * - require_approval: Pause for human approval (HITL)
+ * - redact: Mask sensitive content
+ * - warn: Log warning, allow request
+ * - log: Audit only
  */
-export type OverrideAction = 'block' | 'warn' | 'log' | 'redact';
+export type OverrideAction = 'block' | 'require_approval' | 'redact' | 'warn' | 'log';
 
 /**
  * Action to take when policy matches
+ * - block: Immediately block the request
+ * - require_approval: Pause for human approval (HITL)
+ * - redact: Mask sensitive content
+ * - warn: Log warning, allow request
+ * - log: Audit only
+ * - allow: Explicitly allow (for overrides)
  */
-export type PolicyAction = 'block' | 'warn' | 'log' | 'redact' | 'allow';
+export type PolicyAction = 'block' | 'require_approval' | 'redact' | 'warn' | 'log' | 'allow';
 
 /**
  * Policy severity levels


### PR DESCRIPTION
## Summary
- Add `require_approval` to PolicyAction and OverrideAction types
- Enables Human-in-the-Loop (HITL) workflows for AI oversight

## Changes
- Updated `PolicyAction` type to include `require_approval`
- Updated `OverrideAction` type to include `require_approval`
- Added detailed JSDoc comments explaining each action

## Use Cases
- EU AI Act Article 14 compliance (human oversight for high-risk AI)
- SEBI AI/ML Circular (high-value transaction oversight)
- Admin access detection and sensitive data access control

## Behavior
| Edition | Behavior |
|---------|----------|
| Enterprise | Pauses execution, creates approval request in HITL queue |
| Community | Auto-approves immediately (upgrade path) |

## Testing
- All existing tests pass
- Build successful