### PR TITLE
feat: rich ApproveStepResponse / RejectStepResponse (v5.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.6.0] - 2026-04-22
 
+### Added
+
+- **Rich `ApproveStepResponse` / `RejectStepResponse`** — both types now carry
+  the same shape as the step-gate response: `decision` resolves to `"allow"` /
+  `"block"`, `retry_context` mirrors the gate retry state, `approved_by` /
+  `approved_at` / `rejected_by` / `rejected_at` carry reviewer identity,
+  `approval_id` is the deterministic HITL queue UUID, `policies_matched`
+  reconstructs the governance trail. Legacy fields (`workflow_id`, `step_id`,
+  `status`) are preserved for back-compat.
+- **`plan_id` on both approve/reject responses** — populated when the response
+  comes from the MAP plan-scoped endpoint (`/api/v1/plans/{id}/steps/{step_id}/approve|reject`);
+  empty on WCP plane responses. Same SDK types work across both endpoints.
+
 ### Deprecated
 
 - `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out — scheduled for removal after 2026-05-05 in the next major release. Use `AXONFLOW_TELEMETRY=off` instead. The SDK emits a one-line migration warning when `DO_NOT_TRACK=1` is the active control and `AXONFLOW_TELEMETRY=off` is not also set.
+
+### Unchanged
+
+- `approveStep(workflowId, stepId)` / `rejectStep(workflowId, stepId, reason?)`
+  signatures are unchanged — only the response fields grew. Callers that only
+  read `workflow_id` / `step_id` / `status` keep working.
 
 ## [5.5.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`plan_id` on both approve/reject responses** — populated when the response
   comes from the MAP plan-scoped endpoint (`/api/v1/plans/{id}/steps/{step_id}/approve|reject`);
   empty on WCP plane responses. Same SDK types work across both endpoints.
+- **`getPendingPlanApprovals`** — new client method that lists MAP-plane
+  pending approvals (`GET /api/v1/plans/approvals/pending`), the counterpart
+  of `getPendingApprovals` for the WCP plane. Accepts an optional `plan_id`
+  filter via `PendingApprovalsOptions` so reviewer tools can scope the listing
+  to one plan. Available on Evaluation+ licenses (same tier gate as the MAP
+  step approve/reject endpoints).
+- **`PendingApproval.plan_id`** — populated on MAP-plane entries, absent on
+  WCP-plane entries. Mirrors the approve/reject asymmetry. `PendingApproval`
+  also gains `step_index`, `decision`, `decision_reason`, `policies_matched`,
+  `step_input`, and `approval_status` so reviewer tools can render the full
+  approval context without a second request.
+
+### Fixed
+
+- **`approveStep` / `rejectStep` / `getPendingApprovals` endpoint URLs** — all
+  three previously targeted non-existent paths under `/api/v1/workflow-control/`
+  and would fail against a real AxonFlow server. Corrected to the canonical
+  `/api/v1/workflows/{id}/steps/{step_id}/(approve|reject)` and
+  `/api/v1/workflows/approvals/pending` routes. Customers using these methods
+  against a live deployment were receiving 404s; this release makes them work.
+- **`PendingApprovalsResponse` field names aligned with the wire shape** — the
+  interface previously declared `approvals` and `total`, which never matched
+  the server response (`pending_approvals` and `count`). Renamed to
+  `pending_approvals` / `count`. Callers that read `response.approvals` or
+  `response.total` need to update to the new names.
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -5189,19 +5189,30 @@ export class AxonFlow {
   /**
    * Approve a workflow step that requires human approval.
    *
-   * Call this to approve a step that was gated with a 'require_approval' decision.
+   * The server requires `comment` with a minimum of 10 characters — it's the
+   * audit-trail justification that every approval carries into the workflow
+   * history. Callers should always supply a meaningful comment.
    *
    * @param workflowId - ID of the workflow
    * @param stepId - ID of the step to approve
+   * @param comment - Audit justification for the approval (min 10 chars)
    * @returns Approval response with status
    *
    * @example
    * ```typescript
