### PR TITLE
examples/basic: switch from deprecated protect() to modern Gateway+Proxy APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`examples/basic/`** — removed the "Sandbox Mode" demonstration that constructed `AxonFlow.sandbox(...)`. The sandbox client hard-codes the decommissioned staging-eu endpoint internally and the example would always fail at that step. The sandbox helper itself is unchanged in the SDK.
 - **`examples/README.md`** — corrected stale env-var docs: examples expect `AXONFLOW_CLIENT_ID` / `AXONFLOW_CLIENT_SECRET`, not `AXONFLOW_API_KEY` / `AXONFLOW_TENANT`. Updated runner instructions to use `tsx` (the examples no longer rely on `ts-node`).
 - **All examples** — standardized on `import { AxonFlow } from '@axonflow/sdk'` (was mixed; some examples imported from `'../../src'` which only worked when copy-pasted inside the repo tree).
+- **`examples/basic/`** — rewritten to use the modern Gateway-Mode (`getPolicyApprovedContext` + `auditLLMCall`) and Proxy-Mode (`proxyLLMCall`) APIs. The previous version used the deprecated `protect()` helper (deprecated in v6.0.0) and the SDK emitted a deprecation warning every time the example ran.
 
 ## [6.1.0] - 2026-04-25 — Plugin Batch 1 explainability fields on MCP responses
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,27 +1,28 @@
 /**
  * Basic AxonFlow SDK Usage Example
  *
- * This example demonstrates:
- * - Simple client initialization
- * - Protecting AI calls with governance
- * - Handling blocked requests
- * - Testing PII detection
+ * This example demonstrates the modern Gateway-Mode and Proxy-Mode APIs:
+ * - Gateway Mode (lower latency): getPolicyApprovedContext + auditLLMCall.
+ *   The caller makes the LLM call themselves; AxonFlow approves before
+ *   and audits after.
+ * - Proxy Mode (zero-config): proxyLLMCall — AxonFlow handles policy
+ *   enforcement and optional LLM routing in a single round-trip.
+ *
+ * Run: npx tsx examples/basic/index.ts
  */
 
 import { AxonFlow } from '@axonflow/sdk';
 
 async function main() {
-  // Load configuration from environment variables
   const agentURL = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
   const clientId = process.env.AXONFLOW_CLIENT_ID;
   const clientSecret = process.env.AXONFLOW_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
-    console.error('❌ AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set');
+    console.error('AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set');
     process.exit(1);
   }
 
