### PR TITLE
chore(telemetry): deprecate DO_NOT_TRACK env var (warn on use)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] - 2026-04-22
+
+### Deprecated
+
+- `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out — scheduled for removal after 2026-05-05 in the next major release. Use `AXONFLOW_TELEMETRY=off` instead. The SDK emits a one-line migration warning when `DO_NOT_TRACK=1` is the active control and `AXONFLOW_TELEMETRY=off` is not also set.
+
 ## [5.5.0] - 2026-04-21
 
 ### Added

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -35,25 +35,42 @@ function generateInstanceId(): string {
 }
 
 /**
+ * Tracks whether the DO_NOT_TRACK deprecation warning has already fired for
+ * this process. A long-running caller shouldn't see the deprecation spam;
+ * operators see it once at the first opt-out check and that's enough.
+ *
+ * Exported so tests that initialize multiple AxonFlow clients against the
+ * same process can reset the latch when they need to assert warn-firing
+ * behavior deterministically.
+ */
+let doNotTrackWarningFired = false;
+
+/** @internal — test helper to reset the warn-once latch. */
+export function __resetDoNotTrackDeprecationWarning(): void {
+  doNotTrackWarningFired = false;
+}
+
+/**
  * Check whether telemetry is opted-out via environment variables.
  *
  * `AXONFLOW_TELEMETRY=off` is the canonical AxonFlow-specific opt-out.
  * `DO_NOT_TRACK=1` is **deprecated** as an AxonFlow opt-out and will be
  * removed after 2026-05-05 in the next major release — when it's the only
- * thing disabling telemetry, a one-line warning is emitted so operators can
- * migrate to `AXONFLOW_TELEMETRY=off`. If both are set, the caller has already
- * migrated and no warning fires.
+ * thing disabling telemetry, a one-line warning is emitted **once per
+ * process** so operators can migrate to `AXONFLOW_TELEMETRY=off`. If both
+ * are set, the caller has already migrated and no warning fires.
  */
 function isOptedOut(): boolean {
   if (typeof process === 'undefined' || !process.env) {
     return false;
   }
   if (process.env.DO_NOT_TRACK?.trim() === '1') {
-    // Only warn when DO_NOT_TRACK is the active control.
-    if (process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off') {
-      // eslint-disable-next-line no-console
+    // Only warn when DO_NOT_TRACK is the active control, and only once per
+    // process so a long-running caller doesn't see the deprecation spam.
+    if (!doNotTrackWarningFired && process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off') {
+      doNotTrackWarningFired = true;
       console.warn(
-        '[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.',
+        '[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.'
       );
     }
     return true;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -37,14 +37,25 @@ function generateInstanceId(): string {
 /**
  * Check whether telemetry is opted-out via environment variables.
  *
- * Respects the standard DO_NOT_TRACK convention and the AxonFlow-specific
- * AXONFLOW_TELEMETRY variable.
+ * `AXONFLOW_TELEMETRY=off` is the canonical AxonFlow-specific opt-out.
+ * `DO_NOT_TRACK=1` is **deprecated** as an AxonFlow opt-out and will be
+ * removed after 2026-05-05 in the next major release — when it's the only
+ * thing disabling telemetry, a one-line warning is emitted so operators can
+ * migrate to `AXONFLOW_TELEMETRY=off`. If both are set, the caller has already
+ * migrated and no warning fires.
  */
 function isOptedOut(): boolean {
   if (typeof process === 'undefined' || !process.env) {
     return false;
   }
   if (process.env.DO_NOT_TRACK?.trim() === '1') {
+    // Only warn when DO_NOT_TRACK is the active control.
+    if (process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.',
+      );
+    }
     return true;
   }
   if (process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() === 'off') {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -35,40 +35,27 @@ function generateInstanceId(): string {
 }
 
 /**
- * Tracks whether the DO_NOT_TRACK deprecation warning has already fired for
- * this process. A long-running caller shouldn't see the deprecation spam;
- * operators see it once at the first opt-out check and that's enough.
- *
- * Exported so tests that initialize multiple AxonFlow clients against the
- * same process can reset the latch when they need to assert warn-firing
- * behavior deterministically.
- */
-let doNotTrackWarningFired = false;
-
-/** @internal — test helper to reset the warn-once latch. */
-export function __resetDoNotTrackDeprecationWarning(): void {
-  doNotTrackWarningFired = false;
-}
-
-/**
  * Check whether telemetry is opted-out via environment variables.
  *
  * `AXONFLOW_TELEMETRY=off` is the canonical AxonFlow-specific opt-out.
  * `DO_NOT_TRACK=1` is **deprecated** as an AxonFlow opt-out and will be
  * removed after 2026-05-05 in the next major release — when it's the only
- * thing disabling telemetry, a one-line warning is emitted **once per
- * process** so operators can migrate to `AXONFLOW_TELEMETRY=off`. If both
- * are set, the caller has already migrated and no warning fires.
+ * thing disabling telemetry, a one-line warning is emitted so operators can
+ * migrate to `AXONFLOW_TELEMETRY=off`. If both are set, the caller has
+ * already migrated and no warning fires.
+ *
+ * Consistent with the Go, Python, and Java SDKs — the warning fires on
+ * every opt-out check, not once per process, so any downstream log sink
+ * sees every invocation (cron jobs, per-request child processes).
  */
 function isOptedOut(): boolean {
   if (typeof process === 'undefined' || !process.env) {
     return false;
   }
   if (process.env.DO_NOT_TRACK?.trim() === '1') {
-    // Only warn when DO_NOT_TRACK is the active control, and only once per
-    // process so a long-running caller doesn't see the deprecation spam.
-    if (!doNotTrackWarningFired && process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off') {
-      doNotTrackWarningFired = true;
+    // Only warn when DO_NOT_TRACK is the active control. If AXONFLOW_TELEMETRY=off
+    // is also set, the caller has already migrated.
+    if (process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off') {
       console.warn(
         '[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.'
       );

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1424,6 +1424,11 @@ describe('AxonFlow Client Unit Tests', () => {
     });
 
     it('should allow tenant without clientId in community mode', () => {
+      // Scope out the inherited DO_NOT_TRACK=1 env var so the telemetry
+      // deprecation warning (landed alongside v7.4.0) doesn't shadow this
+      // test's credential-warning assertion.
+      const origDoNotTrack = process.env.DO_NOT_TRACK;
+      delete process.env.DO_NOT_TRACK;
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
       new AxonFlow({
@@ -1432,12 +1437,15 @@ describe('AxonFlow Client Unit Tests', () => {
         debug: true,
       });
 
-      // No deprecation warnings - tenant alone is valid for community mode
+      // No credential-shape warnings — tenant alone is valid for community mode.
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
+      if (origDoNotTrack !== undefined) process.env.DO_NOT_TRACK = origDoNotTrack;
     });
 
     it('should NOT warn when using endpoint only (pure community mode)', () => {
+      const origDoNotTrack = process.env.DO_NOT_TRACK;
+      delete process.env.DO_NOT_TRACK;
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
       new AxonFlow({
@@ -1445,9 +1453,10 @@ describe('AxonFlow Client Unit Tests', () => {
         debug: true,
       });
 
-      // No warnings expected - just endpoint in community mode
+      // No credential-shape warnings expected for pure community mode.
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
+      if (origDoNotTrack !== undefined) process.env.DO_NOT_TRACK = origDoNotTrack;
     });
 
     it('should work with any endpoint without credentials', () => {


### PR DESCRIPTION
## Summary

- Starts a deprecation of `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out. Removal target: **after 2026-05-05 in the next major release**.
- `AXONFLOW_TELEMETRY=off` remains the canonical AxonFlow-specific opt-out. Its behavior is unchanged.
- When `DO_NOT_TRACK=1` is set AND `AXONFLOW_TELEMETRY=off` is NOT set, the SDK now emits a one-line warning at the point the opt-out takes effect, pointing operators at the canonical switch. If both are set, the caller has already migrated and no warning fires.
- Aligns with the v7.4.0 platform release train — other WCP / MAP fields are also being deprecated for removal after the 2026-05-05 cutoff.

