### PR TITLE
release(v5.2.0): telemetry endpoint_type field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0] - 2026-04-09
+
+### Added
+
+- **Telemetry `endpoint_type` field.** The anonymous telemetry ping now includes an SDK-derived classification of the configured AxonFlow endpoint as one of `localhost`, `private_network`, `remote`, or `unknown`. The raw URL is never sent and is not hashed. This helps distinguish self-hosted evaluation from real production deployments on the checkpoint dashboard. Opt out as before via `DO_NOT_TRACK=1` or `AXONFLOW_TELEMETRY=off`.
+- **`classifyEndpoint(url)` and `EndpointType` type** exported from `src/telemetry.ts` for applications that want to inspect the classification.
+
+### Changed
+
+- Examples and documentation updated to reflect the new AxonFlow platform v6.2.0 defaults for `PII_ACTION` (now `warn` — was `redact`) and the new `AXONFLOW_PROFILE` env var. No SDK API changes.
+
+---
+
 ## [5.1.0] - 2026-04-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "5.0.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "5.0.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -93,8 +93,82 @@ export interface TelemetryPayload {
   arch: string;
   runtime_version: string;
   deployment_mode: string;
+  /**
+   * Classification of the configured AxonFlow endpoint URL, derived on the
+   * SDK side. One of: "localhost", "private_network", "remote", "unknown".
+   * The raw URL is never sent. See issue #1525.
+   */
+  endpoint_type: EndpointType;
   features: string[];
   instance_id: string;
