### PR TITLE
feat!(types): resolve PolicyInfo / MCPPolicyInfo naming collision (v6.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING — `PolicyInfo` reassignment (v6.0.0)
+
+`PolicyInfo` and `MCPPolicyInfo` referred to two different concepts in v5.x:
+
+- `PolicyInfo` (in `src/types/proxy.ts`) was the proxy-mode shape returned by `/api/request` — fields like `policiesEvaluated`, `staticChecks`, `processingTime`, `tenantId`, `codeArtifact`.
+- `MCPPolicyInfo` (in `src/types/connector.ts`) was the MCP shape returned by `/api/v1/mcp/check-input` and friends — fields like `policies_evaluated`, `blocked`, `block_reason`, `processing_time_ms`, `matched_policies`. **This is what the OpenAPI spec calls `PolicyInfo`.**
+
+The naming has been swapped to align with the OpenAPI spec:
+
+| In v5.x | In v6.0.0 |
+|--|--|
+| `PolicyInfo` (proxy shape) | **`ProxyPolicyInfo`** (renamed) |
+| `MCPPolicyInfo` (MCP shape) | **`PolicyInfo`** (renamed; matches OpenAPI spec) |
+
+Migration:
+
+- If you imported `PolicyInfo` to read proxy-mode `/api/request` responses, change to `ProxyPolicyInfo` (or use the `PolicyInfoLegacyProxyShape` type alias as a one-major-version shim).
+- If you imported `MCPPolicyInfo` for MCP responses, change to `PolicyInfo`. The `MCPPolicyInfo` name is kept as a `type` alias for one major-version migration window and will be removed in v7.0.0.
+
+This was previously hidden by the naming collision — code reading `response.policyInfo` on `ExecuteQueryResponse` continues to work because the property type is now `ProxyPolicyInfo` with the same fields. The break only affects code that imported the type names by hand.
+
 ### Added
 
 - **`WebhookSubscription.secret`** — HMAC-SHA256 signing key now exposed on the response from `createWebhook`. Required to verify the `X-AxonFlow-Signature` header on inbound webhook deliveries; without it, callers couldn't validate payload authenticity. Also adds `org_id` and `tenant_id` (ownership scoping).

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,11 @@ export type {
   DynamicPolicyInfo,
   DynamicPolicyMatch,
   ConnectorHealthStatus,
+  // v6.0.0: `PolicyInfo` exported from connector.ts is the OpenAPI
+  // `PolicyInfo` (MCP shape). The proxy-mode shape is `ProxyPolicyInfo`
+  // (exported below). `MCPPolicyInfo` kept as a type alias for one
+  // major-version migration window.
+  PolicyInfo,
   MCPPolicyInfo,
   ExfiltrationCheckInfo,
   MCPCheckInputOptions,
@@ -121,7 +126,12 @@ export type {
   CircuitBreakerConfigUpdate,
   // Proxy Mode types
   RequestType,
-  PolicyInfo,
+  // v6.0.0: this is the proxy-mode shape, renamed from `PolicyInfo`.
+  // The OpenAPI `PolicyInfo` (MCP shape) is now exported from the
+  // connector group above; `PolicyInfoLegacyProxyShape` is a kept-
+  // for-back-compat alias of `ProxyPolicyInfo` removed in v7.
+  ProxyPolicyInfo,
+  PolicyInfoLegacyProxyShape,
   CodeArtifact,
   HealthStatus,
   PlatformCapability,

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -38,9 +38,15 @@ export interface PolicyMatchInfo {
 
 /**
  * Policy evaluation information included in MCP responses
- * Provides transparency into policy enforcement decisions
+ * (canonical OpenAPI `PolicyInfo` schema). Provides transparency
+ * into policy enforcement decisions returned by `/api/v1/mcp/*`
+ * endpoints.
+ *
+ * Renamed from `MCPPolicyInfo` in v6.0.0 to match the OpenAPI
+ * spec name. The previous proxy-mode `PolicyInfo` (in `proxy.ts`)
+ * is now `ProxyPolicyInfo` so the names align with the spec.
  */
-export interface MCPPolicyInfo {
+export interface PolicyInfo {
   policies_evaluated: number;
   blocked: boolean;
   block_reason?: string;
@@ -52,6 +58,14 @@ export interface MCPPolicyInfo {
   /** Dynamic policy evaluation results (Issue #968) */
   dynamic_policy_info?: DynamicPolicyInfo;
 }
+
+/**
+ * @deprecated Renamed to `PolicyInfo` in v6.0.0 to match the OpenAPI
+ * spec. The previous SDK `PolicyInfo` (proxy-mode shape) is now
+ * `ProxyPolicyInfo`. This alias keeps existing code compiling for
+ * one major version. Removed in v7.0.0.
+ */
+export type MCPPolicyInfo = PolicyInfo;
 
 /**
  * Information about exfiltration limit checks (Issue #966)

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -55,9 +55,16 @@ export interface CodeArtifact {
 }
 
 /**
- * Policy evaluation information from the agent
+ * Proxy-mode policy evaluation summary returned by `/api/request`.
+ *
+ * Renamed from `PolicyInfo` in v6.0.0 — the original name collided
+ * with the OpenAPI `PolicyInfo` schema served by the MCP path
+ * (`/api/v1/mcp/check-input` etc.), which the SDK exposes as
+ * `MCPPolicyInfo`. This type is the proxy-mode shape; the v6
+ * top-level `PolicyInfo` export now refers to the MCP shape (matching
+ * the OpenAPI spec).
  */
-export interface PolicyInfo {
+export interface ProxyPolicyInfo {
   /** List of policies that were evaluated */
   policiesEvaluated: string[];
   /** Static checks that were applied */
@@ -69,6 +76,18 @@ export interface PolicyInfo {
   /** Code artifact metadata if code was detected in the response */
   codeArtifact?: CodeArtifact;
 }
+
+/**
+ * @deprecated Renamed to `ProxyPolicyInfo` in v6.0.0 to resolve a
+ * name collision with the OpenAPI `PolicyInfo` schema (the MCP
+ * shape). For new code, use `ProxyPolicyInfo` from `@axonflow/sdk`
+ * for the proxy-mode shape, or `PolicyInfo` for the MCP shape (the
+ * latter is what was previously exported as `MCPPolicyInfo`).
+ *
+ * This alias keeps existing code compiling for one major version.
+ * Removed in v7.0.0.
+ */
+export type PolicyInfoLegacyProxyShape = ProxyPolicyInfo;
 
 /**
  * Budget enforcement status information (Issue #1082).
@@ -116,8 +135,8 @@ export interface ExecuteQueryResponse {
   blocked: boolean;
   /** Reason for blocking (if blocked) */
   blockReason?: string;
-  /** Policy evaluation info */
-  policyInfo?: PolicyInfo;
+  /** Policy evaluation info (proxy-mode shape) */
+  policyInfo?: ProxyPolicyInfo;
   /** Budget status (Issue #1082) */
   budgetInfo?: BudgetInfo;
   /** Media analysis results (present when media was submitted) */


### PR DESCRIPTION
## Summary

**v6.0.0 prep PR.** Resolves the only genuinely-breaking change surfaced by the wire-shape contract gate audit: the \`PolicyInfo\` / \`MCPPolicyInfo\` naming collision.

This is the second of two PRs from the wire-shape audit:
- #185 — additive sweep (Cat B + RENAME_SAFE + UNRECOVERABLE), no version bump
- **#NEW (this)** — v6.0.0 breaking rename, resolves the collision

## Background

The TS SDK had two unrelated types using overlapping names:

- \`PolicyInfo\` (in \`src/types/proxy.ts\`): the proxy-mode shape returned by \`/api/request\` — fields like \`policiesEvaluated\`, \`staticChecks\`, \`processingTime\`, \`tenantId\`, \`codeArtifact\`.
- \`MCPPolicyInfo\` (in \`src/types/connector.ts\`): the MCP shape returned by \`/api/v1/mcp/*\` endpoints — fields like \`policies_evaluated\`, \`blocked\`, \`block_reason\`, \`processing_time_ms\`, \`matched_policies\`. **This is what the OpenAPI spec calls \`PolicyInfo\`.**

The two types refer to genuinely different concepts; the names just collided historically. The wire-shape gate could never resolve spec \`PolicyInfo\` to the right SDK type, because the spec name and the SDK name pointed at different shapes.

## Change

Swap the names to align with the OpenAPI spec:

| In v5.x | In v6.0.0 |
|--|--|
| \`PolicyInfo\` (proxy shape) | **\`ProxyPolicyInfo\`** |
| \`MCPPolicyInfo\` (MCP shape) | **\`PolicyInfo\`** (matches OpenAPI) |

## Migration

Code using the proxy-mode shape via the property \`response.policyInfo\` on \`ExecuteQueryResponse\` continues to compile — the property type changed from \`PolicyInfo\` to \`ProxyPolicyInfo\`, but the field shape is identical.

Code that explicitly imports the type names by hand needs one of:

- \`s/MCPPolicyInfo/PolicyInfo/\` for MCP-handling code, OR keep the \`MCPPolicyInfo\` alias (kept for one major)
- \`s/PolicyInfo/ProxyPolicyInfo/\` for proxy-mode code, OR temporarily use \`PolicyInfoLegacyProxyShape\` (kept for one major)

Both legacy aliases are removed in v7.0.0.

## Verification

- Build: ✅ \`tsc\` passes (both CJS and ESM targets)
- Tests: ✅ 859 pass
- Lint: ✅ clean
- Wire-shape gate: when this lands, the spec \`PolicyInfo\` schema resolves cleanly against TS \`PolicyInfo\` (the renamed MCPPolicyInfo) — drift entry for \`PolicyInfo\` disappears

## Why a separate PR from #185

#185 is a pure additive sweep — every entry is opt-in (new optional fields) or marked \`@deprecated\` (compile-time compatible). It's safe to ship without a major version bump.

This PR is the only genuinely breaking change from the audit. Putting it in its own PR makes the v6.0.0 manifest reviewable on its own and keeps #185's diff focused on additions.

## Out of scope

- Version bump in package.json — held until release time per current release procedure.
- Tag / publish — held until release time.

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Lint clean
- [x] CHANGELOG \`[Unreleased]\` declares the breaking change with migration instructions
- [ ] CI on this PR is green