-  // Create client with simple initialization
   console.log('Initializing AxonFlow client...');
   const client = new AxonFlow({
     clientId,
@@ -30,49 +31,102 @@ async function main() {
     debug: true,
   });
 
-  // Execute a simple protected AI call
+  // Step 1: Health check ----------------------------------------------------
   console.log('\n' + '='.repeat(60));
-  console.log('Example 1: Simple Protected AI Call');
+  console.log('Step 1: Health Check');
   console.log('='.repeat(60));
-
-  try {
-    const result = await client.protect(async () => {
-      // This would be your actual AI API call
-      return {
-        response: 'The capital of France is Paris.',
-        model: 'gpt-4',
-        usage: { tokens: 15 },
-      };
-    });
-
-    console.log('✓ Query executed successfully');
-    console.log('Result:', result);
-  } catch (error) {
-    const err = error as Error;
-    console.error('❌ Query failed:', err.message);
+  const health = await client.healthCheck();
+  console.log(`Status:  ${health.status}`);
+  if (health.version) {
+    console.log(`Version: ${health.version}`);
   }
 
-  // Test with sensitive data (should be detected/blocked)
+  // Step 2: Gateway Mode (pre-check + audit) -------------------------------
   console.log('\n' + '='.repeat(60));
-  console.log('Example 2: PII Detection');
+  console.log('Step 2: Gateway Mode (getPolicyApprovedContext + auditLLMCall)');
   console.log('='.repeat(60));
-
   try {
-    const result = await client.protect(async () => {
-      return {
-        response:
-          'Based on your query, I found that email john.doe@example.com and SSN 123-45-6789',
-        model: 'gpt-4',
-      };
+    const ctx = await client.getPolicyApprovedContext({
+      userToken: 'demo-user',
+      query: 'What is the capital of France?',
     });
+    console.log(`Approved:  ${ctx.approved}`);
+    console.log(`ContextId: ${ctx.contextId}`);
+    console.log(`Policies:  ${ctx.policies.length} evaluated`);
 
-    console.log('✓ PII handled:', result);
+    if (ctx.approved) {
+      // The caller makes the actual LLM call here (mocked for the example).
+      const startTime = Date.now();
+      const llmResponse = {
+        text: 'Paris is the capital of France.',
+        tokensIn: 7,
+        tokensOut: 8,
+      };
+      const latencyMs = Date.now() - startTime;
+
+      const audit = await client.auditLLMCall({
+        contextId: ctx.contextId,
+        responseSummary: llmResponse.text,
+        provider: 'mock',
+        model: 'mock-model',
+        tokenUsage: {
+          promptTokens: llmResponse.tokensIn,
+          completionTokens: llmResponse.tokensOut,
+          totalTokens: llmResponse.tokensIn + llmResponse.tokensOut,
+        },
+        latencyMs,
+      });
+      console.log(`Audit:     success=${audit.success} id=${audit.auditId}`);
+    }
   } catch (error) {
-    const err = error as Error;
-    console.log('✓ Request blocked (PII detected):', err.message);
+    console.log(`Gateway Mode error: ${(error as Error).message}`);
   }
 
-  console.log('\n✅ All examples completed');
+  // Step 3: Proxy Mode (single round-trip) ---------------------------------
+  console.log('\n' + '='.repeat(60));
+  console.log('Step 3: Proxy Mode (proxyLLMCall)');
+  console.log('='.repeat(60));
+  try {
+    const result = await client.proxyLLMCall({
+      userToken: 'demo-user',
+      query: 'What is the capital of France?',
+      requestType: 'chat',
+    });
+    console.log(`Success:  ${result.success}`);
+    console.log(`Blocked:  ${result.blocked}`);
+    if (result.policyInfo) {
+      console.log(`Policies: ${result.policyInfo.policiesEvaluated.length} evaluated`);
+    }
+  } catch (error) {
+    // Community stacks without an LLM provider configured will return
+    // non-success; that's normal here. Specific error subclasses (e.g.
+    // PolicyViolationError) signal blocked content rather than a failure.
+    console.log(`Proxy Mode error: ${(error as Error).message}`);
+  }
+
+  // Step 4: PII detection (Proxy Mode) -------------------------------------
+  console.log('\n' + '='.repeat(60));
+  console.log('Step 4: PII detection (Proxy Mode)');
+  console.log('='.repeat(60));
+  try {
+    const result = await client.proxyLLMCall({
+      userToken: 'demo-user',
+      query: 'My email is john.doe@example.com and SSN is 123-45-6789',
+      requestType: 'chat',
+    });
+    console.log(`Success:  ${result.success}`);
+    console.log(`Blocked:  ${result.blocked}`);
+    if (result.blocked && result.blockReason) {
+      console.log(`Reason:   ${result.blockReason}`);
+    }
+  } catch (error) {
+    // PolicyViolationError is the expected outcome when PII enforcement
+    // is set to block. Community defaults to warn — caller may see
+    // success=true with a policy match recorded.
+    console.log(`PII step: ${(error as Error).message}`);
+  }
+
+  console.log('\nAll examples completed');
 }
 
 main().catch(error => {


### PR DESCRIPTION
## Summary

Honest hack-cleanup PR. When the user asked \"did you make any hacks/shortcuts during the QF-10 review work?\", this was the most material one: the basic example — the most visible piece of public-facing documentation in the SDK — kept using the deprecated \`protect()\` helper. The SDK emitted this every time the example ran:

\`\`\`
[AxonFlow] protect() is deprecated and will be removed in a future
version. Use Gateway Mode (getPolicyApprovedContext + auditLLMCall) or
Proxy Mode (proxyLLMCall) instead.
\`\`\`

## What this PR does

Rewrites \`examples/basic/index.ts\` to demonstrate both modern paths:

- **Step 1: Health Check** — unchanged
- **Step 2: Gateway Mode** (lower latency — caller makes the LLM call)
  - \`getPolicyApprovedContext\` for pre-check
  - \`auditLLMCall\` after the (mocked) LLM round-trip
- **Step 3: Proxy Mode** (zero-config — AxonFlow makes the round-trip)
- **Step 4: PII Detection** via Proxy Mode

The example no longer triggers the SDK's deprecation warning.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx tsc -p tsconfig.examples.json\` clean
- [x] \`npm run test:contract\` 58/58 pass
- [x] Local E2E smoke: \`npm pack\` → install in /tmp → \`npx tsx index.ts\` → all 4 steps run
- [ ] CI green