### PR TITLE
fix(test): stop real telemetry ping leaking from community-mode client tests

### DIFF
--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1424,11 +1424,13 @@ describe('AxonFlow Client Unit Tests', () => {
     });
 
     it('should allow tenant without clientId in community mode', () => {
-      // Scope out the inherited DO_NOT_TRACK=1 env var so the telemetry
-      // deprecation warning (landed alongside v7.4.0) doesn't shadow this
-      // test's credential-warning assertion.
-      const origDoNotTrack = process.env.DO_NOT_TRACK;
-      delete process.env.DO_NOT_TRACK;
+      // Set AXONFLOW_TELEMETRY=off alongside CI's DO_NOT_TRACK=1 so the
+      // telemetry deprecation warning (v5.6.0+) stays silent and doesn't
+      // shadow this test's credential-warning assertion. This also prevents
+      // the client constructor's fire-and-forget ping from hitting the real
+      // checkpoint endpoint — fetch is not mocked in this file.
+      const origAxonflowTelemetry = process.env.AXONFLOW_TELEMETRY;
+      process.env.AXONFLOW_TELEMETRY = 'off';
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
       new AxonFlow({
@@ -1440,12 +1442,16 @@ describe('AxonFlow Client Unit Tests', () => {
       // No credential-shape warnings — tenant alone is valid for community mode.
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
-      if (origDoNotTrack !== undefined) process.env.DO_NOT_TRACK = origDoNotTrack;
+      if (origAxonflowTelemetry !== undefined) {
+        process.env.AXONFLOW_TELEMETRY = origAxonflowTelemetry;
+      } else {
+        delete process.env.AXONFLOW_TELEMETRY;
+      }
     });
 
     it('should NOT warn when using endpoint only (pure community mode)', () => {
-      const origDoNotTrack = process.env.DO_NOT_TRACK;
-      delete process.env.DO_NOT_TRACK;
+      const origAxonflowTelemetry = process.env.AXONFLOW_TELEMETRY;
+      process.env.AXONFLOW_TELEMETRY = 'off';
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
       new AxonFlow({
@@ -1456,7 +1462,11 @@ describe('AxonFlow Client Unit Tests', () => {
       // No credential-shape warnings expected for pure community mode.
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
-      if (origDoNotTrack !== undefined) process.env.DO_NOT_TRACK = origDoNotTrack;
+      if (origAxonflowTelemetry !== undefined) {
+        process.env.AXONFLOW_TELEMETRY = origAxonflowTelemetry;
+      } else {
+        delete process.env.AXONFLOW_TELEMETRY;
+      }
     });
 
     it('should work with any endpoint without credentials', () => {


### PR DESCRIPTION
## Summary

Two tests added in #180 (the DO_NOT_TRACK deprecation PR) at `test/client.test.ts:1426-1460` delete `DO_NOT_TRACK` from the process env. With the env var removed and `AXONFLOW_TELEMETRY` unset, the `AxonFlow` constructor's fire-and-forget `sendTelemetryPing()` no longer opts out and sends a real POST to `checkpoint.getaxonflow.com`. `global.fetch` is only mocked inside `tests/telemetry.test.ts`, so the pings leaked out of CI.

## Why it's a leak

- Workflow-level `env: DO_NOT_TRACK: '1'` in `.github/workflows/test.yml` plus `jest.setup.ts` set `DO_NOT_TRACK=1` for every test by default
- These two tests explicitly strip that to let the credential-warning assertion run without the telemetry deprecation warning polluting `warnSpy`
- `new AxonFlow({ endpoint: 'http://localhost:8080', ... })` calls `sendTelemetryPing` → `isOptedOut()` reads env, sees no opt-out, returns `false` → real HTTP POST fires
- No `global.fetch` mock in this file — escaped to checkpoint

## Evidence

Checkpoint DynamoDB shows ~18 TS SDK pings from Azure GHA egress IPs (Microsoft Corporation / Microsoft Limited) during the 8:35-8:44 UTC window when SDK PRs (#127 Go, #146 Python, #180 TS, #135 Java) and their merged-main workflows ran. Signature:

- `sdk=typescript`, `endpoint_type=localhost`, `deployment_mode=production`
- Runtime Node 18.20.8 / 20.20.2 (matches our matrix)
- Versions 5.5.0 (pre-merge) and 5.6.0 (post-merge, from this branch's package.json bump)
- Two pings at the exact same second per run (matches the two affected tests running back-to-back)

Go SDK is unaffected because its equivalent tests point at an `httptest.NewServer` local mock, not the real checkpoint. Python/Java don't touch DO_NOT_TRACK in their deprecation test suites.

## Fix

Instead of deleting `DO_NOT_TRACK`, set `AXONFLOW_TELEMETRY='off'` alongside the CI's DO_NOT_TRACK=1:

- `isOptedOut()` sees both and returns `true` (opted out) — **no HTTP ping**
- The deprecation warning path in `isOptedOut()` explicitly skips the `console.warn` when both are set (\"the caller has already migrated\") — `warnSpy` stays clean
- Credential-warning assertion continues to work unchanged

One-file change. 164/164 in `test/client.test.ts` pass locally.

## Test plan

- [x] Local: `DO_NOT_TRACK=1 npx jest test/client.test.ts` → 164/164 pass
- [ ] CI: tests pass on Node 18/20/22 matrix
- [ ] Telemetry sanity: watch checkpoint DynamoDB after merge — no new pings from Microsoft Corp/Limited IPs on TS SDK 5.6.x+