### PR TITLE
fix(telemetry): share deadline across /health + POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Telemetry path is bounded at `TELEMETRY_TIMEOUT_MS` (3s) total; the `/health` probe and checkpoint POST share a single monotonic deadline instead of stacking independent timeouts. Aligns with python/go/java SDKs.
+
 ## [5.6.0] - 2026-04-22
 
 ### Added

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -343,10 +343,7 @@ export function sendTelemetryPing(options: {
         // Health probe gets up to HEALTH_BUDGET_CAP_MS of the remaining budget
         // so the POST always has room, even when /health hits a slow or
         // blackholed endpoint and consumes the full probe budget.
-        const healthBudget = Math.min(
-          HEALTH_BUDGET_CAP_MS,
-          Math.max(0, deadline - Date.now()),
-        );
+        const healthBudget = Math.min(HEALTH_BUDGET_CAP_MS, Math.max(0, deadline - Date.now()));
         if (options.endpoint && healthBudget > MIN_BUDGET_MS) {
           payload.platform_version = await detectPlatformVersion(options.endpoint, healthBudget);
         }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,6 +11,21 @@ const DEFAULT_CHECKPOINT_URL = 'https://checkpoint.getaxonflow.com/v1/ping';
 const TELEMETRY_TIMEOUT_MS = 3000;
 
 /**
+ * Minimum remaining HTTP budget (milliseconds). Below this, skip the operation
+ * rather than issue a request that is almost guaranteed to time out before any
+ * useful work completes. Keeps the telemetry path from making "essentially zero
+ * budget" calls when the shared deadline is nearly spent.
+ */
+const MIN_BUDGET_MS = 100;
+
+/**
+ * Health-probe budget ceiling. The /health probe should never consume more
+ * than 1s of the total TELEMETRY_TIMEOUT_MS budget, so the checkpoint POST
+ * always has enough room even when the probe hits a slow / blackholed endpoint.
+ */
+const HEALTH_BUDGET_CAP_MS = 1000;
+
+/**
  * Generate a random UUID v4-style identifier.
  *
  * Uses crypto.randomUUID() when available (Node 19+), otherwise falls back
@@ -311,12 +326,30 @@ export function sendTelemetryPing(options: {
     instance_id: generateInstanceId(),
   };
 
-  // Fire-and-forget: detect platform version then send ping
+  // Fire-and-forget: detect platform version then send ping.
+  //
+  // Both network operations share a single monotonic deadline so the total
+  // time bounded at TELEMETRY_TIMEOUT_MS covers the WHOLE telemetry path
+  // (/health probe + checkpoint POST). Previously the two had independent
+  // timeouts that stacked to ~5s on unreachable endpoints — defeating the
+  // "bounded at TELEMETRY_TIMEOUT_MS" invariant this function's docstring
+  // and the surrounding sync-expectations assume. Matches the pattern
+  // already shipped for python/go/java SDKs. See enterprise#1707.
   try {
     void (async () => {
+      const deadline = Date.now() + TELEMETRY_TIMEOUT_MS;
+
       try {
-        // Attempt to detect platform version from the health endpoint
-        payload.platform_version = await detectPlatformVersion(options.endpoint);
+        // Health probe gets up to HEALTH_BUDGET_CAP_MS of the remaining budget
+        // so the POST always has room, even when /health hits a slow or
+        // blackholed endpoint and consumes the full probe budget.
+        const healthBudget = Math.min(
+          HEALTH_BUDGET_CAP_MS,
+          Math.max(0, deadline - Date.now()),
+        );
+        if (options.endpoint && healthBudget > MIN_BUDGET_MS) {
+          payload.platform_version = await detectPlatformVersion(options.endpoint, healthBudget);
+        }
       } catch {
         // Silent — platform version remains null
       }
@@ -325,8 +358,14 @@ export function sendTelemetryPing(options: {
         console.log('[AxonFlow] Sending telemetry ping', JSON.stringify(payload, null, 2));
       }
 
+      // POST uses all remaining budget, bounded at the shared deadline.
+      const postBudget = Math.max(0, deadline - Date.now());
+      if (postBudget < MIN_BUDGET_MS) {
+        return;
+      }
+
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+      const timeoutId = setTimeout(() => controller.abort(), postBudget);
 
       try {
         await fetch(checkpointUrl, {
@@ -349,10 +388,14 @@ export function sendTelemetryPing(options: {
 /**
  * Detect the platform version by calling the agent's /health endpoint.
  * Returns the version string or null on any failure.
+ *
+ * @param timeoutMs — derived from the shared telemetry deadline so the health
+ * probe and the checkpoint POST don't stack into a larger combined budget.
+ * See enterprise#1707.
  */
-async function detectPlatformVersion(endpoint: string): Promise<string | null> {
+async function detectPlatformVersion(endpoint: string, timeoutMs: number): Promise<string | null> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 2000);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const resp = await fetch(`${endpoint}/health`, {

--- a/tests/telemetry-shared-deadline.test.ts
+++ b/tests/telemetry-shared-deadline.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test for axonflow-enterprise#1707: the /health probe and the
+ * checkpoint POST must share a single TELEMETRY_TIMEOUT_MS deadline, so total
+ * blocking time is bounded by that constant rather than stacking to ~5s.
+ *
+ * Prior to the fix, detectPlatformVersion had its own 2000ms AbortController
+ * timeout and the POST had its own TELEMETRY_TIMEOUT_MS=3000ms AbortController
+ * timeout, executed sequentially. On an unreachable endpoint the two stacked
+ * to ~5s — defeating the "bounded at TELEMETRY_TIMEOUT_MS" claim in the
+ * inline docstring.
+ *
+ * Key invariant: regardless of how long /health takes, the whole
+ * sendTelemetryPing path (including the awaited inner async IIFE) must
+ * complete within TELEMETRY_TIMEOUT_MS plus a small slack. We verify by
+ * making /health a slow hang and letting the POST mock respond instantly;
+ * total elapsed must stay near TELEMETRY_TIMEOUT_MS, not near
+ * TELEMETRY_TIMEOUT_MS + 2000.
+ */
+
+import { sendTelemetryPing } from '../src/telemetry';
+
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+
+describe('telemetry — shared deadline (regression for #1707)', () => {
+  beforeEach(() => {
+    // Strip environment-level opt-outs so sendTelemetryPing actually fires.
+    // CI and developer shells commonly have DO_NOT_TRACK=1 or AXONFLOW_TELEMETRY=off
+    // set; without this cleanup the fetches never happen and the test times out
+    // without verifying the thing it claims to verify.
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.AXONFLOW_TELEMETRY;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+    jest.useRealTimers();
+  });
+
+  it('bounds total /health + POST duration at TELEMETRY_TIMEOUT_MS (~3s), not stacked (~5s)', async () => {
+    // Simulate a slow /health that hangs past its cap, and a fast POST.
+    // With the shared-deadline fix, /health is capped at HEALTH_BUDGET_CAP_MS
+    // (1s) and the POST proceeds with the remaining ~2s. Total ~1s for the
+    // /health cap + ~0s for the mocked instant POST = <= ~1.2s.
+    //
+    // Without the fix (stacked timeouts), /health would consume its own 2s
+    // budget before the POST even starts, pushing total elapsed toward 2s+.
+    //
+    // Use a threshold that clearly discriminates the two behaviors:
+    //   shared-deadline fix:   elapsed ~1000-1200ms
+    //   stacked-timeout bug:   elapsed ~2000-2200ms
+
+    const fetchMock = jest.fn().mockImplementation((url: string, init?: { signal?: AbortSignal; method?: string }) => {
+      if (url.endsWith('/health')) {
+        // Simulate a slow /health by returning a Promise that only rejects when
+        // the caller's AbortController fires. This mirrors real fetch() semantics:
+        // when the signal aborts, the pending fetch rejects with an AbortError.
+        return new Promise((_resolve, reject) => {
+          // Safety-net teardown: if the caller never aborts (e.g. under a
+          // regression where the AbortController timeout is disabled), let the
+          // Promise reject after a bounded window so the worker exits cleanly.
+          const teardown = setTimeout(() => {
+            reject(new Error('mock teardown — no abort fired'));
+          }, 10_000);
+          teardown.unref?.();
+          if (init?.signal) {
+            init.signal.addEventListener('abort', () => {
+              clearTimeout(teardown);
+              const err = new Error('aborted') as Error & { name: string };
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }
+        });
+      }
+      // POST: respond instantly with 200
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ latest_version: '99.99.99' }),
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    const start = Date.now();
+    sendTelemetryPing({
+      mode: 'production',
+      explicitMode: 'production',
+      endpoint: 'http://127.0.0.1:1', // would be unreachable in reality; mock swaps the behavior
+      telemetryEnabled: true,
+      debug: false,
+    });
+
+    // sendTelemetryPing returns void synchronously (fire-and-forget wrapper).
+    // To measure the total fetch-path duration we need to wait for the inner
+    // IIFE to finish. Poll until fetch has been called for both /health and
+    // the checkpoint POST, OR until an upper bound expires.
+    const upperBound = 4500; // clearly > 3.5s shared-fix expected, < 5s stacked-bug worst-case
+    const pollStart = Date.now();
+    while (Date.now() - pollStart < upperBound) {
+      const sawHealth = fetchMock.mock.calls.some(
+        (c) => typeof c[0] === 'string' && c[0].endsWith('/health'),
+      );
+      const sawPost = fetchMock.mock.calls.some(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[1]?.method === 'POST',
+      );
+      if (sawHealth && sawPost) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    const elapsed = Date.now() - start;
+
+    // The shared-deadline fix caps /health at 1s then proceeds. Under the
+    // stacked bug, /health consumed its own 2s timeout before proceeding,
+    // which would push elapsed toward 2000ms+. 1500ms is the discriminator.
+    expect(elapsed).toBeLessThan(1500);
+
+    // And the POST must have actually fired (not skipped due to budget exhaustion).
+    const sawPost = fetchMock.mock.calls.some(
+      (c) => typeof c[0] === 'string' && c[1]?.method === 'POST',
+    );
+    expect(sawPost).toBe(true);
+  });
+});

--- a/tests/telemetry-shared-deadline.test.ts
+++ b/tests/telemetry-shared-deadline.test.ts
@@ -51,36 +51,38 @@ describe('telemetry — shared deadline (regression for #1707)', () => {
     //   shared-deadline fix:   elapsed ~1000-1200ms
     //   stacked-timeout bug:   elapsed ~2000-2200ms
 
-    const fetchMock = jest.fn().mockImplementation((url: string, init?: { signal?: AbortSignal; method?: string }) => {
-      if (url.endsWith('/health')) {
-        // Simulate a slow /health by returning a Promise that only rejects when
-        // the caller's AbortController fires. This mirrors real fetch() semantics:
-        // when the signal aborts, the pending fetch rejects with an AbortError.
-        return new Promise((_resolve, reject) => {
-          // Safety-net teardown: if the caller never aborts (e.g. under a
-          // regression where the AbortController timeout is disabled), let the
-          // Promise reject after a bounded window so the worker exits cleanly.
-          const teardown = setTimeout(() => {
-            reject(new Error('mock teardown — no abort fired'));
-          }, 10_000);
-          teardown.unref?.();
-          if (init?.signal) {
-            init.signal.addEventListener('abort', () => {
-              clearTimeout(teardown);
-              const err = new Error('aborted') as Error & { name: string };
-              err.name = 'AbortError';
-              reject(err);
-            });
-          }
+    const fetchMock = jest
+      .fn()
+      .mockImplementation((url: string, init?: { signal?: AbortSignal; method?: string }) => {
+        if (url.endsWith('/health')) {
+          // Simulate a slow /health by returning a Promise that only rejects when
+          // the caller's AbortController fires. This mirrors real fetch() semantics:
+          // when the signal aborts, the pending fetch rejects with an AbortError.
+          return new Promise((_resolve, reject) => {
+            // Safety-net teardown: if the caller never aborts (e.g. under a
+            // regression where the AbortController timeout is disabled), let the
+            // Promise reject after a bounded window so the worker exits cleanly.
+            const teardown = setTimeout(() => {
+              reject(new Error('mock teardown — no abort fired'));
+            }, 10_000);
+            teardown.unref?.();
+            if (init?.signal) {
+              init.signal.addEventListener('abort', () => {
+                clearTimeout(teardown);
+                const err = new Error('aborted') as Error & { name: string };
+                err.name = 'AbortError';
+                reject(err);
+              });
+            }
+          });
+        }
+        // POST: respond instantly with 200
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ latest_version: '99.99.99' }),
         });
-      }
-      // POST: respond instantly with 200
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ latest_version: '99.99.99' }),
       });
-    });
     global.fetch = fetchMock as unknown as typeof global.fetch;
 
     const start = Date.now();
@@ -100,15 +102,13 @@ describe('telemetry — shared deadline (regression for #1707)', () => {
     const pollStart = Date.now();
     while (Date.now() - pollStart < upperBound) {
       const sawHealth = fetchMock.mock.calls.some(
-        (c) => typeof c[0] === 'string' && c[0].endsWith('/health'),
+        c => typeof c[0] === 'string' && c[0].endsWith('/health')
       );
       const sawPost = fetchMock.mock.calls.some(
-        (c) =>
-          typeof c[0] === 'string' &&
-          c[1]?.method === 'POST',
+        c => typeof c[0] === 'string' && c[1]?.method === 'POST'
       );
       if (sawHealth && sawPost) break;
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise(r => setTimeout(r, 50));
     }
     const elapsed = Date.now() - start;
 
@@ -119,7 +119,7 @@ describe('telemetry — shared deadline (regression for #1707)', () => {
 
     // And the POST must have actually fired (not skipped due to budget exhaustion).
     const sawPost = fetchMock.mock.calls.some(
-      (c) => typeof c[0] === 'string' && c[1]?.method === 'POST',
+      c => typeof c[0] === 'string' && c[1]?.method === 'POST'
     );
     expect(sawPost).toBe(true);
   });


### PR DESCRIPTION
Closes getaxonflow/axonflow-enterprise#1707

## Summary

TypeScript SDK's telemetry had the same stacked-timeout bug already fixed in the other three SDKs (python v6.6.1, go v5.6.1, java PR #136 merged pending release): \`detectPlatformVersion\` had its own 2000ms AbortController timeout and the checkpoint POST had its own TELEMETRY_TIMEOUT_MS=3000ms AbortController timeout, executed sequentially without a shared deadline. On an unreachable endpoint total blocking time was ~5s, defeating the \"3-second timeout prevents blocking\" claim in the inline docstring.

Not a user-visible delivery drop — Node's event loop refcounts pending fetches, so short-lived processes don't lose the ping. **TypeScript remains the control group for delivery-on-exit.** But the documented bound was false and TS was the last SDK without shared-deadline hardening.

## Fix

- Compute \`deadline = Date.now() + TELEMETRY_TIMEOUT_MS\` once before both HTTP calls inside the inner async IIFE.
- Pass a \`timeoutMs\` parameter to \`detectPlatformVersion\`, derived from remaining budget and capped at \`HEALTH_BUDGET_CAP_MS\` (1000ms) so the POST always has ≥2s of headroom even when /health fully consumes its slice.
- POST uses \`max(0, deadline - Date.now())\` as its AbortController timeout; skips the call if remaining budget is below \`MIN_BUDGET_MS\` (100ms) to avoid essentially-zero-budget requests.

## Regression test

\`tests/telemetry-shared-deadline.test.ts\` mocks fetch so /health returns a Promise that only rejects on AbortController abort (matching real fetch semantics) and POST responds instantly. Asserts total elapsed <1500ms — discriminator between the fix path (~1000ms) and the stacked-bug path (~2000ms). Verified:

- **FAIL at 2056ms** when reverted to stacked timeouts
- **PASS at 1029ms** with the shared-deadline fix

## Test plan

- [x] Regression test **FAIL under revert, PASS with fix**
- [x] Full test suite: **859 passed, 13 skipped, 0 failures**
- [x] TypeScript build clean
- [x] \`detectPlatformVersion\` is file-private so the signature change is internal-only; no public API change

## Post-merge

Bundle into the next TS SDK release. CHANGELOG \`[Unreleased]\` is terse per the minimal-telemetry-changelog convention.