### PR TITLE
ci: port integration tests to community-stack pattern + fix example drift

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,56 +1,29 @@
 name: Integration Tests
 
 on:
-  # Manual trigger only - requires Agent Docker image to be published
-  # Enable pull_request trigger when ghcr.io/getaxonflow/agent is available
-  workflow_dispatch:
-    inputs:
-      agent_image:
-        description: 'Agent Docker image tag'
-        required: false
-        default: 'latest'
-      debug:
-        description: 'Enable debug logging'
-        required: false
-        default: 'false'
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+  # Weekly drift catch
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 06:00 UTC
 
 permissions:
   contents: read
 
 env:
   DO_NOT_TRACK: '1'
-  AXONFLOW_AGENT_URL: http://localhost:8080
-  AXONFLOW_CLIENT_ID: integration-test-client
-  AXONFLOW_CLIENT_SECRET: integration-test-secret
 
 jobs:
-  integration-tests:
-    name: Integration Tests
+  # Contract tests run on every PR and push. No network, no stack.
+  contract-tests:
+    name: Contract Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    services:
-      # AxonFlow Agent service
-      agent:
-        image: ghcr.io/getaxonflow/agent:${{ github.event.inputs.agent_image || 'latest' }}
-        env:
-          SELF_HOSTED_MODE: 'true'
-          LOG_LEVEL: ${{ github.event.inputs.debug == 'true' && 'debug' || 'info' }}
-          ENABLE_PII_DETECTION: 'true'
-          ENABLE_SQL_INJECTION_DETECTION: 'true'
-          DEFAULT_TENANT: integration-test-client
-        ports:
-          - 8080:8080
-        options: >-
-          --health-cmd "curl -f http://localhost:8080/health || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --health-start-period 30s
-
+    timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -61,60 +34,43 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Wait for Agent to be healthy
-        run: |
-          echo "Waiting for Agent to be ready..."
-          HEALTHY=false
-          for i in {1..30}; do
-            if curl -s http://localhost:8080/health | grep -q "ok"; then
-              echo "Agent is healthy!"
-              HEALTHY=true
-              break
-            fi
-            echo "Attempt $i/30: Agent not ready yet..."
-            sleep 2
-          done
-          if [ "$HEALTHY" != "true" ]; then
-            echo "ERROR: Agent failed to become healthy within 60 seconds"
-            exit 1
-          fi
+      - name: Run contract tests
+        run: npm run test:contract
 
-      - name: Run integration tests
-        env:
-          RUN_INTEGRATION_TESTS: '1'
-          AXONFLOW_DEBUG: ${{ github.event.inputs.debug || 'false' }}
-        run: npm run test:integration
-
-      - name: Collect Agent logs on failure
-        if: failure()
-        run: |
-          echo "=== Agent Container Logs ==="
-          docker logs $(docker ps -q --filter "ancestor=ghcr.io/getaxonflow/agent") 2>&1 || echo "No logs available"
-
-  # Smoke test with example applications
-  example-smoke-test:
-    name: Example App Smoke Test
+  # Example type-check on every PR and push. Catches API drift at PR time
+  # without needing a live stack. Mirrors Python SDK demo-scripts job.
+  example-typecheck:
+    name: Example Type-Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: integration-tests
-
-    services:
-      agent:
-        image: ghcr.io/getaxonflow/agent:${{ github.event.inputs.agent_image || 'latest' }}
-        env:
-          SELF_HOSTED_MODE: 'true'
-          LOG_LEVEL: info
-        ports:
-          - 8080:8080
-        options: >-
-          --health-cmd "curl -f http://localhost:8080/health || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --health-start-period 30s
-
+    needs: contract-tests
     steps:
