### PR TITLE
fix: bump version to 1.6.0 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
The v1.6.0 release failed to publish to npm because package.json version was still 1.5.0. This PR bumps the version so we can retrigger the release.