### PR TITLE
fix(telemetry)!: remove DO_NOT_TRACK opt-out (BREAKING)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Contract tests run on every PR and push. No network, no stack.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Preflight: validate CHANGELOG has a section for the tag being released

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.
+
+  `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
+
+### Fixed
+
+- The one-line `[AxonFlow] DO_NOT_TRACK=1 is deprecated...` `console.warn` is no longer emitted. Removing the warning eliminates console noise that previously appeared on every client construction when `DO_NOT_TRACK=1` was set.
+
+### CI / development
+
+- Test harness (`jest.setup.ts`) and CI workflows (`test.yml`, `integration.yml`, `publish.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.
+
+
 ## [6.2.0] - 2026-04-28 — listProviders() + example modernization
 
 Minor release. New LLM-provider listing API closes the parity gap with the Java + Python SDKs; the rest of the cycle is example modernization and a non-breaking default-endpoint correction. Coordinated cycle: Python v6.9.0 / Go v6.0.0 (major: see SDKCompatibility breaking type change in that release) / Java v6.2.0 ship same day.

--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,10 @@ const axonflow = new AxonFlow({
 ## Telemetry
 
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
-No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off` or `DO_NOT_TRACK=1`.
+No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
+
+`DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
+
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.
 
 ## License

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,3 @@
 // Disable telemetry during tests to prevent sendTelemetryPing from
 // interfering with fetch mocks in unrelated test files.
-process.env.DO_NOT_TRACK = '1';
+process.env.AXONFLOW_TELEMETRY = 'off';

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -53,29 +53,15 @@ function generateInstanceId(): string {
  * Check whether telemetry is opted-out via environment variables.
  *
  * `AXONFLOW_TELEMETRY=off` is the canonical AxonFlow-specific opt-out.
- * `DO_NOT_TRACK=1` is **deprecated** as an AxonFlow opt-out and will be
- * removed after 2026-05-05 in the next major release — when it's the only
- * thing disabling telemetry, a one-line warning is emitted so operators can
- * migrate to `AXONFLOW_TELEMETRY=off`. If both are set, the caller has
- * already migrated and no warning fires.
  *
- * Consistent with the Go, Python, and Java SDKs — the warning fires on
- * every opt-out check, not once per process, so any downstream log sink
- * sees every invocation (cron jobs, per-request child processes).
+ * `DO_NOT_TRACK` is intentionally NOT honored. It is commonly inherited from
+ * host tools and developer environments (CLIs like Codex and Claude Code
+ * inject it unconditionally), which makes it an unreliable expression of
+ * user intent for AxonFlow telemetry.
  */
 function isOptedOut(): boolean {
   if (typeof process === 'undefined' || !process.env) {
     return false;
-  }
-  if (process.env.DO_NOT_TRACK?.trim() === '1') {
-    // Only warn when DO_NOT_TRACK is the active control. If AXONFLOW_TELEMETRY=off
-    // is also set, the caller has already migrated.
-    if (process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off') {
-      console.warn(
-        '[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.'
-      );
-    }
-    return true;
   }
   if (process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() === 'off') {
     return true;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -85,8 +85,8 @@ export interface AxonFlowConfig {
    * When undefined, defaults to ON for production mode and OFF for sandbox mode.
    * Set explicitly to `true` or `false` to override the default.
    *
-   * Telemetry can also be disabled globally via the DO_NOT_TRACK=1 or
-   * AXONFLOW_TELEMETRY=off environment variables.
+   * Telemetry can also be disabled globally via the
+   * `AXONFLOW_TELEMETRY=off` environment variable.
    */
   telemetry?: boolean;
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1424,11 +1424,10 @@ describe('AxonFlow Client Unit Tests', () => {
     });
 
     it('should allow tenant without clientId in community mode', () => {
-      // Set AXONFLOW_TELEMETRY=off alongside CI's DO_NOT_TRACK=1 so the
-      // telemetry deprecation warning (v5.6.0+) stays silent and doesn't
-      // shadow this test's credential-warning assertion. This also prevents
-      // the client constructor's fire-and-forget ping from hitting the real
-      // checkpoint endpoint — fetch is not mocked in this file.
+      // Set AXONFLOW_TELEMETRY=off so the client constructor's fire-and-forget
+      // ping doesn't hit the real checkpoint endpoint (fetch is not mocked in
+      // this file). jest.setup.ts already sets this globally, but we re-set it
+      // here in case a prior test scrubbed it.
       const origAxonflowTelemetry = process.env.AXONFLOW_TELEMETRY;
       process.env.AXONFLOW_TELEMETRY = 'off';
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation();

--- a/tests/telemetry-shared-deadline.test.ts
+++ b/tests/telemetry-shared-deadline.test.ts
@@ -24,10 +24,12 @@ const originalEnv = { ...process.env };
 
 describe('telemetry — shared deadline (regression for #1707)', () => {
   beforeEach(() => {
-    // Strip environment-level opt-outs so sendTelemetryPing actually fires.
-    // CI and developer shells commonly have DO_NOT_TRACK=1 or AXONFLOW_TELEMETRY=off
-    // set; without this cleanup the fetches never happen and the test times out
-    // without verifying the thing it claims to verify.
+    // Strip the AxonFlow opt-out so sendTelemetryPing actually fires. CI
+    // workflows + jest.setup.ts set AXONFLOW_TELEMETRY=off; without this
+    // cleanup the fetches never happen and the test times out without
+    // verifying the thing it claims to verify. DO_NOT_TRACK is also
+    // deleted defensively (no-op for telemetry but cheap; some dev shells
+    // export it from broader privacy conventions).
     delete process.env.DO_NOT_TRACK;
     delete process.env.AXONFLOW_TELEMETRY;
   });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -73,7 +73,7 @@ describe('sendTelemetryPing', () => {
   // Opt-out via environment variables
   // ============================================================
   describe('opt-out via environment variables', () => {
-    it('should not send when DO_NOT_TRACK=1', () => {
+    it('should STILL send when only DO_NOT_TRACK=1 is set (DNT no longer honored)', async () => {
       process.env.DO_NOT_TRACK = '1';
 
       sendTelemetryPing({
@@ -81,7 +81,11 @@ describe('sendTelemetryPing', () => {
         endpoint: 'https://api.axonflow.com',
       });
 
-      expect(mockFetch).not.toHaveBeenCalled();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // DNT alone is no longer honored — host CLIs inject it unconditionally
+      // so it cannot be a real user signal.
+      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
     });
 
     it('should not send when AXONFLOW_TELEMETRY=off', () => {
@@ -95,8 +99,21 @@ describe('sendTelemetryPing', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('should send when DO_NOT_TRACK is not set to 1', async () => {
-      process.env.DO_NOT_TRACK = '0';
+    it('should not send when AXONFLOW_TELEMETRY=off, even with DO_NOT_TRACK=1 also set', () => {
+      process.env.DO_NOT_TRACK = '1';
+      process.env.AXONFLOW_TELEMETRY = 'off';
+
+      sendTelemetryPing({
+        mode: 'production',
+        endpoint: 'https://api.axonflow.com',
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should not emit a console.warn when DO_NOT_TRACK=1 is set (no deprecation noise)', async () => {
+      process.env.DO_NOT_TRACK = '1';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       sendTelemetryPing({
         mode: 'production',
@@ -104,8 +121,8 @@ describe('sendTelemetryPing', () => {
       });
 
       await new Promise(resolve => setTimeout(resolve, 50));
-
-      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('should send when AXONFLOW_TELEMETRY is not off', async () => {
@@ -259,7 +276,7 @@ describe('sendTelemetryPing', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('env var opt-out takes priority over telemetryEnabled=true', () => {
+    it('DNT=1 alone does NOT override telemetryEnabled=true (DNT no longer honored)', async () => {
       process.env.DO_NOT_TRACK = '1';
 
       sendTelemetryPing({
@@ -268,7 +285,8 @@ describe('sendTelemetryPing', () => {
         telemetryEnabled: true,
       });
 
-      expect(mockFetch).not.toHaveBeenCalled();
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
     });
 
     it('AXONFLOW_TELEMETRY=off takes priority over telemetryEnabled=true', () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -2,7 +2,7 @@
  * Telemetry Module Tests
  *
  * Verifies the anonymous usage telemetry ping behavior:
- * - Opt-out via DO_NOT_TRACK and AXONFLOW_TELEMETRY env vars
+ * - Opt-out via AXONFLOW_TELEMETRY=off env var (DO_NOT_TRACK is no longer honored)
  * - Default ON for all modes except sandbox
  * - Config-level override of defaults
  * - Payload format correctness


### PR DESCRIPTION
## Summary

**BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.

`DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry. Major version bump at release time under explicit approval — not in this PR.

## Changes

- `src/telemetry.ts` — drop DNT branch + `console.warn` deprecation message from `isOptedOut`.
- `jest.setup.ts` — replace `DO_NOT_TRACK=1` with `AXONFLOW_TELEMETRY=off`.
- `tests/telemetry.test.ts` — flip every DNT-suppress assertion + add canonical-wins coverage + `console.warn` regression guard.
- `.github/workflows/{test,integration,publish}.yml` — migrate suppression env.
- `README.md`, `CHANGELOG.md` — updated.

## Test plan

- [x] `npx jest tests/telemetry.test.ts` — 31/31 pass
- [ ] CI green