### PR TITLE
docs(contrib): baseline burndown policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,22 @@ npm run build
 5. Address review feedback
 6. Squash commits before merging (if requested)
 
+## Baseline burndown policy
+
+Several CI gates use a baseline file to grandfather pre-existing findings — the gate fails on any *new* finding but tolerates the listed ones. Baselines exist to land the gate without a giant cleanup PR; they are not intended to be permanent.
+
+When your PR touches a baselined area (e.g. a method listed in `.lint_baselines/transformer_coverage.json`, or a type in `tests/fixtures/wire-shape-baseline.json`), do one of:
+
+- **Burn it down.** Fix the baselined finding in this PR, remove the entry from the baseline file, and note "burndown: `<entry>`" in the PR description.
+- **Justify it.** If the finding can't be fixed in this PR (different scope, blocked on a platform change, etc.), say so in the PR description in one line.
+
+Baseline files in this repo:
+
+- `.lint_baselines/transformer_coverage.json` — TS AST gate (type-vs-implementation)
+- `tests/fixtures/wire-shape-baseline.json` — wire-shape contract gate
+
+CI does not block PRs that touch a baselined area without addressing it, but reviewers will ask the burndown-or-justify question.
+
 ## Testing
 
 - Write unit tests for all new code


### PR DESCRIPTION
## Summary

Adds a baseline burndown policy section to CONTRIBUTING.md so reviewers and contributors share an expectation about what to do when a PR touches a baselined area.

The wire-shape contract gate (and the new transformer-coverage / falsey-clobber gates where applicable) accept a baseline file of grandfathered findings. Without a written policy, baselined entries linger indefinitely; with one, every PR that touches a baselined area either burns the entry down or explicitly justifies why it can't.

Doc-only change. No code.

## Test plan

- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] Wording matches the gate file paths in this repo