### PR TITLE
feat(client): add demo mode via AXONFLOW_DEMO env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.3.0] - Unreleased
+## [5.3.0] - 2026-04-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,22 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `registerTry()` helper in `@axonflow/sdk/community` for self-registering a tenant
 - Checkpoint telemetry reports `endpoint_type: "community-saas"` when try mode is active
 
-### Changed
-
-- Renamed `AXONFLOW_DEMO` to `AXONFLOW_TRY` (demo mode → try mode)
-- Removed client-side random suffix from clientId (server generates UUID tenant_id)
-
-### Fixed
-
-- **IPv6 endpoint classification.** `classifyEndpoint` now handles IPv6 private ranges and expanded loopback forms that previously fell through to `remote`, matching the Python and Go SDK implementations:
-  - IPv6 ULA (`fc00::/7`, RFC 4193) → `private_network`
-  - IPv6 link-local (`fe80::/10`) → `private_network`
-  - Expanded IPv6 loopback (`0:0:0:0:0:0:0:1`, zero-padded forms) → `localhost`
-  - IPv6 unspecified (`::`) → `localhost` (symmetric with `0.0.0.0`)
-  - Public IPv6 addresses (`2001::/3` space) → `remote`
-- The previous v5.2.0 classifier only recognized IPv4 private ranges and hostname suffixes, leaving self-hosted IPv6 deployments miscounted as remote traffic on the checkpoint dashboard.
-- **Strengthened payload-leak regression test** — the previous v5.2.0 test was a type-shape check only. It now serializes a payload built from a realistic sensitive URL and asserts that no URL fragment (hostname, domain, port, scheme) leaks into the JSON body.
-
 ---
 
 ## [5.2.0] - 2026-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.3.0] - Release Pending (2026-04-09)
+## [5.3.0] - Unreleased
+
+### Added
+
+- `AXONFLOW_TRY=1` environment variable to connect to `try.getaxonflow.com` shared evaluation server
+- `registerTry()` helper in `@axonflow/sdk/community` for self-registering a tenant
+- Checkpoint telemetry reports `endpoint_type: "community-saas"` when try mode is active
+
+### Changed
+
+- Renamed `AXONFLOW_DEMO` to `AXONFLOW_TRY` (demo mode → try mode)
+- Removed client-side random suffix from clientId (server generates UUID tenant_id)
 
 ### Fixed
 
@@ -16,9 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - IPv6 unspecified (`::`) → `localhost` (symmetric with `0.0.0.0`)
   - Public IPv6 addresses (`2001::/3` space) → `remote`
 - The previous v5.2.0 classifier only recognized IPv4 private ranges and hostname suffixes, leaving self-hosted IPv6 deployments miscounted as remote traffic on the checkpoint dashboard.
-
-### Changed
-
 - **Strengthened payload-leak regression test** — the previous v5.2.0 test was a type-shape check only. It now serializes a payload built from a realistic sensitive URL and asserts that no URL fragment (hostname, domain, port, scheme) leaks into the JSON body.
 
 ---

--- a/src/client.ts
+++ b/src/client.ts
@@ -218,15 +218,14 @@ export class AxonFlow {
       );
     }
 