## Why

`DO_NOT_TRACK=1` is a widely-understood privacy convention in dev tooling. It is set broadly across CI environments and corporate shells, often as a blanket policy, not as an intentional decision about AxonFlow specifically. When it silently disables AxonFlow telemetry the product operator learns nothing and the project loses the ability to see real usage.

This is the middle path between keep-honoring-DO_NOT_TRACK-forever (status quo — commercially blind) and ignore-DO_NOT_TRACK-overnight (trust-breaking). Announce the deprecation now, warn during the transition window, remove in the next major release. Users who genuinely want AxonFlow telemetry off can set the AxonFlow-specific switch; users whose DO_NOT_TRACK comes from a generic policy can opt in intentionally if they want the signal on.

## What changed

- Telemetry init: single code-path change that adds the warning emission.
- CHANGELOG: new `### Deprecated` section under the next version with the rationale and timeline.

## Test plan

- [x] Existing telemetry test suite still passes (no decision-logic change)
- [x] Warning fires only when `DO_NOT_TRACK=1` is the active control (`AXONFLOW_TELEMETRY=off` silences it)
- [ ] After merge, CI confirms the `release-notes-from-CHANGELOG` preflight picks up the `### Deprecated` entry verbatim for the release notes

## Related

- Sibling PRs in the other 3 SDK repos landing the same deprecation warning
- Companion platform v7.4.0 release train (#1678)
