### PR TITLE
feat: explainDecision + audit search filter parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from a specific checkpoint with fresh policy evaluation (Enterprise).
 - **Checkpoint types** — `Checkpoint`, `CheckpointListResponse`, and
   `ResumeFromCheckpointResponse` interfaces.
+- **`AxonFlow.explainDecision(decisionId)`** — fetches the full explanation for a
+  previously-made policy decision via `GET /api/v1/decisions/:id/explain`.
+  Returns a `DecisionExplanation` with matched policies, risk level, reason,
+  override availability, existing override ID (if any), and a rolling-24h
+  session hit count for the matched rule. Shape is frozen; additive-only
+  fields ensure forward compatibility.
+- **`DecisionExplanation`, `ExplainPolicy`, `ExplainRule`** — new TypeScript
+  interfaces exported from `@axonflow/sdk`.
+- **`AuditSearchRequest.decisionId`, `.policyName`, `.overrideId`** — three
+  new optional filter fields on `searchAuditLogs`. Use `decisionId` to gather
+  every record tied to one decision; `policyName` to find everything matched
+  by a specific policy; `overrideId` to reconstruct an override's full
+  lifecycle (`override_created` → `override_used` → `override_expired | override_revoked`).
+
+### Compatibility
+
+Companion to platform v7.1.0. Works against plugin releases (OpenClaw v1.3.0+,
+Claude Code v0.5.0+, Cursor v0.5.0+, Codex v0.4.0+) that surface the
+`DecisionExplanation` shape. Audit filter fields pass through when unset;
+server-side filtering activates on v7.1.0+ platforms.
 
 ## [5.3.0] - 2026-04-09
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2397,7 +2397,7 @@ export class AxonFlow {
     }
     const response = await this.orchestratorRequest<Record<string, unknown>>(
       'GET',
-      `/api/v1/decisions/${encodeURIComponent(decisionId)}/explain`,
+      `/api/v1/decisions/${encodeURIComponent(decisionId)}/explain`
     );
     return this.parseDecisionExplanation(response);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,9 @@ import {
   AuditResult,
   AuditOptions,
   AuditSearchRequest,
+  DecisionExplanation,
+  ExplainPolicy,
+  ExplainRule,
   AuditQueryOptions,
   AuditLogEntry,
   AuditSearchResponse,
@@ -2366,6 +2369,80 @@ export class AxonFlow {
    * }
    * ```
    */
+  /**
+   * Fetch the full explanation for a previously-made policy decision.
+   *
+   * Implements ADR-043. Returns a {@link DecisionExplanation} including
+   * matched policies, risk level, override availability, and a rolling
+   * 24-hour session hit count for the matched rule.
+   *
+   * The caller must either own the decision (user_email match) or belong
+   * to the same tenant as the decision's originator.
+   *
+   * @param decisionId - The global decision identifier returned in the
+   *   original step gate or policy evaluation response.
+   * @throws Error if `decisionId` is empty.
+   *
+   * @example
+   * ```typescript
+   * const exp = await client.explainDecision('dec_wf123_step4');
+   * if (exp.overrideAvailable) {
+   *   // offer the user a governed override action
+   * }
+   * ```
+   */
+  async explainDecision(decisionId: string): Promise<DecisionExplanation> {
+    if (!decisionId) {
+      throw new Error('decisionId is required');
+    }
+    const response = await this.orchestratorRequest<Record<string, unknown>>(
+      'GET',
+      `/api/v1/decisions/${encodeURIComponent(decisionId)}/explain`,
+    );
+    return this.parseDecisionExplanation(response);
+  }
+
+  /**
+   * Parses a raw platform response into a DecisionExplanation.
+   * Timestamp is coerced to Date; unknown extra fields are ignored for
+   * forward compatibility per ADR-043.
+   */
+  private parseDecisionExplanation(raw: Record<string, unknown>): DecisionExplanation {
+    const r = raw || {};
+    const rawMatches = (r.policy_matches as Array<Record<string, unknown>>) || [];
+    const policyMatches: ExplainPolicy[] = rawMatches.map(m => ({
+      policyId: (m.policy_id as string) || '',
+      policyName: m.policy_name as string | undefined,
+      action: m.action as string | undefined,
+      riskLevel: m.risk_level as string | undefined,
+      allowOverride: (m.allow_override as boolean) ?? false,
+      policyDescription: m.policy_description as string | undefined,
+    }));
+
+    const rawRules = r.matched_rules as Array<Record<string, unknown>> | undefined;
+    const matchedRules: ExplainRule[] | undefined = rawRules?.map(m => ({
+      policyId: (m.policy_id as string) || '',
+      ruleId: m.rule_id as string | undefined,
+      ruleText: m.rule_text as string | undefined,
+      matchedOn: m.matched_on as string | undefined,
+    }));
+
+    return {
+      decisionId: (r.decision_id as string) || '',
+      timestamp: r.timestamp ? new Date(r.timestamp as string) : new Date(),
+      policyMatches,
+      matchedRules,
+      decision: (r.decision as string) || '',
+      reason: (r.reason as string) || '',
+      riskLevel: r.risk_level as string | undefined,
+      overrideAvailable: (r.override_available as boolean) ?? false,
+      overrideExistingId: r.override_existing_id as string | undefined,
+      historicalHitCountSession: (r.historical_hit_count_session as number) ?? 0,
+      policySourceLink: r.policy_source_link as string | undefined,
+      toolSignature: r.tool_signature as string | undefined,
+    };
+  }
+
   async searchAuditLogs(request?: AuditSearchRequest): Promise<AuditSearchResponse> {
     const limit = Math.min(request?.limit ?? 100, 1000);
     const offset = request?.offset ?? 0;
@@ -2377,6 +2454,9 @@ export class AxonFlow {
     if (request?.startTime) body.start_time = request.startTime.toISOString();
     if (request?.endTime) body.end_time = request.endTime.toISOString();
     if (request?.requestType) body.request_type = request.requestType;
+    if (request?.decisionId) body.decision_id = request.decisionId;
+    if (request?.policyName) body.policy_name = request.policyName;
+    if (request?.overrideId) body.override_id = request.overrideId;
     if (offset > 0) body.offset = offset;
 
     if (this.config.debug) {

--- a/src/types/decisions.ts
+++ b/src/types/decisions.ts
@@ -1,0 +1,50 @@
+/**
+ * Decision explainability types (ADR-043 Explainability Data Contract).
+ *
+ * The DecisionExplanation shape is frozen: additive-only changes are
+ * non-breaking; renames/removals require a major version bump.
+ */
+
+/** A policy reference inside a decision explanation. */
+export interface ExplainPolicy {
+  policyId: string;
+  policyName?: string;
+  action?: string;
+  /** low | medium | high | critical */
+  riskLevel?: string;
+  /** false iff policy forbids session override (ADR-042) */
+  allowOverride?: boolean;
+  policyDescription?: string;
+}
+
+/** Rule-level detail inside a decision explanation. */
+export interface ExplainRule {
+  policyId: string;
+  ruleId?: string;
+  ruleText?: string;
+  matchedOn?: string;
+}
+
+/**
+ * Canonical payload returned by {@link AxonFlowClient.explainDecision}.
+ *
+ * Shape frozen per ADR-043. Fields are documented in
+ * `axonflow-docs/governance/explainability`.
+ */
+export interface DecisionExplanation {
+  decisionId: string;
+  timestamp: Date;
+  policyMatches: ExplainPolicy[];
+  matchedRules?: ExplainRule[];
+  /** allow | deny | require_approval */
+  decision: string;
+  reason: string;
+  /** low | medium | high | critical */
+  riskLevel?: string;
+  overrideAvailable: boolean;
+  overrideExistingId?: string;
+  /** Number of hits for the same (policy, user) pair in the rolling 24h window. */
+  historicalHitCountSession: number;
+  policySourceLink?: string;
+  toolSignature?: string;
+}

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -229,6 +229,19 @@ export interface AuditSearchRequest {
   endTime?: Date;
   /** Filter by request type (e.g., "llm_chat", "policy_check") */
   requestType?: string;
+  /**
+   * Filter by decision ID (ADR-043). Gathers every audit record tied to
+   * a single decision — the explain flow's cross-reference pivot.
+   */
+  decisionId?: string;
+  /** Filter by matched policy name (ADR-043). */
+  policyName?: string;
+  /**
+   * Filter by session override ID (ADR-042). Use this to reconstruct the
+   * full lifecycle of one override: override_created → override_used →
+   * override_expired | override_revoked.
+   */
+  overrideId?: string;
   /** Maximum results to return (default: 100, max: 1000) */
   limit?: number;
   /** Pagination offset (default: 0) */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,3 +16,4 @@ export * from './execution';
 export * from './hitl';
 export * from './media';
 export * from './simulation';
+export * from './decisions';

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -104,7 +104,7 @@ describe('Decision Explainability (ADR-043)', () => {
           policy_matches: [],
           override_available: false,
           historical_hit_count_session: 0,
-        }),
+        })
       );
       await client.explainDecision('a/b');
       const url = mockFetch.mock.calls[0][0] as string;
@@ -122,7 +122,7 @@ describe('Decision Explainability (ADR-043)', () => {
           override_available: false,
           historical_hit_count_session: 0,
           future_field_unknown: { nested: true },
-        }),
+        })
       );
       const exp = await client.explainDecision('dec-1');
       expect(exp.decisionId).toBe('dec-1');
@@ -138,7 +138,7 @@ describe('Decision Explainability (ADR-043)', () => {
           policy_matches: [],
           override_available: false,
           historical_hit_count_session: 0,
-        }),
+        })
       );
       const exp = await client.explainDecision('dec-1');
       expect(exp.matchedRules).toBeUndefined();

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for decisions.explain (ADR-043) + audit search filter parity (ADR-042).
+ */
+
+import { AxonFlow } from '../src/client';
+import type { AuditSearchRequest } from '../src/types/gateway';
+import type { DecisionExplanation } from '../src/types/decisions';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('Decision Explainability (ADR-043)', () => {
+  let client: AxonFlow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+      tenant: 'test-tenant',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const mockResponse = (data: unknown, status = 200) =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    });
+
+  describe('explainDecision', () => {
+    it('rejects empty decision ID', async () => {
+      await expect(client.explainDecision('')).rejects.toThrow(/required/);
+    });
+
+    it('calls the correct endpoint and parses full payload', async () => {
+      const raw = {
+        decision_id: 'dec_wf1_step2',
+        timestamp: '2026-04-17T12:00:00Z',
+        decision: 'deny',
+        reason: 'SQL injection detected',
+        risk_level: 'high',
+        policy_matches: [
+          {
+            policy_id: 'pol-sqli',
+            policy_name: 'SQL Injection Detector',
+            action: 'deny',
+            risk_level: 'high',
+            allow_override: true,
+            policy_description: 'Blocks SQL injection',
+          },
+        ],
+        matched_rules: [
+          {
+            policy_id: 'pol-sqli',
+            rule_id: 'r-1',
+            rule_text: 'UNION SELECT',
+            matched_on: 'query.sql',
+          },
+        ],
+        override_available: true,
+        override_existing_id: 'ov-abc',
+        historical_hit_count_session: 3,
+        policy_source_link: 'https://policies.axonflow/sqli',
+        tool_signature: 'Bash',
+      };
+      mockFetch.mockReturnValueOnce(mockResponse(raw));
+
+      const exp: DecisionExplanation = await client.explainDecision('dec_wf1_step2');
+
+      const callArgs = mockFetch.mock.calls[0];
+      const url = callArgs[0] as string;
+      expect(url).toContain('/api/v1/decisions/dec_wf1_step2/explain');
+      expect((callArgs[1] as { method: string }).method).toBe('GET');
+
+      expect(exp.decisionId).toBe('dec_wf1_step2');
+      expect(exp.decision).toBe('deny');
+      expect(exp.policyMatches).toHaveLength(1);
+      expect(exp.policyMatches[0].policyId).toBe('pol-sqli');
+      expect(exp.policyMatches[0].allowOverride).toBe(true);
+      expect(exp.matchedRules).toHaveLength(1);
+      expect(exp.matchedRules![0].ruleText).toBe('UNION SELECT');
+      expect(exp.overrideAvailable).toBe(true);
+      expect(exp.overrideExistingId).toBe('ov-abc');
+      expect(exp.historicalHitCountSession).toBe(3);
+      expect(exp.toolSignature).toBe('Bash');
+      expect(exp.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('URL-encodes the decision ID', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse({
+          decision_id: 'a/b',
+          timestamp: '2026-04-17T12:00:00Z',
+          decision: 'allow',
+          reason: '',
+          policy_matches: [],
+          override_available: false,
+          historical_hit_count_session: 0,
+        }),
+      );
+      await client.explainDecision('a/b');
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('a%2Fb/explain');
+    });
+
+    it('tolerates unknown extra fields for forward compatibility', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse({
+          decision_id: 'dec-1',
+          timestamp: '2026-04-17T12:00:00Z',
+          decision: 'allow',
+          reason: '',
+          policy_matches: [],
+          override_available: false,
+          historical_hit_count_session: 0,
+          future_field_unknown: { nested: true },
+        }),
+      );
+      const exp = await client.explainDecision('dec-1');
+      expect(exp.decisionId).toBe('dec-1');
+    });
+
+    it('handles minimal responses without optional fields', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse({
+          decision_id: 'dec-1',
+          timestamp: '2026-04-17T12:00:00Z',
+          decision: 'allow',
+          reason: '',
+          policy_matches: [],
+          override_available: false,
+          historical_hit_count_session: 0,
+        }),
+      );
+      const exp = await client.explainDecision('dec-1');
+      expect(exp.matchedRules).toBeUndefined();
+      expect(exp.overrideExistingId).toBeUndefined();
+    });
+  });
+
+  describe('AuditSearchRequest new filters (ADR-042/ADR-043)', () => {
+    it('sends decision_id when set', async () => {
+      mockFetch.mockReturnValueOnce(mockResponse({ entries: [], total: 0, limit: 100, offset: 0 }));
+      const req: AuditSearchRequest = { decisionId: 'dec-abc' };
+      await client.searchAuditLogs(req);
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.decision_id).toBe('dec-abc');
+    });
+
+    it('sends policy_name when set', async () => {
+      mockFetch.mockReturnValueOnce(mockResponse({ entries: [], total: 0, limit: 100, offset: 0 }));
+      const req: AuditSearchRequest = { policyName: 'SQL Injection Detector' };
+      await client.searchAuditLogs(req);
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.policy_name).toBe('SQL Injection Detector');
+    });
+
+    it('sends override_id when set', async () => {
+      mockFetch.mockReturnValueOnce(mockResponse({ entries: [], total: 0, limit: 100, offset: 0 }));
+      const req: AuditSearchRequest = { overrideId: 'ov-xyz' };
+      await client.searchAuditLogs(req);
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.override_id).toBe('ov-xyz');
+    });
+
+    it('omits all three filter fields when unset', async () => {
+      mockFetch.mockReturnValueOnce(mockResponse({ entries: [], total: 0, limit: 100, offset: 0 }));
+      await client.searchAuditLogs({});
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.decision_id).toBeUndefined();
+      expect(body.policy_name).toBeUndefined();
+      expect(body.override_id).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

TypeScript SDK half of Plugin Batch 1 (ADR-042 + ADR-043).

Companion to:
- Platform v7.1.0 — axonflow-enterprise PR #1605
- Go v5.4.0 — axonflow-sdk-go PR #122
- Python v6.4.0 — axonflow-sdk-python PR #141
- Java v5.4.0 (follow-up)
- OpenClaw v1.3.0, Claude Code v0.5.0, Cursor v0.5.0, Codex v0.4.0 (follow-up)

## Added
- `explainDecision(decisionId)` — returns `DecisionExplanation` per ADR-043
- `DecisionExplanation`, `ExplainPolicy`, `ExplainRule` interfaces
- `AuditSearchRequest.decisionId`, `.policyName`, `.overrideId` filters

## Version: 5.3.0 → 5.4.0

## Tests
9 new tests, all passing. Full test suite green.