### PR TITLE
feat(wcp): retry_context + idempotency_key (#1673 P1+P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`retry_context` and `idempotency_key` support on the step gate** — `StepGateResponse`
+  now carries a non-nullable `retry_context` object on every gate call with the true
+  `(workflow_id, step_id)` lifecycle: `gate_count`, `completion_count`,
+  `prior_completion_status` (`'none' | 'completed' | 'gated_not_completed'`),
+  `prior_output_available`, `prior_output`, `prior_completion_at`, `first_attempt_at`,
+  `last_attempt_at`, `last_decision`, and `idempotency_key`. Prefer these fields to
+  the legacy `cached` / `decision_source` fields.
+- **`stepGate(..., options)`** — new optional fourth argument
+  `{ includePriorOutput?: boolean }`. When `true`, the SDK sends
+  `?include_prior_output=true` and `retry_context.prior_output` is populated when a
+  prior `/complete` has landed. Existing callers that omit `options` behave unchanged.
+- **`StepGateRequest.idempotency_key`** — caller-supplied opaque business-level key
+  (max 255 chars). Immutable once recorded on the first gate call for a
+  `(workflow_id, step_id)`; subsequent gate/complete calls must pass the same key.
+- **`MarkStepCompletedRequest.idempotency_key`** — must match the key set on the
+  corresponding gate call, if any. Mismatch (including missing-vs-set on either side)
+  surfaces as a typed `IdempotencyKeyMismatchError`.
+- **`IdempotencyKeyMismatchError`** — typed error thrown by `stepGate` and
+  `markStepCompleted` when the platform returns HTTP 409 with
+  `error.code === "IDEMPOTENCY_KEY_MISMATCH"`. Surfaces `workflowId`, `stepId`,
+  `expectedIdempotencyKey`, `receivedIdempotencyKey`, and the human-readable `message`.
+- **`RetryContext`, `PriorCompletionStatus`, `StepGateOptions`** — exported TypeScript
+  types.
+
+### Deprecated
+
+- **`StepGateResponse.cached`** and **`StepGateResponse.decision_source`** — still
+  populated but deprecated in favor of `retry_context.gate_count > 1` and
+  `retry_context.prior_completion_status`. Planned for removal in a future major version.
+
+### Compatibility
+
+Companion to the platform change that introduces `retry_context` on
+`POST /api/v1/workflows/{workflow_id}/steps/{step_id}/gate`. Additive only — existing
+callers that never set `idempotency_key` or `includePriorOutput` see no behavior change.
+
 ## [5.4.0] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.5.0] - 2026-04-21
 
 ### Added
 

--- a/examples/wcp-retry-idempotency/index.ts
+++ b/examples/wcp-retry-idempotency/index.ts
@@ -1,0 +1,157 @@
+/**
+ * WCP retry_context + idempotency_key E2E example (Issue #1673 Phase 1 + 2).
+ *
+ * Exercises the new SDK surface end-to-end against a running v7.3.0
+ * enterprise stack.
+ *
+ * Run:
+ *   source /tmp/axonflow-e2e-env.sh
+ *   export AXONFLOW_BASE_URL=http://localhost:8080
+ *   npx ts-node index.ts
+ */
+
+import {
+  AxonFlow,
+  IdempotencyKeyMismatchError,
+  type StepGateRequest,
+} from '../../src';
+
+function mustEnv(k: string): string {
+  const v = process.env[k];
+  if (!v) {
+    console.error(`missing env: ${k}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function banner(s: string): void {
+  console.log('');
+  console.log('━━━', s, '━━━');
+}
+
+function fail(msg: string): never {
+  console.error('FAIL:', msg);
+  process.exit(1);
+}
+
+function assertEqStr(label: string, want: string, got: string): void {
+  if (want !== got) fail(`${label}: want "${want}", got "${got}"`);
+}
+
+function assertEqInt(label: string, want: number, got: number): void {
+  if (want !== got) fail(`${label}: want ${want}, got ${got}`);
+}
+
+function assertTrue(label: string, cond: boolean): void {
+  if (!cond) fail(`assertion failed: ${label}`);
+}
+
+async function main(): Promise<void> {
+  const endpoint = process.env.AXONFLOW_BASE_URL || 'http://localhost:8080';
+  const clientId = mustEnv('AXONFLOW_CLIENT_ID');
+  const clientSecret = mustEnv('AXONFLOW_CLIENT_SECRET');
+
+  const client = new AxonFlow({ clientId, clientSecret, endpoint });
+
+  banner('Act 1 — retry_context (TypeScript SDK)');
+  await act1(client);
+
+  banner('Act 2 — idempotency_key (TypeScript SDK)');
+  await act2(client);
+
+  banner('All assertions passed ✔');
+}
+
+async function act1(client: AxonFlow): Promise<void> {
+  const wf = await client.createWorkflow({ workflow_name: 'ts-sdk-retry-context' });
+  console.log(`workflow: ${wf.workflow_id}`);
+
+  // 1) First gate — first-call invariants
+  const req: StepGateRequest = { step_name: 'first-step', step_type: 'tool_call' as const };
+  const first = await client.stepGate(wf.workflow_id, 'step-1', req);
+  assertEqInt('first gate_count', 1, first.retry_context.gate_count);
+  assertEqInt('first completion_count', 0, first.retry_context.completion_count);
+  assertEqStr('first prior_completion_status', 'none', first.retry_context.prior_completion_status);
+  assertTrue('first !prior_output_available', !first.retry_context.prior_output_available);
+  assertEqStr('first last_decision (first-call invariant)', first.decision, first.retry_context.last_decision);
+  assertEqStr('first FirstAttemptAt == LastAttemptAt', first.retry_context.first_attempt_at ?? '', first.retry_context.last_attempt_at ?? '');
+  console.log('  first gate invariants ✔');
+
+  // 2) Complete, then re-gate
+  await client.markStepCompleted(wf.workflow_id, 'step-1', {
+    output: { transfer_id: 'TXN-ts-1', amount: 500 },
+  });
+  const reGate = await client.stepGate(wf.workflow_id, 'step-1', { step_type: 'tool_call' as const });
+  assertEqInt('re-gate post-complete gate_count', 2, reGate.retry_context.gate_count);
+  assertEqInt('re-gate post-complete completion_count', 1, reGate.retry_context.completion_count);
+  assertEqStr('re-gate post-complete prior_completion_status', 'completed', reGate.retry_context.prior_completion_status);
+  assertTrue('re-gate post-complete prior_output_available', reGate.retry_context.prior_output_available);
+  assertTrue('re-gate post-complete prior_output omitted by default', reGate.retry_context.prior_output === null || reGate.retry_context.prior_output === undefined);
+  assertTrue('re-gate post-complete cached==true', reGate.cached);
+  console.log('  re-gate post-complete ✔');
+
+  // 3) Gate on step-2 without completion (agent-crash simulation)
+  await client.stepGate(wf.workflow_id, 'step-2', { step_name: 'second-step', step_type: 'tool_call' as const });
+  const reGate2 = await client.stepGate(wf.workflow_id, 'step-2', { step_type: 'tool_call' as const });
+  assertEqStr('gated_not_completed status', 'gated_not_completed', reGate2.retry_context.prior_completion_status);
+  assertEqInt('gated_not_completed completion_count', 0, reGate2.retry_context.completion_count);
+  console.log('  gated_not_completed ✔');
+
+  // 4) include_prior_output=true recovers the payload
+  const withPrior = await client.stepGate(
+    wf.workflow_id,
+    'step-1',
+    { step_type: 'tool_call' as const },
+    { includePriorOutput: true }
+  );
+  assertTrue('prior_output populated', !!withPrior.retry_context.prior_output);
+  assertEqStr('prior_output.transfer_id', 'TXN-ts-1', String(withPrior.retry_context.prior_output!.transfer_id));
+  console.log('  prior_output recovery ✔');
+}
+
+async function act2(client: AxonFlow): Promise<void> {
+  const wf = await client.createWorkflow({ workflow_name: 'ts-sdk-idempotency-key' });
+  console.log(`workflow: ${wf.workflow_id}`);
+
+  const originalKey = 'payment:wire:ts-sdk-invoice-1';
+
+  // 5) Gate with key — echoes back
+  const first = await client.stepGate(wf.workflow_id, 'step-1', {
+    step_name: 'wire',
+    step_type: 'tool_call' as const,
+    idempotency_key: originalKey,
+  });
+  assertEqStr('retry_context.idempotency_key echo', originalKey, first.retry_context.idempotency_key);
+  console.log('  key round-trip ✔');
+
+  // 6) Re-gate with different key → IdempotencyKeyMismatchError
+  try {
+    await client.stepGate(wf.workflow_id, 'step-1', {
+      step_type: 'tool_call' as const,
+      idempotency_key: 'payment:wire:different-2',
+    });
+    fail('expected IdempotencyKeyMismatchError on gate with different key');
+  } catch (err) {
+    if (!(err instanceof IdempotencyKeyMismatchError)) {
+      fail(`expected IdempotencyKeyMismatchError, got ${(err as Error).constructor?.name}: ${(err as Error).message}`);
+    }
+    assertEqStr('mismatch expected_key', originalKey, err.expectedIdempotencyKey);
+    assertEqStr('mismatch received_key', 'payment:wire:different-2', err.receivedIdempotencyKey);
+    assertTrue('mismatch workflow_id', err.workflowId.startsWith('wf_'));
+    assertEqStr('mismatch step_id', 'step-1', err.stepId);
+  }
+  console.log('  typed 409 error ✔');
+
+  // 7) Complete with matching key
+  await client.markStepCompleted(wf.workflow_id, 'step-1', {
+    output: { transfer_id: 'TXN-K1' },
+    idempotency_key: originalKey,
+  });
+  console.log('  complete with matching key ✔');
+}
+
+main().catch((err) => {
+  console.error('UNEXPECTED ERROR:', err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "5.3.0",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "5.3.0",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,6 +98,7 @@ import {
   CreateWorkflowResponse,
   StepGateRequest,
   StepGateResponse,
+  StepGateOptions,
   WorkflowStatusResponse,
   ListWorkflowsOptions,
   ListWorkflowsResponse,
@@ -174,8 +175,49 @@ import {
   ConnectorError,
   PlanExecutionError,
   VersionConflictError,
+  IdempotencyKeyMismatchError,
 } from './errors';
 import { generateRequestId, debugLog } from './utils/helpers';
+
+/**
+ * Extract a typed IdempotencyKeyMismatchError from an APIError with HTTP 409 and
+ * `error.code === "IDEMPOTENCY_KEY_MISMATCH"` in the response body. Returns null if
+ * the error doesn't match that shape (caller should rethrow the original).
+ */
+function mapIdempotencyKeyMismatch(err: unknown): IdempotencyKeyMismatchError | null {
+  if (!(err instanceof APIError) || err.statusCode !== 409) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(err.body);
+  } catch {
+    return null;
+  }
+  const envelope = parsed as {
+    error?: {
+      code?: string;
+      message?: string;
+      details?: {
+        workflow_id?: string;
+        step_id?: string;
+        expected_idempotency_key?: string;
+        received_idempotency_key?: string;
+      };
+    };
+  };
+  if (!envelope?.error || envelope.error.code !== 'IDEMPOTENCY_KEY_MISMATCH') {
+    return null;
+  }
+  const details = envelope.error.details ?? {};
+  return new IdempotencyKeyMismatchError(
+    envelope.error.message ?? 'idempotency_key mismatch',
+    details.workflow_id ?? '',
+    details.step_id ?? '',
+    details.expected_idempotency_key ?? '',
+    details.received_idempotency_key ?? ''
+  );
+}
 
 /**
  * Compare two semver version strings numerically.
@@ -4864,6 +4906,11 @@ export class AxonFlow {
    * This is the core governance method. Call this before executing each step
    * in your workflow to check if the step is allowed based on policies.
    *
+   * Pass `options.includePriorOutput: true` to request `retry_context.prior_output`
+   * be populated on the response (sent as `?include_prior_output=true` query param).
+   * Supply `request.idempotency_key` to bind this step to a caller-chosen business key;
+   * mismatched keys on subsequent gate/complete calls throw `IdempotencyKeyMismatchError`.
+   *
    * @example
    * ```typescript
    * const gate = await client.stepGate('wf_123', 'step-generate-code', {
@@ -4871,23 +4918,23 @@ export class AxonFlow {
    *   step_type: 'llm_call',
    *   model: 'gpt-4',
    *   provider: 'openai',
-   *   step_input: { prompt: 'Generate a hello world function' }
-   * });
+   *   step_input: { prompt: 'Generate a hello world function' },
+   *   idempotency_key: 'payment:wire:acct4471:invoice-7721',
+   * }, { includePriorOutput: true });
    *
    * if (gate.decision === 'block') {
    *   throw new Error(`Step blocked: ${gate.reason}`);
    * }
-   * if (gate.decision === 'require_approval') {
-   *   console.log(`Approval required: ${gate.approval_url}`);
-   *   return;
+   * if (gate.retry_context.prior_completion_status === 'completed') {
+   *   // prior result available at gate.retry_context.prior_output
    * }
-   * // Step is allowed, proceed with execution
    * ```
    */
   async stepGate(
     workflowId: string,
     stepId: string,
-    request: StepGateRequest
+    request: StepGateRequest,
+    options?: StepGateOptions
   ): Promise<StepGateResponse> {
     if (!workflowId) {
       throw new ConfigurationError('Workflow ID is required');
@@ -4896,12 +4943,18 @@ export class AxonFlow {
       throw new ConfigurationError('Step ID is required');
     }
 
-    const response = await this.orchestratorRequest<StepGateResponse>(
-      'POST',
-      `/api/v1/workflows/${workflowId}/steps/${stepId}/gate`,
-      request
-    );
-    return response;
+    let path = `/api/v1/workflows/${workflowId}/steps/${stepId}/gate`;
+    if (options?.includePriorOutput) {
+      path += '?include_prior_output=true';
+    }
+
+    try {
+      return await this.orchestratorRequest<StepGateResponse>('POST', path, request);
+    } catch (err) {
+      const idem = mapIdempotencyKeyMismatch(err);
+      if (idem) throw idem;
+      throw err;
+    }
   }
 
   /**
@@ -4986,11 +5039,17 @@ export class AxonFlow {
       throw new ConfigurationError('Step ID is required');
     }
 
-    await this.orchestratorRequest(
-      'POST',
-      `/api/v1/workflows/${workflowId}/steps/${stepId}/complete`,
-      request || {}
-    );
+    try {
+      await this.orchestratorRequest(
+        'POST',
+        `/api/v1/workflows/${workflowId}/steps/${stepId}/complete`,
+        request || {}
+      );
+    } catch (err) {
+      const idem = mapIdempotencyKeyMismatch(err);
+      if (idem) throw idem;
+      throw err;
+    }
   }
 
   /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -227,6 +227,54 @@ export class VersionConflictError extends AxonFlowError {
 }
 
 /**
+ * Error thrown when an `idempotency_key` on a gate or complete request conflicts with
+ * the key recorded on an earlier gate call for the same (workflow_id, step_id).
+ * Maps to HTTP 409 with `error.code === "IDEMPOTENCY_KEY_MISMATCH"`.
+ *
+ * `expectedIdempotencyKey` is the empty string `""` when the gate call had no key but
+ * complete did; conversely `receivedIdempotencyKey` is `""` when complete omitted a key
+ * that gate had set.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.markStepCompleted(workflowId, stepId, { idempotency_key: 'k2' });
+ * } catch (err) {
+ *   if (err instanceof IdempotencyKeyMismatchError) {
+ *     console.log(`expected=${err.expectedIdempotencyKey} received=${err.receivedIdempotencyKey}`);
+ *   }
+ * }
+ * ```
+ */
+export class IdempotencyKeyMismatchError extends AxonFlowError {
+  public readonly workflowId: string;
+  public readonly stepId: string;
+  public readonly expectedIdempotencyKey: string;
+  public readonly receivedIdempotencyKey: string;
+
+  constructor(
+    message: string,
+    workflowId: string,
+    stepId: string,
+    expectedIdempotencyKey: string,
+    receivedIdempotencyKey: string
+  ) {
+    super(message, {
+      workflowId,
+      stepId,
+      expectedIdempotencyKey,
+      receivedIdempotencyKey,
+    });
+    this.name = 'IdempotencyKeyMismatchError';
+    this.workflowId = workflowId;
+    this.stepId = stepId;
+    this.expectedIdempotencyKey = expectedIdempotencyKey;
+    this.receivedIdempotencyKey = receivedIdempotencyKey;
+    Object.setPrototypeOf(this, IdempotencyKeyMismatchError.prototype);
+  }
+}
+
+/**
  * Error thrown for API errors (non-2xx responses).
  * Includes HTTP status code, status text, and response body.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   AuthenticationError,
   RateLimitError,
   TimeoutError,
+  IdempotencyKeyMismatchError,
   APIError,
 } from './errors';
 
@@ -248,6 +249,9 @@ export type {
   CreateWorkflowResponse,
   StepGateRequest,
   StepGateResponse,
+  StepGateOptions,
+  RetryContext,
+  PriorCompletionStatus,
   WorkflowStepInfo,
   WorkflowStatusResponse,
   ListWorkflowsOptions,

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -147,10 +147,12 @@ export interface RetryContext {
   /** Decision of the immediately prior gate call. On first call, equals the current call's decision. */
   last_decision: GateDecision;
   /**
-   * Key the caller set on this step (from the first gate call that supplied one), or
-   * `null` if the caller never supplied one. Once set, immutable.
+   * Key the caller set on this step (from the first gate call that supplied one),
+   * or empty string `""` if the caller never supplied one. Always present in the
+   * response — never null, never omitted — per the wire contract. Once set on a
+   * step, the key is immutable for the step's lifetime.
    */
-  idempotency_key: string | null;
+  idempotency_key: string;
 }
 
 /**

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -148,9 +148,9 @@ export interface RetryContext {
   last_decision: GateDecision;
   /**
    * Key the caller set on this step (from the first gate call that supplied one), or
-   * empty string if the caller never supplied one. Once set, immutable.
+   * `null` if the caller never supplied one. Once set, immutable.
    */
-  idempotency_key: string;
+  idempotency_key: string | null;
 }
 
 /**

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -103,6 +103,68 @@ export interface StepGateRequest {
   tool_context?: ToolContext;
   /** Retry behavior: "idempotent" (default) returns cached decision, "reevaluate" forces fresh evaluation */
   retry_policy?: RetryPolicy;
+  /**
+   * Caller-supplied opaque business-level key (max 255 chars). Once set on the first
+   * gate call for a (workflow_id, step_id), it is immutable — subsequent gate/complete
+   * calls must pass the same key or receive IdempotencyKeyMismatchError. The key is
+   * echoed on retry_context.idempotency_key in every subsequent gate response.
+   */
+  idempotency_key?: string;
+}
+
+/**
+ * Prior completion status for a step: "none" on first gate call, "completed" after
+ * a prior gate + prior /complete both landed, "gated_not_completed" when a prior gate
+ * landed but no /complete has followed.
+ */
+export type PriorCompletionStatus = 'none' | 'completed' | 'gated_not_completed';
+
+/**
+ * Retry context for a step gate — the first-class state signal for (workflow_id, step_id).
+ * Returned on every StepGateResponse, including the first call. Prefer these fields to the
+ * legacy `cached` and `decision_source` fields on StepGateResponse.
+ */
+export interface RetryContext {
+  /** Number of /gate calls for this (workflow_id, step_id), including the current call. Always >= 1. */
+  gate_count: number;
+  /** Number of successful /complete calls for this (workflow_id, step_id). */
+  completion_count: number;
+  /** Whether a prior gate+complete cycle has landed. */
+  prior_completion_status: PriorCompletionStatus;
+  /** True iff `prior_completion_status === "completed"`. */
+  prior_output_available: boolean;
+  /**
+   * Output from the prior /complete call, or null. Non-null only when this gate call set
+   * `include_prior_output=true` AND `prior_completion_status === "completed"`.
+   */
+  prior_output: Record<string, unknown> | null;
+  /** ISO 8601 timestamp of the prior /complete, or null. */
+  prior_completion_at: string | null;
+  /** ISO 8601 timestamp of the first gate call for this (workflow_id, step_id). */
+  first_attempt_at: string;
+  /** ISO 8601 timestamp of the current gate call. */
+  last_attempt_at: string;
+  /** Decision of the immediately prior gate call. On first call, equals the current call's decision. */
+  last_decision: GateDecision;
+  /**
+   * Key the caller set on this step (from the first gate call that supplied one), or
+   * empty string if the caller never supplied one. Once set, immutable.
+   */
+  idempotency_key: string;
+}
+
+/**
+ * Options for calling `stepGate` that live outside the request body. Currently carries
+ * `includePriorOutput`, which is sent as the `?include_prior_output=true` query param
+ * and controls whether `retry_context.prior_output` is populated on the response.
+ */
+export interface StepGateOptions {
+  /**
+   * When true, sends `?include_prior_output=true` on the gate call. The response's
+   * `retry_context.prior_output` is populated when a prior /complete exists. Default false
+   * because prior output may be large and/or contain sensitive data.
+   */
+  includePriorOutput?: boolean;
 }
 
 /**
@@ -123,10 +185,21 @@ export interface StepGateResponse {
   policiesEvaluated?: PolicyMatch[];
   /** Policies that matched and influenced the decision (Issue #1021) */
   policiesMatched?: PolicyMatch[];
-  /** Whether this response was served from a prior decision rather than a fresh policy evaluation */
+  /**
+   * Whether this response was served from a prior decision rather than a fresh policy evaluation.
+   * @deprecated Use `retry_context.gate_count > 1` instead. Will be removed in a future major version.
+   */
   cached: boolean;
-  /** How the decision was produced: "fresh" or "cached" */
+  /**
+   * How the decision was produced: "fresh" or "cached".
+   * @deprecated Use `retry_context.prior_completion_status` instead. Will be removed in a future major version.
+   */
   decision_source: string;
+  /**
+   * First-class state signal for (workflow_id, step_id). Always present on every gate response.
+   * See `RetryContext` for field semantics.
+   */
+  retry_context: RetryContext;
 }
 
 /**
@@ -282,6 +355,11 @@ export interface MarkStepCompletedRequest {
   tokens_out?: number;
   /** Estimated cost in USD for this step */
   cost_usd?: number;
