### PR TITLE
fix(client): close review gaps on listProviders — full shape, pagination, URLSearchParams

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ import {
   ConnectorResponse,
   ConnectorHealthStatus,
   LLMProvider,
+  LLMProviderListResponse,
   ListProvidersOptions,
   MCPCheckInputOptions,
   MCPCheckInputResponse,
@@ -990,13 +991,17 @@ export class AxonFlow {
   }
 
   /**
-   * List configured LLM providers and their per-provider health status.
+   * List configured LLM providers from a SINGLE page of results.
    *
    * Calls `GET /api/v1/llm-providers`. Mirrors the Java SDK's
    * `listLLMProviders()`, the Python SDK's `list_providers()`, and the Go
    * SDK's `ListProviders()`.
    *
-   * @param options - Optional filters: `type` and/or `enabled`.
+   * For multi-page traversal use {@link listAllProviders}; for pagination
+   * metadata use {@link listProvidersPaged}.
+   *
+   * @param options - Optional filters and pagination: `type`, `enabled`,
+   *   `page`, `page_size`. Server defaults are page 1, page_size 20.
    * @returns Array of LLMProvider records, each with optional health snapshot.
    *
    * @example
@@ -1008,26 +1013,102 @@ export class AxonFlow {
    * ```
    */
   async listProviders(options?: ListProvidersOptions): Promise<LLMProvider[]> {
-    const queryParts: string[] = [];
+    const result = await this.listProvidersPaged(options);
+    return result.providers;
+  }
+
+  /**
+   * List one page of LLM providers along with the pagination metadata
+   * (page / page_size / total_items / total_pages) so callers can
+   * paginate manually.
+   *
+   * @param options - Optional filters and pagination controls.
+   * @returns LLMProviderListResponse with `providers` and `pagination`.
+   */
+  async listProvidersPaged(options?: ListProvidersOptions): Promise<LLMProviderListResponse> {
+    const params = new URLSearchParams();
     if (options?.type !== undefined) {
-      queryParts.push(`type=${encodeURIComponent(options.type)}`);
+      params.set('type', options.type);
     }
     if (options?.enabled !== undefined) {
-      queryParts.push(`enabled=${options.enabled ? 'true' : 'false'}`);
+      params.set('enabled', options.enabled ? 'true' : 'false');
     }
-    const path = queryParts.length
-      ? `/api/v1/llm-providers?${queryParts.join('&')}`
-      : '/api/v1/llm-providers';
+    if (options?.page !== undefined) {
+      params.set('page', String(options.page));
+    }
+    if (options?.page_size !== undefined) {
+      params.set('page_size', String(options.page_size));
+    }
+    const queryString = params.toString();
+    const path = queryString ? `/api/v1/llm-providers?${queryString}` : '/api/v1/llm-providers';
 
-    const response = await this.orchestratorRequest<{ providers?: LLMProvider[] }>('GET', path);
+    const response = await this.orchestratorRequest<LLMProviderListResponse | LLMProvider[]>(
+      'GET',
+      path
+    );
 
-    const providers = Array.isArray(response) ? response : (response.providers ?? []);
+    if (Array.isArray(response)) {
+      // Defensive fallback — older platforms may not have wrapped the
+      // response in {providers: [...], pagination: {...}}.
+      return {
+        providers: response,
+        pagination: {
+          page: 1,
+          page_size: response.length,
+          total_items: response.length,
+          total_pages: 1,
+        },
+      };
+    }
+
+    const providers = response.providers ?? [];
+    const pagination = response.pagination ?? {
+      page: 1,
+      page_size: providers.length,
+      total_items: providers.length,
+      total_pages: 1,
+    };
 
     if (this.config.debug) {
-      debugLog('Listed LLM providers', { count: providers.length });
+      debugLog('Listed LLM providers', {
+        count: providers.length,
+        page: pagination.page,
+        total_pages: pagination.total_pages,
+      });
     }
 
-    return providers;
+    return { providers, pagination };
+  }
+
+  /**
+   * Walk every page of LLM providers and return the combined list.
+   *
+   * Defaults to `page_size=100` (the server-side max) to minimise round
+   * trips. Per-page filters from `options.type` / `options.enabled` are
+   * honoured on every page; `options.page` / `options.page_size` are
+   * overridden by the walker.
+   *
+   * @param options - Optional `type` / `enabled` filters and `page_size`.
+   * @returns The full provider list across all pages.
+   */
+  async listAllProviders(options?: ListProvidersOptions): Promise<LLMProvider[]> {
+    const pageSize = options?.page_size ?? 100;
+    const all: LLMProvider[] = [];
+    let page = 1;
+    while (true) {
+      const result = await this.listProvidersPaged({
+        type: options?.type,
+        enabled: options?.enabled,
+        page,
+        page_size: pageSize,
+      });
+      all.push(...result.providers);
+      if (result.pagination.total_pages <= page || result.providers.length === 0) {
+        break;
+      }
+      page += 1;
+    }
+    return all;
   }
 
   /**

--- a/src/types/llm-providers.ts
+++ b/src/types/llm-providers.ts
@@ -12,7 +12,14 @@ export interface LLMProviderHealth {
   last_checked?: string;
 }
 
-/** A configured LLM provider returned by `client.listProviders()`. */
+/**
+ * A configured LLM provider returned by `client.listProviders()`.
+ *
+ * Mirrors the platform's `LLMProviderResource` schema. Optional fields
+ * are populated when the provider config has them set; `settings` is a
+ * free-form provider-specific record (e.g. Bedrock inference-profile id,
+ * Azure OpenAI deployment name).
+ */
 export interface LLMProvider {
   name: string;
   type: string;
@@ -21,15 +28,40 @@ export interface LLMProvider {
   weight?: number;
   has_api_key: boolean;
   health?: LLMProviderHealth;
+  endpoint?: string;
+  model?: string;
+  region?: string;
+  rate_limit?: number;
+  timeout_seconds?: number;
+  settings?: Record<string, unknown>;
 }
 
 /**
- * Optional filters for `client.listProviders()`. Both fields are optional;
- * leaving them undefined returns every configured provider.
+ * Optional filters and pagination controls for `client.listProviders()`.
+ * All fields are optional; leaving them undefined uses the server's
+ * defaults (page 1, page_size 20, no filtering).
  */
 export interface ListProvidersOptions {
   /** Filter by provider type (e.g. `"openai"`, `"anthropic"`). */
   type?: string;
   /** Filter by the provider's enabled flag. */
   enabled?: boolean;
+  /** 1-indexed page number. Server default: 1. */
+  page?: number;
+  /** Items per page. Server default: 20, max: 100. */
+  page_size?: number;
+}
+
+/** Pagination metadata returned alongside paginated list responses. */
+export interface PaginationMeta {
+  page: number;
+  page_size: number;
+  total_items: number;
+  total_pages: number;
+}
+
+/** Paginated wrapper returned by `client.listProvidersPaged()`. */
+export interface LLMProviderListResponse {
+  providers: LLMProvider[];
+  pagination: PaginationMeta;
 }

--- a/tests/list-providers-review-fixes.test.ts
+++ b/tests/list-providers-review-fixes.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for the review-feedback fixes on listProviders():
+ *
+ *  1. Wire-shape: `LLMProvider` surfaces endpoint, model, region,
+ *     rate_limit, timeout_seconds, settings.
+ *  2. Pagination: `listProvidersPaged` returns `LLMProviderListResponse`
+ *     with `pagination`; `listAllProviders` walks every page.
+ *  3. Network errors: a fetch rejection bubbles up as an error rather
+ *     than an "all tests pass" lie.
+ *  4. Bare-array response from older platforms decodes correctly.
+ */
+
+import { AxonFlow } from '../src/client';
+import type { LLMProvider } from '../src/types/llm-providers';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('listProviders() review fixes', () => {
+  let client: AxonFlow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+  });
+
+  const mockOk = (data: unknown) =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    });
+
+  it('surfaces endpoint, model, region, rate_limit, timeout_seconds, settings', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockOk({
+        providers: [
+          {
+            name: 'anthropic',
+            type: 'anthropic',
+            enabled: true,
+            has_api_key: true,
+            endpoint: 'https://api.anthropic.com',
+            model: 'claude-haiku-4-5',
+            region: 'us-east-1',
+            rate_limit: 60,
+            timeout_seconds: 30,
+            settings: { temperature_default: 0.2 },
+            health: { status: 'healthy' },
+          },
+        ],
+        pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+      })
+    );
+
+    const providers = await client.listProviders();
+    expect(providers).toHaveLength(1);
+    const p = providers[0];
+    expect(p.endpoint).toBe('https://api.anthropic.com');
+    expect(p.model).toBe('claude-haiku-4-5');
+    expect(p.region).toBe('us-east-1');
+    expect(p.rate_limit).toBe(60);
+    expect(p.timeout_seconds).toBe(30);
+    expect(p.settings).toEqual({ temperature_default: 0.2 });
+  });
+
+  it('listProvidersPaged returns pagination metadata', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockOk({
+        providers: [{ name: 'p1', type: 'openai', enabled: true, has_api_key: true }],
+        pagination: { page: 2, page_size: 5, total_items: 7, total_pages: 2 },
+      })
+    );
+
+    const result = await client.listProvidersPaged({ page: 2, page_size: 5 });
+    expect(result.pagination).toEqual({
+      page: 2,
+      page_size: 5,
+      total_items: 7,
+      total_pages: 2,
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('page=2');
+    expect(url).toContain('page_size=5');
+  });
+
+  it('listAllProviders walks every page', async () => {
+    mockFetch
+      .mockReturnValueOnce(
+        mockOk({
+          providers: [
+            { name: 'a', type: 'openai', enabled: true, has_api_key: true },
+            { name: 'b', type: 'openai', enabled: true, has_api_key: true },
+          ],
+          pagination: { page: 1, page_size: 2, total_items: 3, total_pages: 2 },
+        })
+      )
+      .mockReturnValueOnce(
+        mockOk({
+          providers: [{ name: 'c', type: 'anthropic', enabled: true, has_api_key: true }],
+          pagination: { page: 2, page_size: 2, total_items: 3, total_pages: 2 },
+        })
+      );
+
+    const all = await client.listAllProviders({ page_size: 2 });
+    expect(all.map((p: LLMProvider) => p.name)).toEqual(['a', 'b', 'c']);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on network error (fetch rejection)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network unreachable'));
+    await expect(client.listProviders()).rejects.toBeDefined();
+  });
+
+  it('decodes bare-array response (older platform fallback)', async () => {
+    // Older platforms may have returned a bare array rather than the wrapped object.
+    mockFetch.mockReturnValueOnce(
+      mockOk([{ name: 'legacy', type: 'openai', enabled: true, has_api_key: true }])
+    );
+
+    const providers = await client.listProviders();
+    expect(providers).toHaveLength(1);
+    expect(providers[0].name).toBe('legacy');
+  });
+
+  it('decodes bare-array response with synthetic pagination meta', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockOk([
+        { name: 'a', type: 'openai', enabled: true, has_api_key: true },
+        { name: 'b', type: 'anthropic', enabled: true, has_api_key: true },
+      ])
+    );
+
+    const result = await client.listProvidersPaged();
+    expect(result.providers).toHaveLength(2);
+    expect(result.pagination.page).toBe(1);
+    expect(result.pagination.total_items).toBe(2);
+    expect(result.pagination.total_pages).toBe(1);
+  });
+
+  it('combines multiple filters with proper URL encoding', async () => {
+    mockFetch.mockReturnValueOnce(mockOk({ providers: [] }));
+    await client.listProviders({
+      type: 'azure-openai',
+      enabled: true,
+      page: 3,
+      page_size: 50,
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('type=azure-openai');
+    expect(url).toContain('enabled=true');
+    expect(url).toContain('page=3');
+    expect(url).toContain('page_size=50');
+  });
+});


