### PR TITLE
feat(client): add listProviders() — closes provider-listing parity gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`client.listProviders(options?)`** — list configured LLM providers and their per-provider health snapshot. Calls `GET /api/v1/llm-providers`. New `LLMProvider`, `LLMProviderHealth`, and `ListProvidersOptions` types in `@axonflow/sdk`. Supports `type` and `enabled` filters. Closes the parity gap with the Java SDK's `listLLMProviders()` and the Python SDK's `list_providers()`.
+
 ## [6.1.0] - 2026-04-25 — Plugin Batch 1 explainability fields on MCP responses
 
 Minor release. Surfaces fields the AxonFlow agent has emitted since v7.1.0 (Plugin Batch 1) but the SDK didn't declare. Pure field-additions on existing methods — no new SDK methods, no breaking changes. Documented in OpenAPI via platform v7.4.3.

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,8 @@ import {
   ConnectorInstallRequest,
   ConnectorResponse,
   ConnectorHealthStatus,
+  LLMProvider,
+  ListProvidersOptions,
   MCPCheckInputOptions,
   MCPCheckInputResponse,
   MCPCheckOutputOptions,
@@ -985,6 +987,50 @@ export class AxonFlow {
     }
 
     return connectors;
+  }
+
+  /**
+   * List configured LLM providers and their per-provider health status.
+   *
+   * Calls `GET /api/v1/llm-providers`. Mirrors the Java SDK's
+   * `listLLMProviders()`, the Python SDK's `list_providers()`, and the Go
+   * SDK's `ListProviders()`.
+   *
+   * @param options - Optional filters: `type` and/or `enabled`.
+   * @returns Array of LLMProvider records, each with optional health snapshot.
+   *
+   * @example
+   * ```typescript
+   * const providers = await client.listProviders();
+   * providers.forEach(p =>
+   *   console.log(`${p.name} (${p.type}) — ${p.health?.status ?? "?"}`)
+   * );
+   * ```
+   */
+  async listProviders(options?: ListProvidersOptions): Promise<LLMProvider[]> {
+    const queryParts: string[] = [];
+    if (options?.type !== undefined) {
+      queryParts.push(`type=${encodeURIComponent(options.type)}`);
+    }
+    if (options?.enabled !== undefined) {
+      queryParts.push(`enabled=${options.enabled ? 'true' : 'false'}`);
+    }
+    const path = queryParts.length
+      ? `/api/v1/llm-providers?${queryParts.join('&')}`
+      : '/api/v1/llm-providers';
+
+    const response = await this.orchestratorRequest<{ providers?: LLMProvider[] }>(
+      'GET',
+      path
+    );
+
+    const providers = Array.isArray(response) ? response : (response.providers ?? []);
+
+    if (this.config.debug) {
+      debugLog('Listed LLM providers', { count: providers.length });
+    }
+
+    return providers;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1019,10 +1019,7 @@ export class AxonFlow {
       ? `/api/v1/llm-providers?${queryParts.join('&')}`
       : '/api/v1/llm-providers';
 
-    const response = await this.orchestratorRequest<{ providers?: LLMProvider[] }>(
-      'GET',
-      path
-    );
+    const response = await this.orchestratorRequest<{ providers?: LLMProvider[] }>('GET', path);
 
     const providers = Array.isArray(response) ? response : (response.providers ?? []);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,3 +17,4 @@ export * from './hitl';
 export * from './media';
 export * from './simulation';
 export * from './decisions';
+export * from './llm-providers';

--- a/src/types/llm-providers.ts
+++ b/src/types/llm-providers.ts
@@ -1,0 +1,35 @@
+/**
+ * Types for the platform's LLM provider listing endpoint
+ * (`GET /api/v1/llm-providers`).
+ *
+ * Mirrors `LLMProvider` / `LLMProviderHealth` in the Python and Go SDKs.
+ */
+
+/** Health snapshot for a registered LLM provider. */
+export interface LLMProviderHealth {
+  status: string;
+  message?: string;
+  last_checked?: string;
+}
+
+/** A configured LLM provider returned by `client.listProviders()`. */
+export interface LLMProvider {
+  name: string;
+  type: string;
+  enabled: boolean;
+  priority?: number;
+  weight?: number;
+  has_api_key: boolean;
+  health?: LLMProviderHealth;
+}
+
+/**
+ * Optional filters for `client.listProviders()`. Both fields are optional;
+ * leaving them undefined returns every configured provider.
+ */
+export interface ListProvidersOptions {
+  /** Filter by provider type (e.g. `"openai"`, `"anthropic"`). */
+  type?: string;
+  /** Filter by the provider's enabled flag. */
+  enabled?: boolean;
+}

--- a/tests/list-providers.test.ts
+++ b/tests/list-providers.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for client.listProviders().
+ *
+ * Pins the wire-shape contract for `GET /api/v1/llm-providers` and
+ * confirms the optional `type` and `enabled` filters get passed through
+ * as query strings. Closes the parity gap with the Java/Python/Go SDKs.
+ */
+
+import { AxonFlow } from '../src/client';
+import type { LLMProvider } from '../src/types/llm-providers';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('listProviders()', () => {
+  let client: AxonFlow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+  });
+
+  const mockOk = (data: unknown) =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    });
+
+  it('returns typed providers with health snapshot', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockOk({
+        providers: [
+          {
+            name: 'anthropic',
+            type: 'anthropic',
+            enabled: true,
+            priority: 0,
+            weight: 0,
+            has_api_key: true,
+            health: {
+              status: 'healthy',
+              message: 'provider is operational',
+              last_checked: '2026-04-28T08:45:12Z',
+            },
+          },
+          {
+            name: 'openai',
+            type: 'openai',
+            enabled: true,
+            has_api_key: true,
+            health: { status: 'unhealthy', message: 'billing exceeded' },
+          },
+        ],
+      })
+    );
+
+    const providers = await client.listProviders();
+    expect(providers).toHaveLength(2);
+    expect(providers[0].name).toBe('anthropic');
+    expect(providers[0].health?.status).toBe('healthy');
+    expect(providers[1].health?.status).toBe('unhealthy');
+  });
+
+  it('passes type filter as query string', async () => {
+    mockFetch.mockReturnValueOnce(mockOk({ providers: [] }));
+    await client.listProviders({ type: 'anthropic' });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/llm-providers?type=anthropic');
+  });
+
+  it('passes enabled=false filter as query string', async () => {
+    mockFetch.mockReturnValueOnce(mockOk({ providers: [] }));
+    await client.listProviders({ enabled: false });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('enabled=false');
+  });
+
+  it('combines multiple filters with &', async () => {
+    mockFetch.mockReturnValueOnce(mockOk({ providers: [] }));
+    await client.listProviders({ type: 'openai', enabled: true });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('type=openai');
+    expect(url).toContain('enabled=true');
+    expect(url).toContain('?');
+    expect(url).toContain('&');
+  });
+
+  it('returns empty array when server returns no providers', async () => {
+    mockFetch.mockReturnValueOnce(mockOk({ providers: [] }));
+    const providers = await client.listProviders();
+    expect(providers).toEqual([]);
+  });
+
+  it('handles provider response missing health field', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockOk({
+        providers: [{ name: 'ollama', type: 'ollama', enabled: true, has_api_key: false }],
+      })
+    );
+    const providers: LLMProvider[] = await client.listProviders();
+    expect(providers).toHaveLength(1);
+    expect(providers[0].health).toBeUndefined();
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: () => Promise.resolve({ error: 'forbidden' }),
+        text: () => Promise.resolve('forbidden'),
+      })
+    );
+    await expect(client.listProviders()).rejects.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`client.listProviders(options?)\` to the TypeScript SDK, closing the parity gap with the Java SDK's \`listLLMProviders()\`, the Python SDK's \`list_providers()\`, and the Go SDK's \`ListProviders()\`. Caught by the Phase 1 quality-freeze sweep.

## What changed

- New types in \`src/types/llm-providers.ts\`: \`LLMProvider\`, \`LLMProviderHealth\`, \`ListProvidersOptions\`
- Re-exported from \`src/types/index.ts\`
- New method \`async listProviders(options?)\` on the \`AxonFlow\` client
- 7 regression tests in \`tests/list-providers.test.ts\` covering: dict shape with health, type filter as query, enabled-false filter, multi-filter combination, empty list, missing-health field, HTTP error

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest tests/list-providers.test.ts\` — 7/7 pass