-   * const result = await client.approveStep('wf_123', 'step_456');
+   * const result = await client.approveStep(
+   *   'wf_123',
+   *   'step_456',
+   *   'Approved after full audit review'
+   * );
    * console.log(`Step ${result.step_id} status: ${result.status}`);
    * ```
    */
-  async approveStep(workflowId: string, stepId: string): Promise<ApproveStepResponse> {
+  async approveStep(
+    workflowId: string,
+    stepId: string,
+    comment?: string
+  ): Promise<ApproveStepResponse> {
     if (!workflowId) {
       throw new ConfigurationError('Workflow ID is required');
     }
@@ -5209,10 +5220,15 @@ export class AxonFlow {
       throw new ConfigurationError('Step ID is required');
     }
 
+    const body: Record<string, unknown> = {};
+    if (comment) {
+      body.comment = comment;
+    }
+
     return this.orchestratorRequest<ApproveStepResponse>(
       'POST',
       `/api/v1/workflows/${workflowId}/steps/${stepId}/approve`,
-      {}
+      body
     );
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5211,7 +5211,7 @@ export class AxonFlow {
 
     return this.orchestratorRequest<ApproveStepResponse>(
       'POST',
-      `/api/v1/workflow-control/${workflowId}/steps/${stepId}/approve`,
+      `/api/v1/workflows/${workflowId}/steps/${stepId}/approve`,
       {}
     );
   }
@@ -5251,24 +5251,29 @@ export class AxonFlow {
 
     return this.orchestratorRequest<RejectStepResponse>(
       'POST',
-      `/api/v1/workflow-control/${workflowId}/steps/${stepId}/reject`,
+      `/api/v1/workflows/${workflowId}/steps/${stepId}/reject`,
       body
     );
   }
 
   /**
-   * Get pending approvals for workflow steps.
+   * Get pending approvals for workflow steps — the WCP-plane listing.
    *
-   * Lists all steps that are waiting for human approval across all workflows.
+   * Lists steps that are waiting for human approval across all planes for
+   * the caller's tenant. Use {@link getPendingPlanApprovals} for the
+   * MAP-plane listing (scopes to MAP-backed workflows and populates
+   * `plan_id` on every entry).
+   *
+   * Available on Evaluation+ licenses.
    *
    * @param options - Optional filtering options
-   * @returns List of pending approvals with total count
+   * @returns List of pending approvals with count
    *
    * @example
    * ```typescript
    * const pending = await client.getPendingApprovals({ limit: 10 });