### PR DESCRIPTION
## Summary

Six review-driven fixes on the just-shipped \`listProviders()\` (PR #195). All flagged by the post-merge deep code review.

## What changed

| # | Issue | Fix |
|---|---|---|
| 1 | \`LLMProvider\` was silently dropping six platform-emitted fields | Added \`endpoint\`, \`model\`, \`region\`, \`rate_limit\`, \`timeout_seconds\`, \`settings: Record<string, unknown>\` to the interface |
| 2 | Pagination ignored — silent truncation at 20 providers | Extended \`ListProvidersOptions\` with \`page\` + \`page_size\`. Added \`listProvidersPaged()\` (single page + meta) and \`listAllProviders()\` (walks every page, default \`page_size=100\`) |
| 3 | Manual string concat for query params, inconsistent with rest of codebase | Switched to \`URLSearchParams\` (matches \`listStaticPolicies\` etc.) |
| 4 | Response type was incomplete | Now declared as \`LLMProviderListResponse \| LLMProvider[]\` to acknowledge the bare-array fallback the existing code already handled |
| 5 | Bare-array fallback path was untested | New tests for both \`listProviders()\` and \`listProvidersPaged()\` against bare-array responses; the latter synthesises a single-page \`pagination\` meta |
| 6 | No network error / multi-filter URL encoding tests | Added 7 new regression tests in \`tests/list-providers-review-fixes.test.ts\` |

## New types

- \`PaginationMeta\` (page, page_size, total_items, total_pages)
- \`LLMProviderListResponse\` (providers, pagination)

Both re-exported via \`src/types/index.ts\` so they're reachable from \`@axonflow/sdk\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest tests/list-providers.test.ts tests/list-providers-review-fixes.test.ts\` — 14/14 pass (7 existing + 7 new)
- [x] Prettier-formatted

## Cross-SDK note

Sibling PRs landing the same fixes in Python / Go SDKs: axonflow-sdk-python#165, axonflow-sdk-go#142. Java SDK PR coming.