+}
+
+export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown';
+
+/**
+ * Classify the configured AxonFlow endpoint URL for analytics (#1525).
+ *
+ * Returns one of:
+ *   - "localhost": localhost, 127.0.0.1, ::1, 0.0.0.0, *.localhost
+ *   - "private_network": RFC1918 v4, link-local, *.internal, *.local, *.lan, *.intranet
+ *   - "remote": everything else (public hostnames and IPs)
+ *   - "unknown": on parse failure
+ *
+ * The raw URL is never sent to the checkpoint service — only the classification.
+ */
+export function classifyEndpoint(url: string | null | undefined): EndpointType {
+  if (!url) return 'unknown';
+
+  let host: string;
+  try {
+    const parsed = new URL(url);
+    host = parsed.hostname.toLowerCase();
+  } catch {
+    return 'unknown';
+  }
+  if (!host) return 'unknown';
+
+  // Node's URL parser returns IPv6 hostnames with surrounding brackets,
+  // e.g. "[::1]". Strip them so the comparison below works.
+  if (host.startsWith('[') && host.endsWith(']')) {
+    host = host.slice(1, -1);
+  }
+
+  // IPv6 addresses in URLs come back from URL().hostname with brackets
+  // stripped, so ::1 and ::1 literal both pass through as "::1".
+  if (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '::1' ||
+    host === '0.0.0.0' ||
+    host.endsWith('.localhost')
+  ) {
+    return 'localhost';
+  }
+
+  if (
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    host.endsWith('.lan') ||
+    host.endsWith('.intranet')
+  ) {
+    return 'private_network';
+  }
+
+  // IPv4 classification.
+  const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4Match) {
+    const [a, b] = [parseInt(ipv4Match[1], 10), parseInt(ipv4Match[2], 10)];
+    if (a === 10) return 'private_network';
+    if (a === 192 && b === 168) return 'private_network';
+    if (a === 172 && b >= 16 && b <= 31) return 'private_network';
+    if (a === 169 && b === 254) return 'private_network'; // link-local
+    if (a === 127) return 'localhost'; // 127.0.0.0/8
+    return 'remote';
+  }
+
+  // Anything else — a public hostname — is remote.
+  return 'remote';
 }
 
 /**
@@ -137,6 +211,7 @@ export function sendTelemetryPing(options: {
     arch: typeof process !== 'undefined' ? process.arch : 'unknown',
     runtime_version: typeof process !== 'undefined' ? process.version.replace(/^v/, '') : 'unknown',
     deployment_mode: options.mode,
+    endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
   };

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '5.1.0';
+export const VERSION = '5.2.0';

--- a/test/telemetry-endpoint-type.test.ts
+++ b/test/telemetry-endpoint-type.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for classifyEndpoint (issue #1525).
+ */
+import { classifyEndpoint, TelemetryPayload } from '../src/telemetry';
+
+describe('classifyEndpoint', () => {
+  describe('localhost', () => {
+    it('classifies hostname localhost', () => {
+      expect(classifyEndpoint('http://localhost:8080')).toBe('localhost');
+      expect(classifyEndpoint('https://localhost')).toBe('localhost');
+    });
+    it('classifies IPv4 127.0.0.1', () => {
+      expect(classifyEndpoint('http://127.0.0.1')).toBe('localhost');
+      expect(classifyEndpoint('http://127.0.0.1:8080')).toBe('localhost');
+    });
+    it('classifies IPv6 ::1', () => {
+      expect(classifyEndpoint('http://[::1]')).toBe('localhost');
+      expect(classifyEndpoint('http://[::1]:8080')).toBe('localhost');
+    });
+    it('classifies 0.0.0.0', () => {
+      expect(classifyEndpoint('http://0.0.0.0:8080')).toBe('localhost');
+    });
+    it('classifies *.localhost', () => {
+      expect(classifyEndpoint('http://agent.localhost')).toBe('localhost');
+    });
+    it('classifies 127/8 as localhost', () => {
+      expect(classifyEndpoint('http://127.1.2.3')).toBe('localhost');
+    });
+  });
+
+  describe('private_network', () => {
+    it('classifies RFC1918 10.x', () => {
+      expect(classifyEndpoint('http://10.0.0.1')).toBe('private_network');
+      expect(classifyEndpoint('http://10.1.2.3')).toBe('private_network');
+    });
+    it('classifies RFC1918 192.168.x', () => {
+      expect(classifyEndpoint('http://192.168.1.1')).toBe('private_network');
+    });
+    it('classifies RFC1918 172.16-31', () => {
+      expect(classifyEndpoint('http://172.16.0.1')).toBe('private_network');
+      expect(classifyEndpoint('http://172.31.255.254')).toBe('private_network');
+    });
+    it('does NOT classify 172.15 or 172.32 as private', () => {
+      expect(classifyEndpoint('http://172.15.0.1')).toBe('remote');
+      expect(classifyEndpoint('http://172.32.0.1')).toBe('remote');
+    });
+    it('classifies link-local 169.254', () => {
+      expect(classifyEndpoint('http://169.254.169.254')).toBe('private_network');
+    });
+    it('classifies .internal and .local and .lan and .intranet', () => {
+      expect(classifyEndpoint('http://agent.internal')).toBe('private_network');
+      expect(classifyEndpoint('http://agent.local')).toBe('private_network');
+      expect(classifyEndpoint('http://agent.lan')).toBe('private_network');
+      expect(classifyEndpoint('http://agent.intranet')).toBe('private_network');
+    });
+  });
+
+  describe('remote', () => {
+    it('classifies public hostnames', () => {
+      expect(classifyEndpoint('https://production-us.getaxonflow.com')).toBe('remote');
+      expect(classifyEndpoint('https://api.example.com')).toBe('remote');
+    });
+    it('classifies public IPv4', () => {
+      expect(classifyEndpoint('http://8.8.8.8')).toBe('remote');
+      expect(classifyEndpoint('http://1.1.1.1')).toBe('remote');
+    });
+  });
+
+  describe('unknown', () => {
+    it('classifies empty string', () => {
+      expect(classifyEndpoint('')).toBe('unknown');
+    });
+    it('classifies null', () => {
+      expect(classifyEndpoint(null)).toBe('unknown');
+    });
+    it('classifies undefined', () => {
+      expect(classifyEndpoint(undefined)).toBe('unknown');
+    });
+    it('classifies malformed URL', () => {
+      expect(classifyEndpoint('not-a-url')).toBe('unknown');
+      expect(classifyEndpoint('://nohost')).toBe('unknown');
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('uppercase host becomes lowercase', () => {
+      expect(classifyEndpoint('http://LOCALHOST')).toBe('localhost');
+      expect(classifyEndpoint('http://AGENT.INTERNAL')).toBe('private_network');
+    });
+  });
+});
+
+describe('TelemetryPayload shape', () => {
+  it('type includes endpoint_type', () => {
+    // Compile-time check via type assertion. No runtime assert needed.
+    const p: TelemetryPayload = {
+      sdk: 'typescript',
+      sdk_version: '5.2.0',
+      platform_version: null,
+      os: 'linux',
+      arch: 'x64',
+      runtime_version: '20',
+      deployment_mode: 'production',
+      endpoint_type: 'localhost',
+      features: [],
+      instance_id: 'test',
+    };
+    expect(p.endpoint_type).toBe('localhost');
+  });
+});


### PR DESCRIPTION
## Summary

TS SDK v5.2.0 (dated 2026-04-09) — adds the telemetry `endpoint_type` field (issue #1525 tracked in axonflow-enterprise) so the checkpoint dashboard can distinguish localhost evaluation from real production deployments without sending the raw URL.

## Changes

- **`classifyEndpoint(url)` and `EndpointType` type** exported publicly
- Classifications: `localhost` (hostname, 127/8, ::1, 0.0.0.0, *.localhost), `private_network` (RFC1918, link-local, *.internal, *.local, *.lan, *.intranet), `remote` (everything else), `unknown` (parse failure)
- IPv6 hostname unwrapping: `URL()` returns `[::1]` with brackets; we strip them before comparison
- 20 unit tests covering every classification branch + boundary cases (172.15 / 172.32)
- Version bumps 5.1.0 → 5.2.0 in both `src/version.ts` and `package.json`
- CHANGELOG entry

## Non-goals

- Does not send the raw URL or any hash of it
- Does not override `deployment_mode`
- Does not auto-suppress localhost telemetry

## Test plan

- [x] `npx jest test/telemetry-endpoint-type.test.ts` passes 20/20
- [ ] E2E against checkpoint staging after merge

## Related

- axonflow-enterprise#1547 ships the checkpoint lambda changes