### PR TITLE
fix(release): emit CHANGELOG section as GitHub release body

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,46 @@ env:
   DO_NOT_TRACK: '1'
 
 jobs:
+  # Preflight: validate CHANGELOG has a section for the tag being released
+  # BEFORE any publish step runs. A missing section fails the entire
+  # workflow cleanly rather than publishing to npm first and then failing
+  # at the GitHub release step.
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract CHANGELOG section
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          awk -v ver="$VERSION" '$0 ~ "^## \\["ver"\\]" {p=1; next} p && /^## \[/ {exit} p {print}' CHANGELOG.md > /tmp/release-body.md
+          if [ ! -s /tmp/release-body.md ]; then
+            echo "::error::No CHANGELOG.md section found for version $VERSION — refusing to publish."
+            echo "::error::Add a '## [$VERSION] - YYYY-MM-DD' section to CHANGELOG.md and re-tag."
+            exit 1
+          fi
+          {
+            echo "## AxonFlow TypeScript SDK v${VERSION}"
+            echo ""
+            echo "### Installation"
+            echo ""
+            echo '```bash'
+            echo "npm install @axonflow/sdk@${VERSION}"
+            echo '```'
+            echo ""
+            cat /tmp/release-body.md
+          } > /tmp/release-body-final.md
+          echo "Release body: $(wc -l < /tmp/release-body-final.md) lines"
+
+      - name: Upload release body artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-body
+          path: /tmp/release-body-final.md
+          retention-days: 1
+
   publish:
+    needs: preflight
     runs-on: ubuntu-latest
 
     steps:
@@ -49,35 +88,28 @@ jobs:
       run: npm publish --provenance --access public
 
   create-release:
-    needs: publish
+    needs: [preflight, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - name: Download release body artifact
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: release-body
+        path: /tmp/release-body
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:
         name: Release ${{ github.ref_name }}
-        body: |
-          ## AxonFlow TypeScript SDK ${{ github.ref_name }}
-
-          ### Installation
-
-          ```bash
-          npm install @axonflow/sdk
-          ```
-
-          ### Changes
-
-          See [CHANGELOG.md](https://github.com/getaxonflow/axonflow-sdk-typescript/blob/main/CHANGELOG.md) for full release details.
+        body_path: /tmp/release-body/release-body-final.md
         generate_release_notes: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   verify-publish:
-    needs: publish
+    needs: [preflight, publish]
     runs-on: ubuntu-latest
     steps:
     - name: Extract version from tag


### PR DESCRIPTION
## Summary

Mirrors [axonflow-openclaw-plugin#47](https://github.com/getaxonflow/axonflow-openclaw-plugin/pull/47) (already merged, verified on v1.3.1 release — release page now carries the full CHANGELOG section inline).

Before this change, every tagged release produced a generic "install + see CHANGELOG.md for details" body. Anyone landing on the GitHub release page (from README links, registry listings that pull GitHub release descriptions, or external citations) had to click through to see what changed. Worse, a missing CHANGELOG section would still publish to the registry first and only fail at the GitHub release step — leaving a partial release with no release page and no retry path on the same version.

## Changes

- **New `preflight` job** runs FIRST with no dependencies. Validates the CHANGELOG.md section exists for the target version (awk extracts the section between `## [X.Y.Z]` and the next `## [`), fails loudly with an actionable error if missing, builds the final release body (install block + CHANGELOG content), and uploads as artifact.
- **Publish / release jobs depend on preflight.** Missing CHANGELOG → preflight fails → zero side effects across any registry. No partial releases possible.
- **Final release body** = install block prepended to the extracted CHANGELOG section, delivered via `body_path` from the artifact.
- **SHA-pinned** `actions/upload-artifact` and `actions/download-artifact` to match repo convention.

## Test plan

- [x] YAML sanity check (`yaml.safe_load`)
- [x] awk extraction pattern verified locally against CHANGELOG format this repo uses
- [ ] Merge + tag next patch to observe preflight+artifact flow end-to-end (or trigger manually via a test tag)