-    // Demo mode: when AXONFLOW_DEMO=1 is set, override endpoint and require clientId
-    if (process.env['AXONFLOW_DEMO'] === '1') {
+    // Try mode: when AXONFLOW_TRY=1 is set, override endpoint and require clientId
+    if (process.env['AXONFLOW_TRY'] === '1') {
       if (!config.clientId) {
-        throw new ConfigurationError('clientId is required in demo mode (AXONFLOW_DEMO=1)');
+        throw new ConfigurationError('clientId is required in try mode (AXONFLOW_TRY=1)');
       }
       config = {
         ...config,
-        endpoint: 'https://demo.getaxonflow.com',
-        clientId: `${config.clientId}-${Math.random().toString(36).slice(2, 8)}`,
+        endpoint: 'https://try.getaxonflow.com',
       };
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -223,7 +223,11 @@ export class AxonFlow {
       if (!config.clientId) {
         throw new ConfigurationError('clientId is required in demo mode (AXONFLOW_DEMO=1)');
       }
-      config = { ...config, endpoint: 'https://demo.getaxonflow.com' };
+      config = {
+        ...config,
+        endpoint: 'https://demo.getaxonflow.com',
+        clientId: `${config.clientId}-${Math.random().toString(36).slice(2, 8)}`,
+      };
     }
 
     // Set defaults first to determine endpoint

--- a/src/client.ts
+++ b/src/client.ts
@@ -218,6 +218,14 @@ export class AxonFlow {
       );
     }
 
+    // Demo mode: when AXONFLOW_DEMO=1 is set, override endpoint and require clientId
+    if (process.env['AXONFLOW_DEMO'] === '1') {
+      if (!config.clientId) {
+        throw new ConfigurationError('clientId is required in demo mode (AXONFLOW_DEMO=1)');
+      }
+      config = { ...config, endpoint: 'https://demo.getaxonflow.com' };
+    }
+
     // Set defaults first to determine endpoint
     const endpoint = config.endpoint || 'https://staging-eu.getaxonflow.com';
 

--- a/src/community.ts
+++ b/src/community.ts
@@ -19,7 +19,7 @@ export interface TryRegistration {
  */
 export async function registerTry(
   label?: string,
-  endpoint: string = TRY_ENDPOINT,
+  endpoint: string = TRY_ENDPOINT
 ): Promise<TryRegistration> {
   const response = await fetch(`${endpoint}/api/v1/register`, {
     method: 'POST',

--- a/src/community.ts
+++ b/src/community.ts
@@ -1,0 +1,34 @@
+/**
+ * Community SaaS registration helper for try.getaxonflow.com.
+ */
+
+const TRY_ENDPOINT = 'https://try.getaxonflow.com';
+
+export interface TryRegistration {
+  tenant_id: string;
+  secret: string;
+  secret_prefix: string;
+  expires_at: string;
+  endpoint: string;
+  note: string;
+}
+
+/**
+ * Register for a free evaluation tenant on try.getaxonflow.com.
+ * Store the secret securely — it is shown only once.
+ */
+export async function registerTry(
+  label?: string,
+  endpoint: string = TRY_ENDPOINT,
+): Promise<TryRegistration> {
+  const response = await fetch(`${endpoint}/api/v1/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(label ? { label } : {}),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Registration failed (${response.status}): ${text}`);
+  }
+  return response.json();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,6 +378,10 @@ export type {
   DisableKillSwitchRequest,
 } from './types/masfeat';
 
+// Export community SaaS registration helper
+export { registerTry } from './community';
+export type { TryRegistration } from './community';
+
 // Export version
 export { VERSION } from './version';
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -103,7 +103,12 @@ export interface TelemetryPayload {
   instance_id: string;
 }
 
-export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown' | 'community-saas';
+export type EndpointType =
+  | 'localhost'
+  | 'private_network'
+  | 'remote'
+  | 'unknown'
+  | 'community-saas';
 
 /**
  * Classify the configured AxonFlow endpoint URL for analytics (#1525).

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -103,7 +103,7 @@ export interface TelemetryPayload {
   instance_id: string;
 }
 
-export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown';
+export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown' | 'community-saas';
 
 /**
  * Classify the configured AxonFlow endpoint URL for analytics (#1525).
@@ -125,6 +125,10 @@ export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown
  * http://[fd00::1]:8080 fell through to "remote" (review finding P3).
  */
 export function classifyEndpoint(url: string | null | undefined): EndpointType {
+  if (process.env.AXONFLOW_TRY === '1') {
+    return 'community-saas';
+  }
+
   if (!url) return 'unknown';
 
   let host: string;


### PR DESCRIPTION
Addresses https://github.com/getaxonflow/axonflow-enterprise/issues/1500.

## Changes

**Commit 1 — demo mode:** When `AXONFLOW_DEMO=1` is set, the client overrides `endpoint` to the public demo instance (`https://demo.getaxonflow.com`, placeholder URL pending the instance being stood up) and makes `clientId` mandatory.

**Commit 2 — random suffix:** In demo mode, a 6-character random alphanumeric suffix is appended to the provided `clientId` (e.g. `acme` → `acme-k4p2rz`). This gives each evaluator session a unique namespace on the shared demo instance without requiring them to choose a globally unique ID.

## Notes

- No behavior change when `AXONFLOW_DEMO` is unset.
- Demo URL is a placeholder — PRs will be updated with the real URL before merge.