+  /**
+   * Must match the key passed on the corresponding gate call, if any. Mismatch
+   * (including missing-vs-set on either side) yields IdempotencyKeyMismatchError.
+   */
+  idempotency_key?: string;
 }
 
 // =============================================================================

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '5.4.0';
+export const VERSION = '5.5.0';

--- a/tests/retry-context-idempotency.test.ts
+++ b/tests/retry-context-idempotency.test.ts
@@ -249,7 +249,7 @@ describe('retry_context + idempotency_key (#1673)', () => {
     }
   });
 
-  it('retry_context accepts null idempotency_key (contract §3: "string or null")', async () => {
+  it('retry_context idempotency_key is empty string when not supplied (contract §3)', async () => {
     mockFetch.mockResolvedValueOnce(
       mockResponse({
         decision: 'allow',
@@ -264,13 +264,13 @@ describe('retry_context + idempotency_key (#1673)', () => {
           first_attempt_at: '2026-04-21T15:30:00.000Z',
           last_attempt_at: '2026-04-21T15:30:00.000Z',
           last_decision: 'allow',
-          idempotency_key: null,
+          idempotency_key: '',
         },
       })
     );
 
     const gate = await client.stepGate('wf_1', 'step_1', { step_type: 'llm_call' });
-    expect(gate.retry_context.idempotency_key).toBeNull();
+    expect(gate.retry_context.idempotency_key).toBe('');
   });
 
   it('stepGate: 409 IDEMPOTENCY_KEY_MISMATCH also surfaces as typed error', async () => {

--- a/tests/retry-context-idempotency.test.ts
+++ b/tests/retry-context-idempotency.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for WCP retry_context + idempotency_key (#1673 Phase 1 + 2).
+ * Mirrors the six shapes from §6.8 of WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md.
+ */
+
+import { AxonFlow } from '../src/client';
+import { IdempotencyKeyMismatchError } from '../src/errors';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const mockResponse = (data: unknown, status = 200) => {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : status === 204 ? 'No Content' : 'Conflict',
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+};
+
+describe('retry_context + idempotency_key (#1673)', () => {
+  let client: AxonFlow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 't',
+      clientSecret: 's',
+      tenant: 'test',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Test a: first-call response shape
+  it('first-call shape: gate_count===1, prior_completion_status==="none", timestamps equal', async () => {
+    const now = '2026-04-21T15:30:45.123Z';
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        decision: 'allow',
+        step_id: 'step_1',
+        cached: false,
+        decision_source: 'fresh',
+        retry_context: {
+          gate_count: 1,
+          completion_count: 0,
+          prior_completion_status: 'none',
+          prior_output_available: false,
+          prior_output: null,
+          prior_completion_at: null,
+          first_attempt_at: now,
+          last_attempt_at: now,
+          last_decision: 'allow',
+          idempotency_key: '',
+        },
+      })
+    );
+
+    const gate = await client.stepGate('wf_1', 'step_1', { step_type: 'llm_call' });
+
+    expect(gate.retry_context.gate_count).toBe(1);
+    expect(gate.retry_context.completion_count).toBe(0);
+    expect(gate.retry_context.prior_completion_status).toBe('none');
+    expect(gate.retry_context.prior_output_available).toBe(false);
+    expect(gate.retry_context.prior_output).toBeNull();
+    expect(gate.retry_context.prior_completion_at).toBeNull();
+    expect(gate.retry_context.first_attempt_at).toBe(gate.retry_context.last_attempt_at);
+    expect(gate.retry_context.last_decision).toBe(gate.decision);
+    expect(gate.retry_context.idempotency_key).toBe('');
+
+    // Default call — no query string
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/api/v1/workflows/wf_1/steps/step_1/gate');
+  });
+
+  // Test b: second-call after completion
+  it('second-call after completion: gate_count===2, completion_count===1, status=completed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        decision: 'allow',
+        step_id: 'step_1',
+        retry_context: {
+          gate_count: 2,
+          completion_count: 1,
+          prior_completion_status: 'completed',
+          prior_output_available: true,
+          prior_output: null,
+          prior_completion_at: '2026-04-21T15:30:30.000Z',
+          first_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_attempt_at: '2026-04-21T15:31:00.000Z',
+          last_decision: 'allow',
+          idempotency_key: '',
+        },
+      })
+    );
+
+    const gate = await client.stepGate('wf_1', 'step_1', { step_type: 'llm_call' });
+    expect(gate.retry_context.gate_count).toBe(2);
+    expect(gate.retry_context.completion_count).toBe(1);
+    expect(gate.retry_context.prior_completion_status).toBe('completed');
+    expect(gate.retry_context.prior_output_available).toBe(true);
+    expect(gate.retry_context.prior_completion_at).not.toBeNull();
+    expect(gate.retry_context.first_attempt_at).not.toBe(gate.retry_context.last_attempt_at);
+  });
+
+  // Test c: second-call without completion
+  it('second-call without completion: status=gated_not_completed, output unavailable', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        decision: 'allow',
+        step_id: 'step_1',
+        retry_context: {
+          gate_count: 2,
+          completion_count: 0,
+          prior_completion_status: 'gated_not_completed',
+          prior_output_available: false,
+          prior_output: null,
+          prior_completion_at: null,
+          first_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_attempt_at: '2026-04-21T15:31:00.000Z',
+          last_decision: 'allow',
+          idempotency_key: '',
+        },
+      })
+    );
+
+    const gate = await client.stepGate('wf_1', 'step_1', { step_type: 'llm_call' });
+    expect(gate.retry_context.gate_count).toBe(2);
+    expect(gate.retry_context.completion_count).toBe(0);
+    expect(gate.retry_context.prior_completion_status).toBe('gated_not_completed');
+    expect(gate.retry_context.prior_output_available).toBe(false);
+    expect(gate.retry_context.prior_completion_at).toBeNull();
+  });
+
+  // Test d: include_prior_output=true populates prior_output
+  it('includePriorOutput=true sends ?include_prior_output=true and carries prior_output', async () => {
+    const priorOutput = { result: 'ok', score: 0.92 };
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        decision: 'allow',
+        step_id: 'step_1',
+        retry_context: {
+          gate_count: 2,
+          completion_count: 1,
+          prior_completion_status: 'completed',
+          prior_output_available: true,
+          prior_output: priorOutput,
+          prior_completion_at: '2026-04-21T15:30:30.000Z',
+          first_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_attempt_at: '2026-04-21T15:31:00.000Z',
+          last_decision: 'allow',
+          idempotency_key: '',
+        },
+      })
+    );
+
+    const gate = await client.stepGate(
+      'wf_1',
+      'step_1',
+      { step_type: 'llm_call' },
+      { includePriorOutput: true }
+    );
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      'http://localhost:8080/api/v1/workflows/wf_1/steps/step_1/gate?include_prior_output=true'
+    );
+    expect(gate.retry_context.prior_output).toEqual(priorOutput);
+  });
+
+  // Test e: idempotency key round-trip (gate → retry_context, then complete with same key)
+  it('idempotency_key round-trip: gate sets it, retry_context echoes it, complete carries it', async () => {
+    const key = 'payment:wire:acct4471:invoice-7721';
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        decision: 'allow',
+        step_id: 'step_1',
+        retry_context: {
+          gate_count: 1,
+          completion_count: 0,
+          prior_completion_status: 'none',
+          prior_output_available: false,
+          prior_output: null,
+          prior_completion_at: null,
+          first_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_decision: 'allow',
+          idempotency_key: key,
+        },
+      })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse(undefined, 204));
+
+    const gate = await client.stepGate('wf_1', 'step_1', {
+      step_type: 'llm_call',
+      idempotency_key: key,
+    });
+    expect(gate.retry_context.idempotency_key).toBe(key);
+
+    // Gate body should carry the key
+    const gateBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(gateBody.idempotency_key).toBe(key);
+
+    await client.markStepCompleted('wf_1', 'step_1', {
+      output: { ok: true },
+      idempotency_key: key,
+    });
+    const completeBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(completeBody.idempotency_key).toBe(key);
+  });
+
+  // Test f: 409 IDEMPOTENCY_KEY_MISMATCH surfaces as typed error
+  it('markStepCompleted: 409 IDEMPOTENCY_KEY_MISMATCH throws IdempotencyKeyMismatchError with details', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        {
+          error: {
+            code: 'IDEMPOTENCY_KEY_MISMATCH',
+            message: 'idempotency_key on complete does not match the key recorded on gate',
+            details: {
+              workflow_id: 'wf_41231a72',
+              step_id: 'step-2',
+              expected_idempotency_key: 'payment:wire:acct4471:invoice-7721',
+              received_idempotency_key: 'payment:wire:acct4471:invoice-9999',
+            },
+          },
+        },
+        409
+      )
+    );
+
+    expect.assertions(5);
+    try {
+      await client.markStepCompleted('wf_41231a72', 'step-2', {
+        idempotency_key: 'payment:wire:acct4471:invoice-9999',
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(IdempotencyKeyMismatchError);
+      const idem = err as IdempotencyKeyMismatchError;
+      expect(idem.workflowId).toBe('wf_41231a72');
+      expect(idem.stepId).toBe('step-2');
+      expect(idem.expectedIdempotencyKey).toBe('payment:wire:acct4471:invoice-7721');
+      expect(idem.receivedIdempotencyKey).toBe('payment:wire:acct4471:invoice-9999');
+    }
+  });
+
+  it('stepGate: 409 IDEMPOTENCY_KEY_MISMATCH also surfaces as typed error', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        {
+          error: {
+            code: 'IDEMPOTENCY_KEY_MISMATCH',
+            message: 'mismatch',
+            details: {
+              workflow_id: 'wf_1',
+              step_id: 's1',
+              expected_idempotency_key: 'a',
+              received_idempotency_key: 'b',
+            },
+          },
+        },
+        409
+      )
+    );
+
+    expect.assertions(3);
+    try {
+      await client.stepGate('wf_1', 's1', { step_type: 'llm_call', idempotency_key: 'b' });
+    } catch (err) {
+      expect(err).toBeInstanceOf(IdempotencyKeyMismatchError);
+      const idem = err as IdempotencyKeyMismatchError;
+      expect(idem.expectedIdempotencyKey).toBe('a');
+      expect(idem.receivedIdempotencyKey).toBe('b');
+    }
+  });
+});