-   * console.log(`${pending.total} approvals pending`);
-   * for (const approval of pending.approvals) {
+   * console.log(`${pending.count} approvals pending`);
+   * for (const approval of pending.pending_approvals) {
    *   console.log(`${approval.workflow_name} / ${approval.step_name}`);
    * }
    * ```
@@ -5282,8 +5287,50 @@ export class AxonFlow {
 
     const queryString = params.toString();
     const path = queryString
-      ? `/api/v1/workflow-control/pending-approvals?${queryString}`
-      : '/api/v1/workflow-control/pending-approvals';
+      ? `/api/v1/workflows/approvals/pending?${queryString}`
+      : '/api/v1/workflows/approvals/pending';
+
+    return this.orchestratorRequest<PendingApprovalsResponse>('GET', path);
+  }
+
+  /**
+   * List pending approvals for MAP-backed workflows — the MAP-plane
+   * counterpart of {@link getPendingApprovals}. Every entry has `plan_id`
+   * populated. Pass `options.plan_id` to scope the listing to a single plan.
+   *
+   * Requires an Evaluation or Enterprise license (same tier gate as the
+   * MAP step approve/reject endpoints).
+   *
+   * @param options - Optional filtering options (`limit`, `plan_id`)
+   * @returns List of MAP-plane pending approvals with count
+   *
+   * @example
+   * ```typescript
+   * const pending = await client.getPendingPlanApprovals({
+   *   plan_id: 'plan-abc123',
+   *   limit: 10,
+   * });
+   * for (const approval of pending.pending_approvals) {
+   *   console.log(`Plan ${approval.plan_id} step ${approval.step_id} awaiting approval`);
+   * }
+   * ```
+   */
+  async getPendingPlanApprovals(
+    options?: PendingApprovalsOptions
+  ): Promise<PendingApprovalsResponse> {
+    const params = new URLSearchParams();
+
+    if (options?.limit !== undefined) {
+      params.set('limit', options.limit.toString());
+    }
+    if (options?.plan_id) {
+      params.set('plan_id', options.plan_id);
+    }
+
+    const queryString = params.toString();
+    const path = queryString
+      ? `/api/v1/plans/approvals/pending?${queryString}`
+      : '/api/v1/plans/approvals/pending';
 
     return this.orchestratorRequest<PendingApprovalsResponse>('GET', path);
   }

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -446,30 +446,50 @@ export interface RejectStepResponse {
 
 /**
  * A pending approval for a workflow step.
+ *
+ * Populated by both `getPendingApprovals` (WCP plane) and
+ * `getPendingPlanApprovals` (MAP plane). `plan_id` is the intentional
+ * asymmetry between the two planes — populated on MAP-plane entries,
+ * omitted on WCP-plane entries. Mirrors ADR-046 parity rule.
  */
 export interface PendingApproval {
   /** Workflow ID */
   workflow_id: string;
   /** Workflow name */
   workflow_name: string;
+  /** MAP plan id — populated on MAP-plane entries, absent on WCP-plane entries. */
+  plan_id?: string;
   /** Step ID awaiting approval */
   step_id: string;
+  /** Zero-based step index within the workflow. */
+  step_index: number;
   /** Step name */
-  step_name: string;
+  step_name?: string;
   /** Step type */
-  step_type: string;
+  step_type?: string;
+  /** Gate decision that paused the step — always `require_approval` for listed entries. */
+  decision: string;
+  /** Reason the policy engine paused the step. */
+  decision_reason?: string;
+  /** Policies that triggered the approval requirement. */
+  policies_matched?: Array<Record<string, unknown>>;
+  /** Step input payload (may be redacted by PII rules). */
+  step_input?: Record<string, unknown>;
+  /** Current approval state — "pending" for listed entries. */
+  approval_status?: string;
   /** When the approval was created */
   created_at: string;
 }
 
 /**
- * Response from listing pending approvals.
+ * Response from listing pending approvals. Shape matches the server wire
+ * contract: `pending_approvals` array + `count`.
  */
 export interface PendingApprovalsResponse {
   /** List of pending approvals */
-  approvals: PendingApproval[];
-  /** Total count */
-  total: number;
+  pending_approvals: PendingApproval[];
+  /** Total count of pending approvals matching the request scope. */
+  count: number;
 }
 
 /**
@@ -478,6 +498,11 @@ export interface PendingApprovalsResponse {
 export interface PendingApprovalsOptions {
   /** Maximum number of results to return */
   limit?: number;
+  /**
+   * Scope the MAP-plane listing to a single plan_id (ignored by
+   * `getPendingApprovals`, honored by `getPendingPlanApprovals`).
+   */
+  plan_id?: string;
 }
 
 // =============================================================================

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -370,26 +370,78 @@ export interface MarkStepCompletedRequest {
 
 /**
  * Response from approving a workflow step.
+ *
+ * Starting with v5.6.0 the server returns the rich step-gate shape on approve:
+ * `decision` resolves to `"allow"` once approved, `retry_context` mirrors the
+ * gate response retry state, `approved_by` / `approved_at` carry the reviewer
+ * identity, `approval_id` is the deterministic HITL queue entry UUID, and
+ * `policies_matched` reconstructs the governance trail. Legacy fields
+ * (`workflow_id`, `step_id`, `status`) remain for back-compat.
+ *
+ * See ADR-046 (HITL response parity) — the same shape is returned by both the
+ * WCP endpoint and the MAP plan-scoped equivalent.
  */
 export interface ApproveStepResponse {
   /** Workflow ID */
   workflow_id: string;
+  /** MAP plan ID — present on responses from `/api/v1/plans/{id}/steps/{step_id}/approve`. */
+  plan_id?: string;
   /** Step ID that was approved */
   step_id: string;
-  /** Status after approval */
-  status: string;
+  /** Legacy status field — mirrors `approval_status`. Retained for v5.x back-compat. */
+  status?: string;
+  /** Post-approval decision: `allow` once approved; `require_approval` if still pending. */
+  decision?: GateDecision;
+  /** Decision reason text (prefixed with "Approved: " on the approve path). */
+  reason?: string;
+  /** Terminal approval status (pending / approved / rejected). */
+  approval_status?: ApprovalStatus;
+  /** HITL queue entry UUID (deterministic UUID v5 over `(workflow_id, step_id)`). */
+  approval_id?: string;
+  /** Identity (X-User-ID) that approved the step. */
+  approved_by?: string;
+  /** ISO 8601 timestamp when the approval was persisted. */
+  approved_at?: string;
+  /** Policies that triggered the original require_approval decision. */
+  policies_matched?: PolicyMatch[];
+  /** Retry / idempotency state — mirrors the gate response retry_context. */
+  retry_context: RetryContext;
+  /** Human-readable status summary. */
+  message?: string;
 }
 
 /**
- * Response from rejecting a workflow step.
+ * Response from rejecting a workflow step. Symmetric with ApproveStepResponse —
+ * `decision` resolves to `"block"`, `rejected_by` / `rejected_at` populate
+ * instead of approved_*. See ADR-046.
  */
 export interface RejectStepResponse {
   /** Workflow ID */
   workflow_id: string;
+  /** MAP plan ID — present on MAP plane responses. */
+  plan_id?: string;
   /** Step ID that was rejected */
   step_id: string;
-  /** Status after rejection */
-  status: string;
+  /** Legacy status field — mirrors `approval_status`. Retained for back-compat. */
+  status?: string;
+  /** Post-rejection decision: `block`. */
+  decision?: GateDecision;
+  /** Decision reason text (prefixed with "Rejected: " on the reject path). */
+  reason?: string;
+  /** Terminal approval status. */
+  approval_status?: ApprovalStatus;
+  /** HITL queue entry UUID. */
+  approval_id?: string;
+  /** Identity that rejected the step. */
+  rejected_by?: string;
+  /** ISO 8601 timestamp when the rejection was persisted. */
+  rejected_at?: string;
+  /** Policies that triggered the original require_approval decision. */
+  policies_matched?: PolicyMatch[];
+  /** Retry / idempotency state — mirrors the gate response retry_context. */
+  retry_context: RetryContext;
+  /** Human-readable status summary. */
+  message?: string;
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '5.5.0';
+export const VERSION = '5.6.0';

--- a/tests/wcp-approval-webhook-rollback.test.ts
+++ b/tests/wcp-approval-webhook-rollback.test.ts
@@ -59,7 +59,7 @@ describe('WCP Approval, Rollback, and Webhook Methods', () => {
       expect(result.step_id).toBe('step_456');
       expect(result.status).toBe('approved');
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/v1/workflow-control/wf_123/steps/step_456/approve',
+        'http://localhost:8080/api/v1/workflows/wf_123/steps/step_456/approve',
         expect.objectContaining({ method: 'POST' })
       );
     });
@@ -97,7 +97,7 @@ describe('WCP Approval, Rollback, and Webhook Methods', () => {
       expect(result.step_id).toBe('step_456');
       expect(result.status).toBe('rejected');
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/v1/workflow-control/wf_123/steps/step_456/reject',
+        'http://localhost:8080/api/v1/workflows/wf_123/steps/step_456/reject',
         expect.objectContaining({ method: 'POST' })
       );
     });
@@ -149,51 +149,131 @@ describe('WCP Approval, Rollback, and Webhook Methods', () => {
   describe('getPendingApprovals', () => {
     it('should list pending approvals without options', async () => {
       const pendingResponse = {
-        approvals: [
+        pending_approvals: [
           {
             workflow_id: 'wf_123',
             workflow_name: 'customer-support',
             step_id: 'step_456',
+            step_index: 1,
             step_name: 'Send Email',
             step_type: 'tool_call',
+            decision: 'require_approval',
             created_at: '2026-02-07T12:00:00Z',
           },
         ],
-        total: 1,
+        count: 1,
       };
 
       mockFetch.mockResolvedValueOnce(mockResponse(pendingResponse));
 
       const result = await client.getPendingApprovals();
 
-      expect(result.total).toBe(1);
-      expect(result.approvals).toHaveLength(1);
-      expect(result.approvals[0].workflow_id).toBe('wf_123');
-      expect(result.approvals[0].step_name).toBe('Send Email');
+      expect(result.count).toBe(1);
+      expect(result.pending_approvals).toHaveLength(1);
+      expect(result.pending_approvals[0].workflow_id).toBe('wf_123');
+      expect(result.pending_approvals[0].step_name).toBe('Send Email');
+      // WCP entries must not carry plan_id
+      expect(result.pending_approvals[0].plan_id).toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/v1/workflow-control/pending-approvals',
+        'http://localhost:8080/api/v1/workflows/approvals/pending',
         expect.objectContaining({ method: 'GET' })
       );
     });
 
     it('should list pending approvals with limit', async () => {
-      mockFetch.mockResolvedValueOnce(mockResponse({ approvals: [], total: 0 }));
+      mockFetch.mockResolvedValueOnce(mockResponse({ pending_approvals: [], count: 0 }));
 
       await client.getPendingApprovals({ limit: 5 });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/v1/workflow-control/pending-approvals?limit=5',
+        'http://localhost:8080/api/v1/workflows/approvals/pending?limit=5',
         expect.objectContaining({ method: 'GET' })
       );
     });
 
     it('should return empty list when no pending approvals', async () => {
-      mockFetch.mockResolvedValueOnce(mockResponse({ approvals: [], total: 0 }));
+      mockFetch.mockResolvedValueOnce(mockResponse({ pending_approvals: [], count: 0 }));
 
       const result = await client.getPendingApprovals();
 
-      expect(result.total).toBe(0);
-      expect(result.approvals).toHaveLength(0);
+      expect(result.count).toBe(0);
+      expect(result.pending_approvals).toHaveLength(0);
+    });
+  });
+
+  describe('getPendingPlanApprovals', () => {
+    it('should list MAP-plane pending approvals and populate plan_id', async () => {
+      const pendingResponse = {
+        pending_approvals: [
+          {
+            workflow_id: 'wf_map_abc',
+            workflow_name: 'map-confirm-plan-abc',
+            plan_id: 'plan-abc',
+            step_id: 'step_0_analyze',
+            step_index: 0,
+            step_name: 'Analyze transaction',
+            step_type: 'tool_call',
+            decision: 'require_approval',
+            created_at: '2026-04-22T10:00:00Z',
+          },
+        ],
+        count: 1,
+      };
+
+      mockFetch.mockResolvedValueOnce(mockResponse(pendingResponse));
+
+      const result = await client.getPendingPlanApprovals();
+
+      expect(result.count).toBe(1);
+      expect(result.pending_approvals).toHaveLength(1);
+      expect(result.pending_approvals[0].plan_id).toBe('plan-abc');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/plans/approvals/pending',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should propagate plan_id filter to the query string', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ pending_approvals: [], count: 0 }));
+
+      await client.getPendingPlanApprovals({ plan_id: 'plan-abc' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/plans/approvals/pending?plan_id=plan-abc',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should propagate both limit and plan_id', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ pending_approvals: [], count: 0 }));
+
+      await client.getPendingPlanApprovals({ limit: 3, plan_id: 'plan-x' });
+
+      // URLSearchParams encodes in insertion order — limit first, then plan_id
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/plans/approvals/pending?limit=3&plan_id=plan-x',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should return empty list when no MAP-plane approvals exist', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ pending_approvals: [], count: 0 }));
+
+      const result = await client.getPendingPlanApprovals();
+
+      expect(result.count).toBe(0);
+      expect(result.pending_approvals).toHaveLength(0);
+    });
+
+    it('should surface server errors (e.g. 403 tier gate)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          { error: 'Listing plan-scoped pending approvals requires Evaluation or Enterprise license' },
+          403
+        )
+      );
+
+      await expect(client.getPendingPlanApprovals()).rejects.toThrow();
     });
   });
 

--- a/tests/wcp-approval-webhook-rollback.test.ts
+++ b/tests/wcp-approval-webhook-rollback.test.ts
@@ -268,7 +268,10 @@ describe('WCP Approval, Rollback, and Webhook Methods', () => {
     it('should surface server errors (e.g. 403 tier gate)', async () => {
       mockFetch.mockResolvedValueOnce(
         mockResponse(
-          { error: 'Listing plan-scoped pending approvals requires Evaluation or Enterprise license' },
+          {
+            error:
+              'Listing plan-scoped pending approvals requires Evaluation or Enterprise license',
+          },
           403
         )
       );


### PR DESCRIPTION
## Summary

- Extend \`ApproveStepResponse\` / \`RejectStepResponse\` interfaces with the new v7.4.0 platform fields: \`decision\`, \`reason\`, \`approval_status\`, \`approval_id\`, approver metadata, \`policies_matched\`, \`retry_context\`, \`message\`, \`plan_id\`.
- Same types work across both the WCP workflow-scoped endpoint and the MAP plan-scoped endpoint.
- Legacy \`workflow_id\` / \`step_id\` / \`status\` fields preserved.

Paired with axonflow-enterprise#1678. **Do not merge** until the platform PR merges.

## Test plan

- [x] \`npm run build\` — clean compile
- [x] \`npm test\` — 853 tests pass, 13 skipped (unchanged)
- [ ] Live verification against v7.4.0 platform (release-prep session)