-      - name: Checkout
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check examples against local source
+        run: npx tsc -p tsconfig.examples.json
+
+  # Integration tests run against a live community stack via docker compose.
+  # Runs on main merges, scheduled, and manual dispatch. Skipped on PRs to keep
+  # latency reasonable — PR-level live coverage is added in QF-13.
+  # Mirrors axonflow-sdk-go/.github/workflows/integration.yml.
+  integration:
+    name: Integration Tests (Community Stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [contract-tests, example-typecheck]
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout SDK
         uses: actions/checkout@v4
 
       - name: Setup Node.js
@@ -129,39 +85,58 @@ jobs:
       - name: Build SDK
         run: npm run build
 
-      - name: Wait for Agent
-        run: |
-          echo "Waiting for Agent to be ready..."
-          HEALTHY=false
-          for i in {1..30}; do
-            if curl -s http://localhost:8080/health | grep -q "ok"; then
-              echo "Agent is healthy!"
-              HEALTHY=true
-              break
-            fi
-            echo "Attempt $i/30: Agent not ready yet..."
-            sleep 2
-          done
-          if [ "$HEALTHY" != "true" ]; then
-            echo "ERROR: Agent failed to become healthy within 60 seconds"
-            exit 1
-          fi
+      - name: Clone community stack
+        run: git clone --depth 1 https://github.com/getaxonflow/axonflow.git ../axonflow
 
-      - name: Run basic example
-        working-directory: examples
+      - name: Start community stack
+        run: |
+          cd ../axonflow
+          docker compose up -d
+
+          echo "Waiting for agent to be healthy..."
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 2; done'
+          echo "Agent is healthy"
+
+          echo "Waiting for orchestrator to be healthy..."
+          timeout 60 bash -c 'until curl -sf http://localhost:8081/health; do sleep 2; done'
+          echo "Orchestrator is healthy"
+
+      - name: Run integration tests
         env:
-          AXONFLOW_ENDPOINT: http://localhost:8080
+          RUN_INTEGRATION_TESTS: '1'
+          AXONFLOW_AGENT_URL: http://localhost:8080
+          AXONFLOW_CLIENT_ID: demo-client
+          AXONFLOW_CLIENT_SECRET: demo-secret
+        run: npm run test:integration
+
+      - name: Run basic example against live stack
+        env:
+          AXONFLOW_AGENT_URL: http://localhost:8080
+          AXONFLOW_CLIENT_ID: demo-client
+          AXONFLOW_CLIENT_SECRET: demo-secret
         run: |
-          # Install example dependencies
-          if [ -f "package.json" ]; then
-            npm install
+          set -e
+          mkdir -p /tmp/sdk-tarball /tmp/example-runner
+          npm pack --pack-destination /tmp/sdk-tarball
+          cp examples/basic/index.ts /tmp/example-runner/
+          cd /tmp/example-runner
+          TARBALL=$(ls /tmp/sdk-tarball/*.tgz | head -1)
+          npm init -y >/dev/null
+          npm install "$TARBALL" tsx@4 typescript@5 @types/node@20
+          timeout 30 npx tsx index.ts
+
+      - name: Stop community stack
+        if: always()
+        run: |
+          if [ -d "../axonflow" ]; then
+            cd ../axonflow
+            docker compose down --volumes --remove-orphans || true
           fi
 
-          # Run basic example if it exists
-          if [ -f "basic.ts" ]; then
-            npx ts-node basic.ts || echo "Example completed (may have expected errors)"
-          elif [ -f "basic.js" ]; then
-            node basic.js || echo "Example completed (may have expected errors)"
-          else
-            echo "No basic example found, skipping"
+      - name: Show docker logs on failure
+        if: failure()
+        run: |
+          if [ -d "../axonflow" ]; then
+            cd ../axonflow
+            docker compose logs --tail=200 || true
           fi

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ Set environment variables:
 ```bash
 export AXONFLOW_API_KEY="AXON-PLUS-yourorg-20351025-signature"  # Your license key
 export AXONFLOW_TENANT="your-tenant-id"
-export AXONFLOW_AGENT_URL="https://staging-eu.getaxonflow.com"  # Optional
+export AXONFLOW_AGENT_URL="http://localhost:8080"  # Optional (default for local docker-compose)
 ```
 
 **Note**: `AXONFLOW_API_KEY` should be your AxonFlow license key in the format `AXON-{TIER}-{ORG}-{EXPIRY}-{SIGNATURE}`
@@ -91,7 +91,7 @@ node index.js
 |----------|----------|-------------|
 | `AXONFLOW_API_KEY` | Yes | Your AxonFlow license key (format: AXON-{TIER}-{ORG}-{EXPIRY}-{SIG}) |
 | `AXONFLOW_TENANT` | Yes | Your tenant identifier |
-| `AXONFLOW_AGENT_URL` | No | Custom endpoint (default: staging) |
+| `AXONFLOW_AGENT_URL` | No | Custom endpoint (default: `http://localhost:8080` for local docker-compose) |
 | `AMADEUS_API_KEY` | No | For connector examples |
 | `AMADEUS_API_SECRET` | No | For connector examples |
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -12,7 +12,7 @@ import { AxonFlow } from '@axonflow/sdk';
 
 async function main() {
   // Load configuration from environment variables
-  const agentURL = process.env.AXONFLOW_AGENT_URL || 'https://staging-eu.getaxonflow.com';
+  const agentURL = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
   const clientId = process.env.AXONFLOW_CLIENT_ID;
   const clientSecret = process.env.AXONFLOW_CLIENT_SECRET;
 

--- a/examples/connectors/index.ts
+++ b/examples/connectors/index.ts
@@ -44,8 +44,9 @@ async function main() {
   if (amadeusKey && amadeusSecret) {
     try {
       await client.installConnector({
-        connectorId: 'amadeus-travel',
+        connector_id: 'amadeus-travel',
         name: 'amadeus-prod',
+        tenant_id: clientId,
         options: { environment: 'production' },
         credentials: { api_key: amadeusKey, api_secret: amadeusSecret },
       });

--- a/examples/planning/index.ts
+++ b/examples/planning/index.ts
@@ -42,8 +42,8 @@ async function main() {
       console.log(`   Type: ${step.type}`);
       console.log(`   Agent: ${step.agent}`);
       console.log(`   Description: ${step.description}`);
-      if (step.dependencies?.length) {
-        console.log(`   Dependencies: ${step.dependencies.join(', ')}`);
+      if (step.dependsOn?.length) {
+        console.log(`   Dependencies: ${step.dependsOn.join(', ')}`);
       }
     });
 

--- a/examples/proxy-mode/index.ts
+++ b/examples/proxy-mode/index.ts
@@ -1,21 +1,21 @@
 /**
  * Proxy Mode Example
  *
- * Demonstrates using AxonFlow's Proxy Mode (executeQuery) for policy enforcement.
+ * Demonstrates using AxonFlow's Proxy Mode (proxyLLMCall) for policy enforcement.
  * Proxy Mode routes all requests through AxonFlow, which handles policy checking
  * and optionally routes to LLM providers.
  *
  * Run: npx ts-node examples/proxy-mode/index.ts
  */
 
-import { AxonFlow, ExecuteQueryOptions, PolicyViolationError } from '../../src';
+import { AxonFlow, PolicyViolationError } from '../../src';
 
 async function main() {
   // Initialize client
   const axonflow = new AxonFlow({
     clientId: process.env.AXONFLOW_CLIENT_ID || 'demo-client',
     clientSecret: process.env.AXONFLOW_CLIENT_SECRET || 'demo-secret',
-    endpoint: process.env.AXONFLOW_AGENT_URL || 'https://staging-eu.getaxonflow.com',
+    endpoint: process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080',
     debug: true,
   });
 
@@ -34,7 +34,7 @@ async function main() {
   console.log('\n2. Basic Chat Query');
   console.log('-'.repeat(40));
   try {
-    const chatResult = await axonflow.executeQuery({
+    const chatResult = await axonflow.proxyLLMCall({
       userToken: 'user-123',
       query: 'What is the capital of France?',
       requestType: 'chat',
@@ -52,7 +52,7 @@ async function main() {
   console.log('\n3. Query with Context (LLM Provider Info)');
   console.log('-'.repeat(40));
   try {
-    const contextResult = await axonflow.executeQuery({
+    const contextResult = await axonflow.proxyLLMCall({
       userToken: 'user-123',
       query: 'Explain quantum computing in simple terms',
       requestType: 'chat',
@@ -75,7 +75,7 @@ async function main() {
   console.log('\n4. PII Detection Test (should be blocked)');
   console.log('-'.repeat(40));
   try {
-    await axonflow.executeQuery({
+    await axonflow.proxyLLMCall({
       userToken: 'user-123',
       query: 'Process this SSN: 123-45-6789 and credit card: 4111-1111-1111-1111',
       requestType: 'chat',
@@ -95,7 +95,7 @@ async function main() {
   console.log('\n5. SQL Injection Test (should be blocked)');
   console.log('-'.repeat(40));
   try {
-    await axonflow.executeQuery({
+    await axonflow.proxyLLMCall({
       userToken: 'user-123',
       query: "SELECT * FROM users WHERE id = '1'; DROP TABLE users;--",
       requestType: 'sql',
@@ -114,7 +114,7 @@ async function main() {
   console.log('\n6. Safe SQL Query');
   console.log('-'.repeat(40));
   try {
-    const sqlResult = await axonflow.executeQuery({
+    const sqlResult = await axonflow.proxyLLMCall({
       userToken: 'user-123',
       query: 'SELECT name, email FROM customers WHERE status = active LIMIT 10',
       requestType: 'sql',
@@ -129,7 +129,7 @@ async function main() {
   console.log('\n7. MCP Connector Query');
   console.log('-'.repeat(40));
   try {
-    const mcpResult = await axonflow.executeQuery({
+    const mcpResult = await axonflow.proxyLLMCall({
       userToken: 'user-123',
       query: 'Get recent orders',
       requestType: 'mcp-query',

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "baseUrl": ".",
+    "paths": {
+      "@axonflow/sdk": ["./src/index.ts"]
+    }
+  },
+  "include": ["src/**/*", "examples/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

Closes the QF-12 (TS SDK) row in the Phase 1 quality-freeze epic
(`axonflow-business-docs/engineering/QUALITY_FREEZE_EPIC_2026-04-24.md`).

The previous `integration.yml` was `workflow_dispatch`-only, blocked on the
unpublished `ghcr.io/getaxonflow/agent` image. This PR replaces it with the
Go SDK pattern: clone the community repo, `docker compose up`, run
integration tests + basic example against the live stack.

**Ported from:** `axonflow-sdk-go/.github/workflows/integration.yml`
(the gold-standard template per the QF epic). Same job structure, same
trigger matrix, same env handling.

## What this PR does

### CI

- **`contract-tests`** (every PR + push, no stack): `npm run test:contract`
- **`example-typecheck`** (every PR + push, no stack): `tsc -p tsconfig.examples.json`
  type-checks every example against local SDK source so wire-shape drift fails
  at PR time. Mirrors Python SDK's `demo-scripts` job purpose.
- **`integration`** (push to main + schedule + workflow_dispatch; **skipped on PR**):
  clones community repo, brings up docker compose, runs `npm test:integration`
  + runs the basic example from a freshly-packed tarball (so the example
  exercises the published-shaped artifact, not the source tree).
- No `continue-on-error: true` anywhere.

### Example drift caught + fixed by the new typecheck

The new `tsconfig.examples.json` immediately surfaced four classes of drift
between examples and the actual SDK types/methods. Per the freeze policy
("no bug found gets postponed"), all are fixed in this PR:

- `examples/connectors/index.ts` — `connectorId` → `connector_id` (snake-case
  at the wire boundary), and added the missing required `tenant_id` field on
  `ConnectorInstallRequest`.
- `examples/planning/index.ts` — `step.dependencies` → `step.dependsOn`
  (correct `PlanStep` field name).
- `examples/proxy-mode/index.ts` — dropped `ExecuteQueryOptions` from the
  import (it's `@internal`, not in the public surface). Renamed
  `axonflow.executeQuery(...)` → `proxyLLMCall(...)` — the method was
  renamed; the `ExecuteQueryOptions` type is now kept only as the internal
  option-bag type for `proxyLLMCall`.
- `examples/basic/index.ts`, `examples/proxy-mode/index.ts`,
  `examples/README.md` — replaced decommissioned `staging-eu.getaxonflow.com`
  default endpoint with `http://localhost:8080` (the local docker-compose
  default; staging-eu was torn down 2026-04-09).

## Self-review checklist

- [x] Action versions pinned (`@v4`)
- [x] `permissions: contents: read` scoped tight
- [x] No new secret refs introduced
- [x] No `continue-on-error: true`
- [x] No path filters that could silently exclude future files
- [x] Contract + example-typecheck jobs run in <10 min (PR-blocking budget)
- [x] Integration timeout 20 min matches Go SDK
- [x] No version bump (`package.json` untouched per `feedback_no_per_pr_version_bumps.md`)
- [x] No AI attribution

## Test plan

- [x] `npm ci` clean
- [x] `npm run test:contract` — 58/58 pass
- [x] `npm run build` — clean (CJS + ESM + fix-esm-imports)
- [x] `npx tsc -p tsconfig.examples.json` — clean (was failing on 9 type errors before fixes)
- [x] Local E2E smoke: `npm pack` tarball → install in `/tmp/example-runner` → `npx tsx index.ts` against live local docker-compose at `http://localhost:8080` (v7.4.4, evaluation mode) — basic example runs to completion
- [ ] CI: contract-tests + example-typecheck green on PR
- [ ] CI: integration job green on push to main (post-merge)