--- a/tests/retry-context-idempotency.test.ts
+++ b/tests/retry-context-idempotency.test.ts
@@ -249,6 +249,30 @@ describe('retry_context + idempotency_key (#1673)', () => {
     }
   });
 
+  it('retry_context accepts null idempotency_key (contract §3: "string or null")', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        decision: 'allow',
+        step_id: 'step_1',
+        retry_context: {
+          gate_count: 1,
+          completion_count: 0,
+          prior_completion_status: 'none',
+          prior_output_available: false,
+          prior_output: null,
+          prior_completion_at: null,
+          first_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_attempt_at: '2026-04-21T15:30:00.000Z',
+          last_decision: 'allow',
+          idempotency_key: null,
+        },
+      })
+    );
+
+    const gate = await client.stepGate('wf_1', 'step_1', { step_type: 'llm_call' });
+    expect(gate.retry_context.idempotency_key).toBeNull();
+  });
+
   it('stepGate: 409 IDEMPOTENCY_KEY_MISMATCH also surfaces as typed error', async () => {
     mockFetch.mockResolvedValueOnce(
       mockResponse(


### PR DESCRIPTION
## Summary

Implements the TypeScript SDK side of the WCP retry_context + idempotency_key wire contract for [axonflow-enterprise#1673](https://github.com/getaxonflow/axonflow-enterprise/issues/1673) (Phase 1 + Phase 2). Contract: [WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md](https://github.com/getaxonflow/axonflow-enterprise/blob/feat/1673-retry-context-and-idempotency-key/technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md).

- `RetryContext` interface + `PriorCompletionStatus` union type (always present on `StepGateResponse`).
- `cached` / `decision_source` preserved, marked `@deprecated` with migration guidance.
- `stepGate(workflowId, stepId, request, options?)` — new optional fourth arg `{ includePriorOutput?: boolean }` sends `?include_prior_output=true`.
- `idempotency_key` on `StepGateRequest` and `MarkStepCompletedRequest`.
- `IdempotencyKeyMismatchError` exported from `@axonflow/sdk`, thrown from both `stepGate` and `markStepCompleted` on 409 `IDEMPOTENCY_KEY_MISMATCH`.
- Unit tests for all six shapes from §6.8 of the contract.
- `[Unreleased]` CHANGELOG entry. **No version bump** until platform v7.3.0 tag is cut.

## Coordination

- **Do not merge before** [getaxonflow/axonflow-enterprise#1673](https://github.com/getaxonflow/axonflow-enterprise/issues/1673) platform PR merges.
- After platform merges, reconcile against final response shape (§3), run full E2E per `E2E_EXAMPLES_TESTING_WORKFLOW.md` (CLAUDE.md hard rule #6).
- Version bump lands in this PR once platform tag is cut.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] New unit suite `tests/retry-context-idempotency.test.ts` — 7/7 green
- [x] Full suite (excluding e2e-staging, integration): 852 passed, 0 failed
- [x] `eslint` on changed files — clean
- [ ] E2E against merged platform — deferred until platform PR merges
- [ ] Version bump commit — deferred until platform release tag is cut