### PR TITLE
feat(telemetry): 7-day delivered-heartbeat with stamp-on-success

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -1,0 +1,49 @@
+name: heartbeat-real-stack
+
+# Real-stack heartbeat E2E across Linux + Windows + macOS. Stands up a
+# localhost fake checkpoint server, constructs the SDK through its
+# public API, verifies (a) the OS-native stamp file appears, (b) the
+# checkpoint endpoint received exactly one ping, (c) a second
+# invocation does NOT re-fire (warm-cache regression).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  AXONFLOW_TELEMETRY: 'off'
+
+jobs:
+  real-stack:
+    name: real-stack ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Python (for harness driver)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install + build SDK
+        run: |
+          npm ci
+          npm run build
+
+      - name: Run real-stack heartbeat E2E (cold + warm)
+        env:
+          SDK_DIST_DIR: ${{ github.workspace }}/dist/cjs/index.js
+        run: python tests/heartbeat-real-stack/run_real_stack.py node tests/heartbeat-real-stack/smoke_ts.mjs
+        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The one-line `[AxonFlow] DO_NOT_TRACK=1 is deprecated...` `console.warn` is no longer emitted. Removing the warning eliminates console noise that previously appeared on every client construction when `DO_NOT_TRACK=1` was set.
 
+### Changed
+
+- **Telemetry now follows the 7-day delivered-heartbeat contract** instead of firing on every `new AxonFlow()` construction. The SDK emits at most one anonymous heartbeat per environment every 7 days during SDK activity. A stamp file at the OS-native user cache dir tracks last successful delivery; mtime is the source of truth across process restarts. Failed POSTs do NOT advance the stamp — a transient network error does not silence telemetry for 7 days. An in-memory 1-hour cache caps `fs.statSync` calls on hot request paths; an in-flight Promise coalesces concurrent stampedes so only one ping fires under load. `AXONFLOW_TELEMETRY=off` is re-evaluated on every gate run. Restricted environments where no cache dir is available (e.g. AWS Lambda with no `HOME`/`LOCALAPPDATA`) fall back transparently to the previous "one ping per process" behavior.
+
 ### CI / development
 
 - Test harness (`jest.setup.ts`) and CI workflows (`test.yml`, `integration.yml`, `publish.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { VERSION } from './version';
 import { maybeSendHeartbeat, flushHeartbeat } from './heartbeat';
-import { sendTelemetryPing, sendTelemetryPingNow } from './telemetry';
+import { sendTelemetryPingNow } from './telemetry';
 import {
   AxonFlowConfig,
   AIRequest,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { VERSION } from './version';
-import { sendTelemetryPing } from './telemetry';
+import { maybeSendHeartbeat } from './heartbeat';
+import { sendTelemetryPing, sendTelemetryPingNow } from './telemetry';
 import {
   AxonFlowConfig,
   AIRequest,
@@ -254,6 +255,12 @@ export class AxonFlow {
     retry: { enabled: boolean; maxAttempts: number; delay: number };
     cache: { enabled: boolean; ttl: number };
   };
+  // Stores the explicit telemetry override (true / false / undefined) and the
+  // user's original `mode` so the heartbeat gate's _preRequestHook can match
+  // the legacy `sendTelemetryPing` gating semantics. Auto-detected sandbox
+  // (when explicitMode is undefined) leaves telemetry on at the default.
+  private telemetryEnabled: boolean | undefined;
+  private explicitMode: string | undefined;
   private interceptors: {
     canHandle(aiCall: any): boolean;
     extractRequest(aiCall: any): AIRequest;
@@ -313,6 +320,10 @@ export class AxonFlow {
     // Interceptors removed in v3.0.0 (deprecated wrapOpenAIClient/wrapAnthropicClient)
     this.interceptors = [];
 
+    // Capture for the heartbeat gate (see _preRequestHook).
+    this.telemetryEnabled = config.telemetry;
+    this.explicitMode = config.mode;
+
     if (this.config.debug) {
       // Determine auth method for logging
       const authMethod = hasCredentials ? 'client-credentials' : 'community (no auth)';
@@ -324,14 +335,62 @@ export class AxonFlow {
       });
     }
 
-    // Send telemetry ping (fire-and-forget).
-    sendTelemetryPing({
-      mode: this.config.mode,
-      explicitMode: config.mode,
-      endpoint: this.config.endpoint,
-      telemetryEnabled: config.telemetry,
-      debug: this.config.debug,
-    });
+    // Heartbeat gate: at most one anonymous ping per environment per
+    // 7 days, gated by SDK activity. Constructor schedules the gate
+    // (which may or may not fire a POST depending on the stamp file);
+    // subsequent gate runs happen async via _preRequestHook on every
+    // public HTTP request site. See src/heartbeat.ts.
+    void this._preRequestHook();
+  }
+
+  /**
+   * Single hook invoked at the start of every public HTTP request path
+   * (via the `_fetch` wrapper). Schedules a heartbeat-gate evaluation;
+   * the gate's in-memory 1-hour cache plus the in-flight Promise gate
+   * mean the typical hot-path cost is a single comparison and an env
+   * read.
+   *
+   * Returns a Promise that the caller may discard — the gate runs
+   * asynchronously so user API calls are never delayed by telemetry.
+   */
+  private async _preRequestHook(): Promise<void> {
+    // Replicate the legacy sendTelemetryPing gating decision precisely:
+    //   - explicit telemetry === false → off
+    //   - explicit telemetry === true  → on
+    //   - explicit explicitMode === 'sandbox' (user-provided) → off
+    //   - undefined explicitMode (auto-detected) → on regardless of mode
+    let enabled: boolean;
+    if (this.telemetryEnabled === false) {
+      enabled = false;
+    } else if (this.telemetryEnabled === true) {
+      enabled = true;
+    } else {
+      enabled = this.explicitMode !== 'sandbox';
+    }
+    await maybeSendHeartbeat(enabled, () =>
+      sendTelemetryPingNow({
+        mode: this.config.mode,
+        endpoint: this.config.endpoint,
+        debug: this.config.debug,
+      })
+    );
+  }
+
+  /**
+   * Single HTTP wrapper used by every public-API request path. Schedules
+   * a heartbeat-gate evaluation as a side effect (non-blocking — the gate
+   * runs asynchronously) and returns the underlying `fetch` response.
+   *
+   * IMPORTANT: This wrapper must NOT be called from the telemetry path
+   * itself (sendTelemetryPingNow / detectPlatformVersion). Those use raw
+   * `fetch` to avoid recursive heartbeat triggering.
+   */
+  private async _fetch(
+    input: string | URL | Request,
+    init?: RequestInit
+  ): Promise<Response> {
+    void this._preRequestHook();
+    return fetch(input, init);
   }
 
   /**
@@ -532,7 +591,7 @@ export class AxonFlow {
       ...this.getAuthHeaders(),
     };
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
@@ -656,7 +715,7 @@ export class AxonFlow {
     const url = `${this.config.endpoint}/health`;
 
     try {
-      const response = await fetch(url, {
+      const response = await this._fetch(url, {
         method: 'GET',
         headers: this.getAuthHeaders(),
         signal: AbortSignal.timeout(this.config.timeout),
@@ -729,7 +788,7 @@ export class AxonFlow {
     const url = `${this.config.endpoint}/health`;
 
     try {
-      const response = await fetch(url, {
+      const response = await this._fetch(url, {
         method: 'GET',
         headers: this.getAuthHeaders(),
         signal: AbortSignal.timeout(this.config.timeout),
@@ -848,7 +907,7 @@ export class AxonFlow {
       });
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
@@ -1208,7 +1267,7 @@ export class AxonFlow {
       ...this.getAuthHeaders(),
     };
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
@@ -1295,7 +1354,7 @@ export class AxonFlow {
       });
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
@@ -1394,7 +1453,7 @@ export class AxonFlow {
       });
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
@@ -1478,7 +1537,7 @@ export class AxonFlow {
       });
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
@@ -1570,7 +1629,7 @@ export class AxonFlow {
     };
 
     // Use mapTimeout for MAP operations (default 2 minutes)
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
@@ -1649,7 +1708,7 @@ export class AxonFlow {
     };
 
     // Use mapTimeout for MAP operations (default 2 minutes)
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(agentRequest),
@@ -1715,7 +1774,7 @@ export class AxonFlow {
   async getPlanStatus(planId: string): Promise<PlanExecutionResponse> {
     const url = `${this.config.endpoint}/api/v1/plan/${planId}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       signal: AbortSignal.timeout(this.config.timeout),
     });
@@ -1757,7 +1816,7 @@ export class AxonFlow {
       body.reason = reason;
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
@@ -1818,7 +1877,7 @@ export class AxonFlow {
       body.metadata = request.metadata;
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'PUT',
       headers,
       body: JSON.stringify(body),
@@ -1864,7 +1923,7 @@ export class AxonFlow {
       ...this.getAuthHeaders(),
     };
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers,
       signal: AbortSignal.timeout(this.config.timeout),
@@ -1908,7 +1967,7 @@ export class AxonFlow {
       ...this.getAuthHeaders(),
     };
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({ approved: approved ?? true }),
@@ -2018,7 +2077,7 @@ export class AxonFlow {
       debugLog('Gateway Mode: Pre-check', { query: options.query.substring(0, 50) });
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(requestBody),
@@ -2127,7 +2186,7 @@ export class AxonFlow {
       });
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(requestBody),
@@ -2825,7 +2884,7 @@ export class AxonFlow {
       options.body = JSON.stringify(body);
     }
 
-    const response = await fetch(url, options);
+    const response = await this._fetch(url, options);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -3464,7 +3523,7 @@ export class AxonFlow {
   ): Promise<{ sessionId: string; orgId: string; email: string; name: string; expiresAt: string }> {
     const url = `${this.config.endpoint}/api/v1/auth/login`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ org_id: orgId, password }),
@@ -3520,7 +3579,7 @@ export class AxonFlow {
     }
 
     try {
-      await fetch(`${this.config.endpoint}/api/v1/auth/logout`, {
+      await this._fetch(`${this.config.endpoint}/api/v1/auth/logout`, {
         method: 'POST',
         headers: { Cookie: `axonflow_session=${this.sessionCookie}` },
         signal: AbortSignal.timeout(this.config.timeout),
@@ -4211,7 +4270,7 @@ export class AxonFlow {
       options.body = JSON.stringify(body);
     }
 
-    const response = await fetch(url, options);
+    const response = await this._fetch(url, options);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -4267,7 +4326,7 @@ export class AxonFlow {
       debugLog('Portal request', { method, path });
     }
 
-    const response = await fetch(url, options);
+    const response = await this._fetch(url, options);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -5053,7 +5112,7 @@ export class AxonFlow {
       debugLog('Portal request (text)', { method, path });
     }
 
-    const response = await fetch(url, options);
+    const response = await this._fetch(url, options);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -5592,7 +5651,7 @@ export class AxonFlow {
       ...this.getAuthHeaders(),
     };
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({}),
@@ -5811,7 +5870,7 @@ export class AxonFlow {
       metadata: request.metadata,
     };
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -5832,7 +5891,7 @@ export class AxonFlow {
   private async masfeatGetSystem(systemId: string): Promise<AISystemRegistry> {
     const url = `${this.config.endpoint}/api/v1/masfeat/registry/${systemId}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -5865,7 +5924,7 @@ export class AxonFlow {
     if (request.humanReliance !== undefined) body.human_reliance = request.humanReliance;
     if (request.metadata !== undefined) body.metadata = request.metadata;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -5895,7 +5954,7 @@ export class AxonFlow {
     const queryString = params.toString();
     const url = `${this.config.endpoint}/api/v1/masfeat/registry${queryString ? `?${queryString}` : ''}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -5916,7 +5975,7 @@ export class AxonFlow {
     // Use PUT to update status - the /activate endpoint doesn't exist
     const url = `${this.config.endpoint}/api/v1/masfeat/registry/${systemId}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -5937,7 +5996,7 @@ export class AxonFlow {
   private async masfeatRetireSystem(systemId: string): Promise<AISystemRegistry> {
     const url = `${this.config.endpoint}/api/v1/masfeat/registry/${systemId}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'DELETE',
       headers: {
         ...this.getAuthHeaders(),
@@ -5956,7 +6015,7 @@ export class AxonFlow {
   private async masfeatGetRegistrySummary(): Promise<RegistrySummary> {
     const url = `${this.config.endpoint}/api/v1/masfeat/registry/summary`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -6014,7 +6073,7 @@ export class AxonFlow {
       }));
     }
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6035,7 +6094,7 @@ export class AxonFlow {
   private async masfeatGetAssessment(assessmentId: string): Promise<FEATAssessment> {
     const url = `${this.config.endpoint}/api/v1/masfeat/assessments/${assessmentId}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -6085,7 +6144,7 @@ export class AxonFlow {
     if (request.recommendations !== undefined) body.recommendations = request.recommendations;
     if (request.assessors !== undefined) body.assessors = request.assessors;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -6115,7 +6174,7 @@ export class AxonFlow {
     const queryString = params.toString();
     const url = `${this.config.endpoint}/api/v1/masfeat/assessments${queryString ? `?${queryString}` : ''}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -6135,7 +6194,7 @@ export class AxonFlow {
   private async masfeatSubmitAssessment(assessmentId: string): Promise<FEATAssessment> {
     const url = `${this.config.endpoint}/api/v1/masfeat/assessments/${assessmentId}/submit`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6158,7 +6217,7 @@ export class AxonFlow {
   ): Promise<FEATAssessment> {
     const url = `${this.config.endpoint}/api/v1/masfeat/assessments/${assessmentId}/approve`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6185,7 +6244,7 @@ export class AxonFlow {
   ): Promise<FEATAssessment> {
     const url = `${this.config.endpoint}/api/v1/masfeat/assessments/${assessmentId}/reject`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6210,7 +6269,7 @@ export class AxonFlow {
   private async masfeatGetKillSwitch(systemId: string): Promise<KillSwitch> {
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -6241,7 +6300,7 @@ export class AxonFlow {
     if (request.autoTriggerEnabled !== undefined)
       body.auto_trigger_enabled = request.autoTriggerEnabled;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6265,7 +6324,7 @@ export class AxonFlow {
   ): Promise<KillSwitch> {
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}/check`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6293,7 +6352,7 @@ export class AxonFlow {
   ): Promise<KillSwitch> {
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}/trigger`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6320,7 +6379,7 @@ export class AxonFlow {
   ): Promise<KillSwitch> {
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}/restore`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6344,7 +6403,7 @@ export class AxonFlow {
   private async masfeatEnableKillSwitch(systemId: string): Promise<KillSwitch> {
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}/enable`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6367,7 +6426,7 @@ export class AxonFlow {
   ): Promise<KillSwitch> {
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}/disable`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -6395,7 +6454,7 @@ export class AxonFlow {
     const queryString = params.toString();
     const url = `${this.config.endpoint}/api/v1/masfeat/killswitch/${systemId}/history${queryString ? `?${queryString}` : ''}`;
 
-    const response = await fetch(url, {
+    const response = await this._fetch(url, {
       method: 'GET',
       headers: {
         ...this.getAuthHeaders(),
@@ -7041,7 +7100,7 @@ export class AxonFlow {
 
     let response: Response;
     try {
-      response = await fetch(url, fetchOptions);
+      response = await this._fetch(url, fetchOptions);
     } catch (error: unknown) {
       if (error instanceof Error && error.name === 'AbortError') {
         return; // Clean exit on abort

--- a/src/client.ts
+++ b/src/client.ts
@@ -405,10 +405,7 @@ export class AxonFlow {
    * itself (sendTelemetryPingNow / detectPlatformVersion). Those use raw
    * `fetch` to avoid recursive heartbeat triggering.
    */
-  private async _fetch(
-    input: string | URL | Request,
-    init?: RequestInit
-  ): Promise<Response> {
+  private async _fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
     void this._preRequestHook();
     return fetch(input, init);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { VERSION } from './version';
-import { maybeSendHeartbeat } from './heartbeat';
+import { maybeSendHeartbeat, flushHeartbeat } from './heartbeat';
 import { sendTelemetryPing, sendTelemetryPingNow } from './telemetry';
 import {
   AxonFlowConfig,
@@ -267,6 +267,17 @@ export class AxonFlow {
   }[] = [];
   private sessionCookie: string | null = null;
 
+  /**
+   * Promise that resolves when the constructor's heartbeat gate
+   * evaluation has finished (whether it sent a ping or short-circuited).
+   * Long-running services can ignore this — Node's event loop holds the
+   * process open until the in-flight Promise resolves naturally. CLI
+   * binaries and Lambda boot handlers that exit quickly should
+   * `await client.heartbeatReady` so the boot ping isn't truncated by
+   * an explicit `process.exit()`.
+   */
+  public readonly heartbeatReady: Promise<void>;
+
   constructor(config: AxonFlowConfig) {
     // Configuration validation
     if (config.clientSecret && !config.clientId) {
@@ -336,11 +347,20 @@ export class AxonFlow {
     }
 
     // Heartbeat gate: at most one anonymous ping per environment per
-    // 7 days, gated by SDK activity. Constructor schedules the gate
-    // (which may or may not fire a POST depending on the stamp file);
-    // subsequent gate runs happen async via _preRequestHook on every
-    // public HTTP request site. See src/heartbeat.ts.
-    void this._preRequestHook();
+    // 7 days, gated by SDK activity. Constructor kicks off the gate AND
+    // chains the in-flight delivery Promise so `heartbeatReady` resolves
+    // only once the POST has settled — callers in short-lived processes
+    // (CLI, Lambda boot) can `await client.heartbeatReady` to guarantee
+    // delivery before exit. Subsequent gate runs happen async via
+    // _preRequestHook on every public HTTP request site. See
+    // src/heartbeat.ts.
+    this.heartbeatReady = (async () => {
+      await this._preRequestHook();
+      const inFlight = flushHeartbeat();
+      if (inFlight) {
+        await inFlight;
+      }
+    })();
   }
 
   /**

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,0 +1,222 @@
+/**
+ * 7-day delivered-heartbeat gate for AxonFlow TypeScript SDK telemetry.
+ *
+ * Implements the cross-SDK contract:
+ *
+ *   AxonFlow emits at most one anonymous heartbeat per environment every
+ *   7 days during SDK activity.
+ *
+ * The gate is consulted at client construction and at every public HTTP
+ * request site (via `_preRequestHook`). Each gate run:
+ *
+ *  1. Re-evaluates `AXONFLOW_TELEMETRY=off` cheaply (lock-free) so a
+ *     mid-process opt-out toggle takes effect immediately.
+ *  2. Checks an in-memory 1-hour cache to bound stat() syscall frequency
+ *     on hot request paths.
+ *  3. Reads the stamp file mtime as the source of truth for last
+ *     successful delivery across process restarts.
+ *  4. Sends the ping and writes the stamp ONLY on success — stamp-on-
+ *     DELIVERY semantics. Failed POSTs leave the stamp unchanged so the
+ *     next call after the 1-hour cache expires retries.
+ *  5. Coalesces concurrent callers via an in-flight Promise so a stampede
+ *     across the boundary fires exactly one POST.
+ *
+ * Cross-platform stamp file location (no external deps):
+ *
+ *   macOS:   ~/Library/Caches/axonflow/typescript-telemetry-last-sent
+ *   Linux:   $XDG_CACHE_HOME/axonflow/...  or  ~/.cache/axonflow/...
+ *   Windows: %LOCALAPPDATA%/axonflow/...
+ *
+ * If the cache dir cannot be resolved (e.g. AWS Lambda where HOME is
+ * unset and LOCALAPPDATA is absent), the stamp path is null and the SDK
+ * falls back to "one ping per process" — same as today's pre-heartbeat
+ * behavior. No regression for that runtime.
+ */
+
+import { promises as fsPromises, statSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** 7 days in milliseconds. */
+export const HEARTBEAT_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** 1 hour in milliseconds — bounds how often we stat() the stamp file. */
+export const HEARTBEAT_GUARD_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Resolve the OS-native stamp file path, or `null` if no user cache
+ * directory is available (Lambda etc.). Hand-rolled rather than via the
+ * `env-paths` package to keep the SDK dependency-free.
+ */
+export function resolveStampPath(): string | null {
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    const home = process.env.HOME;
+    if (!home) return null;
+    return path.join(home, 'Library', 'Caches', 'axonflow', 'typescript-telemetry-last-sent');
+  }
+  if (platform === 'win32') {
+    const local = process.env.LOCALAPPDATA;
+    if (!local) return null;
+    return path.join(local, 'axonflow', 'typescript-telemetry-last-sent');
+  }
+  // Linux / *BSD / others — XDG.
+  const xdg = process.env.XDG_CACHE_HOME;
+  if (xdg) {
+    return path.join(xdg, 'axonflow', 'typescript-telemetry-last-sent');
+  }
+  const home = process.env.HOME;
+  if (!home) return null;
+  return path.join(home, '.cache', 'axonflow', 'typescript-telemetry-last-sent');
+}
+
+/** Sentinel: pass to HeartbeatState to opt into the auto-resolved default. */
+export const USE_DEFAULT_CACHE_DIR = Symbol('axonflow.heartbeat.useDefaultCacheDir');
+
+/**
+ * Mutable state for the delivered-heartbeat gate.
+ *
+ * Shared as a module-level singleton across all clients in the process so
+ * multiple AxonFlow instances coalesce onto a single ping. Single-threaded
+ * Node.js runtime means no mutex is needed; an in-flight Promise is enough
+ * to coalesce concurrent callers.
+ *
+ * `stampPath` semantics:
+ *  - string  — use this exact location (typically used in tests).
+ *  - null    — no persistence at all (Lambda / restricted env path).
+ *  - default — auto-resolve via resolveStampPath().
+ */
+export class HeartbeatState {
+  public lastCheckedMs: number | null = null;
+  public inFlight: Promise<void> | null = null;
+  public readonly stampPath: string | null;
+
+  constructor(stampPath: string | null | typeof USE_DEFAULT_CACHE_DIR = USE_DEFAULT_CACHE_DIR) {
+    this.stampPath = stampPath === USE_DEFAULT_CACHE_DIR ? resolveStampPath() : stampPath;
+  }
+
+  /**
+   * Returns the stamp file's mtime as wall-clock ms-since-epoch, or null
+   * if absent / unreadable / no path. Tolerant of every failure mode — a
+   * corrupted or missing stamp is treated as "never sent" so we re-attempt.
+   */
+  readStampMtimeMs(): number | null {
+    if (!this.stampPath) return null;
+    try {
+      return statSync(this.stampPath).mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Atomically write a fresh timestamp to the stamp file via tmp+rename so
+   * concurrent writers never observe torn state. Contents are advisory —
+   * the SDK uses mtime as the source of truth, never the contents.
+   * Errors are silently ignored — a failed write means the next process
+   * retries on schedule.
+   */
+  async writeStampAtomic(): Promise<void> {
+    if (!this.stampPath) return;
+    const dir = path.dirname(this.stampPath);
+    try {
+      await fsPromises.mkdir(dir, { recursive: true });
+    } catch {
+      return;
+    }
+    const tmpName = path.join(dir, `telemetry-last-sent-${process.pid}-${Date.now()}.tmp`);
+    try {
+      await fsPromises.writeFile(tmpName, `last_sent=${new Date().toISOString()}\n`, { flag: 'w' });
+      await fsPromises.rename(tmpName, this.stampPath);
+    } catch {
+      // tmp+rename failure is non-fatal; clean up the orphaned tmp file
+      // if it was created.
+      try {
+        await fsPromises.unlink(tmpName);
+      } catch {
+        /* nothing to clean up */
+      }
+    }
+  }
+}
+
+// Module-level singleton. Tests that need isolation override via
+// `replaceHeartbeatStateForTest` and restore the previous state.
+let _state: HeartbeatState = new HeartbeatState();
+
+export function getHeartbeatStateForTest(): HeartbeatState {
+  return _state;
+}
+
+export function replaceHeartbeatStateForTest(
+  stampPath: string | null | typeof USE_DEFAULT_CACHE_DIR
+): HeartbeatState {
+  const previous = _state;
+  _state = new HeartbeatState(stampPath);
+  return previous;
+}
+
+/**
+ * Cheap opt-out check, re-evaluated on every gate run so a mid-process
+ * `process.env.AXONFLOW_TELEMETRY = 'off'` toggle takes effect immediately
+ * without restart.
+ */
+function isOptedOut(): boolean {
+  if (typeof process === 'undefined' || !process.env) return false;
+  return process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() === 'off';
+}
+
+/**
+ * Central gate for telemetry pings. Called from the AxonFlow constructor
+ * and from `_preRequestHook` on every public HTTP entry point.
+ *
+ * The `pingFn` callback returns a Promise<boolean> indicating delivery
+ * success. The stamp is written ONLY when this resolves to true,
+ * implementing the "stamp-on-delivery" contract.
+ *
+ * Never throws — heartbeat failures must not surface to the caller.
+ */
+export async function maybeSendHeartbeat(
+  isTelemetryEnabled: boolean,
+  pingFn: () => Promise<boolean>
+): Promise<void> {
+  // 1. Cheap opt-out check (lock-free, re-evaluated every call).
+  if (isOptedOut()) return;
+  if (!isTelemetryEnabled) return;
+
+  const h = _state;
+
+  // 2. In-flight Promise gate — coalesces concurrent callers in the
+  //    single-threaded JS runtime. Awaiting it does not delay the caller
+  //    because we don't await the returned Promise from public hot paths.
+  if (h.inFlight) return;
+
+  const nowMs = Date.now();
+
+  // 3. In-memory 1-hour cache.
+  if (h.lastCheckedMs !== null && nowMs - h.lastCheckedMs < HEARTBEAT_GUARD_INTERVAL_MS) {
+    return;
+  }
+  h.lastCheckedMs = nowMs;
+
+  // 4. Stamp file mtime gate.
+  const mtimeMs = h.readStampMtimeMs();
+  if (mtimeMs !== null && nowMs - mtimeMs < HEARTBEAT_INTERVAL_MS) {
+    return;
+  }
+
+  // 5. Send + stamp-on-success. Stored as Promise on `inFlight` so any
+  //    concurrent callers can fast-path out via the check above.
+  h.inFlight = (async () => {
+    try {
+      const ok = await pingFn();
+      if (ok) {
+        await h.writeStampAtomic();
+      }
+    } catch {
+      // pingFn must never throw in practice, but defend anyway.
+    } finally {
+      h.inFlight = null;
+    }
+  })();
+}

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -157,6 +157,34 @@ export function replaceHeartbeatStateForTest(
 }
 
 /**
+ * Test helper: restore a previously-saved singleton.
+ *
+ * Pair with `replaceHeartbeatStateForTest`:
+ *
+ *   const previous = replaceHeartbeatStateForTest(tempStamp);
+ *   try { ... } finally { restoreHeartbeatStateForTest(previous); }
+ */
+export function restoreHeartbeatStateForTest(state: HeartbeatState): void {
+  _state = state;
+}
+
+/**
+ * Returns the in-flight heartbeat Promise, or `null` if no ping is in
+ * progress. Use this from short-lived processes (CLI scripts, Lambda
+ * boot) to await delivery before exit:
+ *
+ *   const client = new AxonFlow(config);
+ *   // ... do work ...
+ *   await flushHeartbeat();  // ensures the boot ping landed
+ *
+ * Long-running services don't need to call this — the Node event loop
+ * keeps the process alive while the Promise is pending.
+ */
+export function flushHeartbeat(): Promise<void> | null {
+  return _state.inFlight;
+}
+
+/**
  * Cheap opt-out check, re-evaluated on every gate run so a mid-process
  * `process.env.AXONFLOW_TELEMETRY = 'off'` toggle takes effect immediately
  * without restart.

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -34,7 +34,6 @@
  */
 
 import { promises as fsPromises, statSync } from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 /** 7 days in milliseconds. */

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -268,10 +268,84 @@ function expandIPv6(addr: string): string {
 }
 
 /**
- * Send an anonymous telemetry ping on client initialization.
+ * Send an anonymous telemetry ping and return whether it landed.
  *
- * This is fire-and-forget: the returned promise is intentionally not awaited,
- * errors are silently swallowed, and a 3-second timeout prevents blocking.
+ * Returns `true` only when the POST received a 2xx response. Network
+ * failures, timeouts, and non-2xx responses all return `false`. Used by
+ * the heartbeat orchestrator (see `heartbeat.ts`) where the boolean
+ * drives stamp-on-DELIVERY semantics: only successful POSTs advance the
+ * stamp file.
+ *
+ * The caller is responsible for the gating decision — this function does
+ * NOT consult `AXONFLOW_TELEMETRY`, the stamp file, or any rate-limit
+ * state.
+ */
+export async function sendTelemetryPingNow(options: {
+  mode: string;
+  endpoint: string;
+  debug?: boolean;
+}): Promise<boolean> {
+  const checkpointUrl = resolveCheckpointUrl();
+
+  const payload: TelemetryPayload = {
+    sdk: 'typescript',
+    sdk_version: VERSION,
+    platform_version: null,
+    os: typeof process !== 'undefined' ? process.platform : 'unknown',
+    arch: typeof process !== 'undefined' ? process.arch : 'unknown',
+    runtime_version: typeof process !== 'undefined' ? process.version.replace(/^v/, '') : 'unknown',
+    deployment_mode: options.mode,
+    endpoint_type: classifyEndpoint(options.endpoint),
+    features: [],
+    instance_id: generateInstanceId(),
+  };
+
+  try {
+    const deadline = Date.now() + TELEMETRY_TIMEOUT_MS;
+
+    try {
+      const healthBudget = Math.min(HEALTH_BUDGET_CAP_MS, Math.max(0, deadline - Date.now()));
+      if (options.endpoint && healthBudget > MIN_BUDGET_MS) {
+        payload.platform_version = await detectPlatformVersion(options.endpoint, healthBudget);
+      }
+    } catch {
+      /* platform_version remains null on failure */
+    }
+
+    if (options.debug) {
+      console.log('[AxonFlow] Sending telemetry ping', JSON.stringify(payload, null, 2));
+    }
+
+    const postBudget = Math.max(0, deadline - Date.now());
+    if (postBudget < MIN_BUDGET_MS) {
+      return false;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), postBudget);
+
+    try {
+      const response = await fetch(checkpointUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      return response.ok;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send an anonymous telemetry ping on client initialization (compat shim).
+ *
+ * Kept for the existing test surface. Production code goes through
+ * `maybeSendHeartbeat` in heartbeat.ts instead. This shim performs the
+ * gating + fire-and-forget POST without consulting the 7-day stamp file.
  */
 export function sendTelemetryPing(options: {
   mode: string;

--- a/tests/heartbeat-e2e.test.ts
+++ b/tests/heartbeat-e2e.test.ts
@@ -1,0 +1,101 @@
+/**
+ * End-to-end test for the 7-day delivered-heartbeat contract.
+ *
+ * Walks through the four-run cycle:
+ *
+ *   Run 1: cold start (no stamp)              → 1 ping;  stamp present
+ *   Run 2: warm start (fresh stamp)           → 0 pings; stamp unchanged
+ *   Run 3: backdate stamp 8d (fs.utimes)      → 1 ping;  stamp re-touched
+ *   Run 4: stale stamp + ping returns false   → 0 successful pings;
+ *                                                stamp NOT advanced;
+ *                                                retry on success lands cleanly
+ *
+ * Validates stamp-on-DELIVERY semantics and cross-run behavior (the stamp
+ * file is the source of truth across "process restarts" simulated by
+ * fresh HeartbeatState construction with the same stamp path).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  HeartbeatState,
+  USE_DEFAULT_CACHE_DIR,
+  maybeSendHeartbeat,
+  replaceHeartbeatStateForTest,
+} from '../src/heartbeat';
+
+let stampPath: string;
+
+beforeEach(() => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'axonflow-hb-e2e-'));
+  stampPath = path.join(dir, 'stamp');
+  delete process.env.AXONFLOW_TELEMETRY;
+});
+
+afterEach(() => {
+  replaceHeartbeatStateForTest(USE_DEFAULT_CACHE_DIR);
+});
+
+function swapState(): HeartbeatState {
+  return replaceHeartbeatStateForTest(stampPath) && new HeartbeatState(stampPath);
+}
+
+async function flush(): Promise<void> {
+  // Wait until the in-flight Promise (if any) resolves on the current
+  // singleton state.
+  // The replaceHeartbeatStateForTest helper installs a fresh state, so we
+  // re-read it after each swap.
+  const state = (await import('../src/heartbeat')).getHeartbeatStateForTest();
+  if (state.inFlight) {
+    await state.inFlight;
+  }
+}
+
+test('four-run cycle: cold → warm → stale → stale+failure → retry', async () => {
+  // --- Run 1: cold start, no stamp -------------------------------------------
+  swapState();
+  const ping1 = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, ping1);
+  await flush();
+  expect(ping1).toHaveBeenCalledTimes(1);
+  expect(fs.existsSync(stampPath)).toBe(true);
+
+  // --- Run 2: simulate fresh process — fresh state, same stamp file ----------
+  swapState();
+  const ping2 = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, ping2);
+  await flush();
+  expect(ping2).toHaveBeenCalledTimes(0);
+
+  // --- Run 3: backdate stamp 8d ----------------------------------------------
+  const eightDaysAgoSec = (Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(stampPath, eightDaysAgoSec, eightDaysAgoSec);
+
+  swapState();
+  const ping3 = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, ping3);
+  await flush();
+  expect(ping3).toHaveBeenCalledTimes(1);
+  expect(Date.now() - fs.statSync(stampPath).mtimeMs).toBeLessThan(5000);
+
+  // --- Run 4a: backdate again, ping returns failure --------------------------
+  fs.utimesSync(stampPath, eightDaysAgoSec, eightDaysAgoSec);
+  const mtimeBeforeFail = fs.statSync(stampPath).mtimeMs;
+
+  swapState();
+  const failingPing = jest.fn().mockResolvedValue(false);
+  await maybeSendHeartbeat(true, failingPing);
+  await flush();
+  expect(failingPing).toHaveBeenCalledTimes(1);
+  const mtimeAfterFail = fs.statSync(stampPath).mtimeMs;
+  expect(mtimeAfterFail).toBe(mtimeBeforeFail); // stamp NOT advanced
+
+  // --- Run 4b: retry against a successful mock -------------------------------
+  swapState();
+  const retryPing = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, retryPing);
+  await flush();
+  expect(retryPing).toHaveBeenCalledTimes(1);
+  expect(Date.now() - fs.statSync(stampPath).mtimeMs).toBeLessThan(5000);
+});

--- a/tests/heartbeat-real-stack/run_real_stack.py
+++ b/tests/heartbeat-real-stack/run_real_stack.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Cross-platform driver for the heartbeat real-stack E2E.
+
+Stands up the fake checkpoint server (server.py), runs an SDK smoke
+twice, and verifies:
+
+  Cold (first run):  exactly 1 checkpoint hit, stamp file present
+  Warm (second run): 0 additional checkpoint hits, stamp unchanged
+
+Usage:
+    python run_real_stack.py <smoke_command...>
+
+The smoke command is invoked twice with these environment variables set:
+    AXONFLOW_AGENT_URL
+    AXONFLOW_CHECKPOINT_URL
+    AXONFLOW_TELEMETRY=""        (defensive; CI workflows often default to off)
+    HOME, USERPROFILE, LOCALAPPDATA, XDG_CACHE_HOME — all rerouted to a
+                                  temp dir so the smoke can verify a clean
+                                  cache state without touching the runner's
+                                  real cache.
+
+Exits 0 on success, non-zero on any failure.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+
+def fetch_counter(url: str) -> dict:
+    with urllib.request.urlopen(url + "/__counter", timeout=5) as r:
+        return json.loads(r.read())
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: run_real_stack.py <smoke_command...>", file=sys.stderr)
+        return 2
+
+    smoke_cmd = list(argv[1:])
+    # Java quirk: the JVM resolves user.home from native APIs at startup
+    # and ignores $HOME on macOS / Windows. Detect and rewrite.
+    java_target = any("java" == os.path.basename(p).lower().replace(".exe", "") for p in [smoke_cmd[0]])
+    here = Path(__file__).resolve().parent
+    server_script = here / "server.py"
+
+    work_root = Path(tempfile.mkdtemp(prefix="hb-real-stack-"))
+    port_file = work_root / "port.txt"
+
+    env = os.environ.copy()
+    env["HEARTBEAT_E2E_PORT_FILE"] = str(port_file)
+
+    # Launch fake server.
+    server_proc = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        # Wait for port file to appear.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if port_file.exists():
+                port_text = port_file.read_text().strip()
+                if port_text:
+                    break
+            time.sleep(0.1)
+        else:
+            print("FAIL: server didn't write port file in 15s", file=sys.stderr)
+            return 1
+
+        port = int(port_text)
+        server_url = f"http://127.0.0.1:{port}"
+        print(f"server: {server_url}")
+
+        # Sanity check.
+        before = fetch_counter(server_url)
+        assert before == {"checkpoint_hits": 0, "health_hits": 0}, before
+
+        # Build a clean HOME / cache redirect.
+        clean_home = work_root / "home"
+        clean_home.mkdir()
+
+        smoke_env = os.environ.copy()
+        smoke_env.update({
+            "AXONFLOW_AGENT_URL": server_url,
+            "AXONFLOW_CHECKPOINT_URL": f"{server_url}/v1/ping",
+            "AXONFLOW_TELEMETRY": "",
+            # Reroute cache dir on every OS:
+            "HOME": str(clean_home),                         # macOS, Linux
+            "USERPROFILE": str(clean_home),                  # Windows
+            "LOCALAPPDATA": str(clean_home / "AppData" / "Local"),  # Windows
+            "XDG_CACHE_HOME": str(clean_home / ".cache"),    # Linux
+        })
+        # Ensure those nested dirs exist for Windows.
+        Path(smoke_env["LOCALAPPDATA"]).mkdir(parents=True, exist_ok=True)
+        Path(smoke_env["XDG_CACHE_HOME"]).mkdir(parents=True, exist_ok=True)
+
+        # Java JVM ignores $HOME for user.home on macOS / Windows; pass
+        # -Duser.home=<clean_home> as the first JVM arg.
+        if java_target:
+            smoke_cmd[1:1] = [f"-Duser.home={clean_home}"]
+
+        # ---- Cold run ----
+        print("--- cold run ---")
+        cold = subprocess.run(smoke_cmd, env=smoke_env, capture_output=True, text=True)
+        sys.stdout.write(cold.stdout)
+        sys.stderr.write(cold.stderr)
+        if cold.returncode != 0:
+            print(f"FAIL: cold smoke exited {cold.returncode}", file=sys.stderr)
+            return 1
+
+        cold_counter = fetch_counter(server_url)
+        print(f"counter after cold: {cold_counter}")
+        if cold_counter["checkpoint_hits"] != 1:
+            print(
+                f"FAIL: expected 1 checkpoint hit on cold, got {cold_counter['checkpoint_hits']}",
+                file=sys.stderr,
+            )
+            return 1
+
+        # ---- Warm run (same clean_home, stamp now exists) ----
+        print("--- warm run ---")
+        warm = subprocess.run(smoke_cmd, env=smoke_env, capture_output=True, text=True)
+        sys.stdout.write(warm.stdout)
+        sys.stderr.write(warm.stderr)
+        if warm.returncode != 0:
+            print(f"FAIL: warm smoke exited {warm.returncode}", file=sys.stderr)
+            return 1
+
+        warm_counter = fetch_counter(server_url)
+        print(f"counter after warm: {warm_counter}")
+        delta = warm_counter["checkpoint_hits"] - cold_counter["checkpoint_hits"]
+        if delta != 0:
+            print(
+                f"FAIL: expected 0 additional pings on warm run, got {delta}",
+                file=sys.stderr,
+            )
+            return 1
+
+        print("\nOK: cold + warm pass — heartbeat real-stack contract holds")
+        return 0
+    finally:
+        server_proc.terminate()
+        try:
+            server_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server_proc.kill()
+        shutil.rmtree(work_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/heartbeat-real-stack/run_real_stack.py
+++ b/tests/heartbeat-real-stack/run_real_stack.py
@@ -66,16 +66,42 @@ def main(argv: list[str]) -> int:
     )
 
     try:
-        # Wait for port file to appear.
-        deadline = time.time() + 15
+        # Wait for port file to appear. 60s is generous — macos-latest GitHub
+        # runners can be slow to cold-start Python; 15s sometimes wasn't enough.
+        # On any timeout we surface the server's stdout+stderr so the cause is
+        # visible in CI logs instead of failing silently.
+        deadline = time.time() + 60
+        port_text: str | None = None
         while time.time() < deadline:
+            if server_proc.poll() is not None:
+                # Server crashed before writing the port file.
+                stdout_bytes, _ = server_proc.communicate(timeout=2)
+                output = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+                print(
+                    f"FAIL: server exited with code {server_proc.returncode} before writing port file.\n"
+                    f"--- server stdout/stderr ---\n{output}",
+                    file=sys.stderr,
+                )
+                return 1
             if port_file.exists():
                 port_text = port_file.read_text().strip()
                 if port_text:
                     break
             time.sleep(0.1)
-        else:
-            print("FAIL: server didn't write port file in 15s", file=sys.stderr)
+        if not port_text:
+            # Port file timeout — kill server and surface its output.
+            server_proc.terminate()
+            try:
+                stdout_bytes, _ = server_proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                stdout_bytes, _ = server_proc.communicate()
+            output = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+            print(
+                "FAIL: server didn't write port file in 60s.\n"
+                f"--- server stdout/stderr ---\n{output}",
+                file=sys.stderr,
+            )
             return 1
 
         port = int(port_text)

--- a/tests/heartbeat-real-stack/server.py
+++ b/tests/heartbeat-real-stack/server.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Cross-platform fake-agent + fake-checkpoint server for the heartbeat E2E.
+
+Same as /tmp/heartbeat-real-e2e/server.py but vendored alongside the
+per-SDK smokes so it can ship inside each SDK repo's tests/ directory.
+"""
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CHECKPOINT_HITS = 0
+HEALTH_HITS = 0
+LOCK = threading.Lock()
+SDK_VERSION = "7.4.5"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def do_GET(self):
+        global HEALTH_HITS
+        if self.path == "/health":
+            with LOCK:
+                HEALTH_HITS += 1
+            self._send_json(200, {"version": SDK_VERSION, "status": "ok"})
+        elif self.path == "/__counter":
+            with LOCK:
+                self._send_json(200, {"checkpoint_hits": CHECKPOINT_HITS, "health_hits": HEALTH_HITS})
+        else:
+            self._send_json(503, {"error": "not implemented"})
+
+    def do_POST(self):
+        global CHECKPOINT_HITS
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        # Accept both /v1/ping (production path) and /v1/checkpoint (legacy local).
+        if self.path.startswith("/v1/"):
+            with LOCK:
+                CHECKPOINT_HITS += 1
+            self._send_json(200, {"latest_version": SDK_VERSION})
+        else:
+            self._send_json(503, {"error": "not implemented"})
+
+    def log_message(self, *_args):
+        pass
+
+
+def main():
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    host, port = server.server_address
+    base = f"http://{host}:{port}"
+    # Write port to a file so the launcher can read it (more reliable than
+    # parsing stdout under Windows + various shells).
+    with open(os.environ.get("HEARTBEAT_E2E_PORT_FILE", "port.txt"), "w") as f:
+        f.write(str(port))
+    print(f"SERVER_URL={base}", flush=True)
+    sys.stdout.flush()
+
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        # Run for up to 5 minutes; CI orchestrator kills us when done.
+        time.sleep(5 * 60)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/heartbeat-real-stack/smoke_ts.mjs
+++ b/tests/heartbeat-real-stack/smoke_ts.mjs
@@ -1,0 +1,82 @@
+// Cross-platform real-stack smoke for the TypeScript SDK. ESM so we
+// can `import` without bundling. CI compiles the SDK first via
+// `npm run build`; this file imports the compiled CJS via the package's
+// public entry point (see SDK_DIST_DIR env var resolution below).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function stampPath() {
+  if (process.platform === 'darwin') {
+    return path.join(
+      process.env.HOME,
+      'Library',
+      'Caches',
+      'axonflow',
+      'typescript-telemetry-last-sent'
+    );
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.LOCALAPPDATA,
+      'axonflow',
+      'typescript-telemetry-last-sent'
+    );
+  }
+  if (process.env.XDG_CACHE_HOME) {
+    return path.join(
+      process.env.XDG_CACHE_HOME,
+      'axonflow',
+      'typescript-telemetry-last-sent'
+    );
+  }
+  return path.join(
+    process.env.HOME,
+    '.cache',
+    'axonflow',
+    'typescript-telemetry-last-sent'
+  );
+}
+
+async function main() {
+  const sdkPath = process.env.SDK_DIST_DIR; // set by CI: /github/workspace/dist/cjs/index.js
+  if (!sdkPath) {
+    console.error('FAIL: SDK_DIST_DIR not set');
+    process.exit(1);
+  }
+  const { AxonFlow } = await import(sdkPath);
+
+  const agent = process.env.AXONFLOW_AGENT_URL;
+  if (!agent) {
+    console.error('FAIL: AXONFLOW_AGENT_URL not set');
+    process.exit(1);
+  }
+
+  const expected = stampPath();
+
+  const client = new AxonFlow({
+    endpoint: agent,
+    clientId: 'smoke-test',
+    clientSecret: 'smoke-secret',
+  });
+  try {
+    await client.healthCheck();
+  } catch {
+    // ignore
+  }
+  // heartbeatReady resolves only after the POST has settled (see
+  // src/client.ts — chains _preRequestHook + flushHeartbeat).
+  await client.heartbeatReady;
+
+  if (!fs.existsSync(expected)) {
+    console.error(`FAIL: stamp not at ${expected}`);
+    process.exit(1);
+  }
+  console.log(`OK: stamp at ${expected}`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error('FAIL:', e);
+  process.exit(1);
+});

--- a/tests/heartbeat-real-stack/smoke_ts.mjs
+++ b/tests/heartbeat-real-stack/smoke_ts.mjs
@@ -5,6 +5,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 function stampPath() {
   if (process.platform === 'darwin') {
@@ -44,7 +45,12 @@ async function main() {
     console.error('FAIL: SDK_DIST_DIR not set');
     process.exit(1);
   }
-  const { AxonFlow } = await import(sdkPath);
+  // Node's ESM loader requires file:// URLs for absolute paths. On Windows
+  // an absolute path like `D:\a\...\index.js` triggers
+  // ERR_UNSUPPORTED_ESM_URL_SCHEME — pathToFileURL handles the platform-
+  // specific conversion correctly (file:///D:/a/.../index.js).
+  const sdkUrl = pathToFileURL(sdkPath).href;
+  const { AxonFlow } = await import(sdkUrl);
 
   const agent = process.env.AXONFLOW_AGENT_URL;
   if (!agent) {

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the 7-day delivered-heartbeat gate.
+ *
+ * The matrix mirrors the cross-SDK reference (see Go SDK heartbeat_test.go):
+ *
+ *   1. cold start, no stamp           → 1 ping fires, stamp written
+ *   2. fresh stamp (1d old)           → 0 pings
+ *   3. stale stamp (8d old)           → 1 ping, stamp updated
+ *   4. 5 calls within 1h cache        → exactly 1 ping
+ *   5. cache expired + stale stamp    → 2nd ping fires
+ *   6. AXONFLOW_TELEMETRY=off mid-run → 0 pings, stamp unchanged
+ *   7. 100 concurrent callers         → exactly 1 ping (stampede coalesced)
+ *   8. no cache dir (stamp_path=null) → 1 ping per "process", no crash
+ *   9. ping returns false             → stamp NOT written; retry on success works
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  HeartbeatState,
+  USE_DEFAULT_CACHE_DIR,
+  getHeartbeatStateForTest,
+  maybeSendHeartbeat,
+  replaceHeartbeatStateForTest,
+} from '../src/heartbeat';
+
+let tempStampPath: string;
+let originalState: HeartbeatState;
+
+beforeEach(() => {
+  // Each test gets an isolated temp stamp file location.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'axonflow-hb-'));
+  tempStampPath = path.join(dir, 'stamp');
+  originalState = replaceHeartbeatStateForTest(tempStampPath);
+  delete process.env.AXONFLOW_TELEMETRY;
+});
+
+afterEach(() => {
+  // Restore original state.
+  replaceHeartbeatStateForTest(USE_DEFAULT_CACHE_DIR);
+  // (Singleton replacement above doesn't expose the previous instance; the
+  // module-level state remains the new default singleton — tests don't
+  // rely on the original state being the literal pre-test object, only on
+  // freshness per test, which is guaranteed by the beforeEach replacement.)
+});
+
+// Helper to wait for the in-flight Promise to resolve so the test can
+// inspect post-state (mock counts, stamp file presence) deterministically.
+async function flushHeartbeat(): Promise<void> {
+  const state = getHeartbeatStateForTest();
+  if (state.inFlight) {
+    await state.inFlight;
+  }
+}
+
+// --- 9-case matrix -------------------------------------------------------
+
+test('Case 1: cold start, no stamp → 1 ping, stamp written', async () => {
+  const ping = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+  expect(fs.existsSync(tempStampPath)).toBe(true);
+});
+
+test('Case 2: fresh stamp (1d old) → 0 pings', async () => {
+  fs.mkdirSync(path.dirname(tempStampPath), { recursive: true });
+  fs.writeFileSync(tempStampPath, 'last_sent=test\n');
+  const oneDayAgoSec = (Date.now() - 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(tempStampPath, oneDayAgoSec, oneDayAgoSec);
+
+  const ping = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(0);
+});
+
+test('Case 3: stale stamp (8d old) → 1 ping, stamp updated', async () => {
+  fs.mkdirSync(path.dirname(tempStampPath), { recursive: true });
+  fs.writeFileSync(tempStampPath, 'last_sent=test\n');
+  const eightDaysAgoSec = (Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(tempStampPath, eightDaysAgoSec, eightDaysAgoSec);
+
+  const ping = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+
+  const newMtimeMs = fs.statSync(tempStampPath).mtimeMs;
+  expect(Date.now() - newMtimeMs).toBeLessThan(5000);
+});
+
+test('Case 4: 5 calls within 1h cache → exactly 1 ping', async () => {
+  const ping = jest.fn().mockResolvedValue(true);
+  for (let i = 0; i < 5; i++) {
+    await maybeSendHeartbeat(true, ping);
+  }
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+});
+
+test('Case 5: cache expired + stale stamp → 2nd ping fires', async () => {
+  const ping = jest.fn().mockResolvedValue(true);
+
+  // First call: fires, stamp written.
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+
+  // Backdate in-memory cache (2h ago) AND stamp file (8d ago).
+  const state = getHeartbeatStateForTest();
+  state.lastCheckedMs = Date.now() - 2 * 60 * 60 * 1000;
+  const eightDaysAgoSec = (Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(tempStampPath, eightDaysAgoSec, eightDaysAgoSec);
+
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(2);
+});
+
+test('Case 6: AXONFLOW_TELEMETRY=off mid-run → 0 pings, stamp unchanged', async () => {
+  const ping = jest.fn().mockResolvedValue(true);
+
+  // First call: fires.
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+
+  // Toggle opt-out, force gates open. Snapshot mtime AFTER manipulation.
+  process.env.AXONFLOW_TELEMETRY = 'off';
+  const state = getHeartbeatStateForTest();
+  state.lastCheckedMs = Date.now() - 2 * 60 * 60 * 1000;
+  const eightDaysAgoSec = (Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(tempStampPath, eightDaysAgoSec, eightDaysAgoSec);
+  const mtimeBefore = fs.statSync(tempStampPath).mtimeMs;
+
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+
+  expect(ping).toHaveBeenCalledTimes(1); // still 1
+  const mtimeAfter = fs.statSync(tempStampPath).mtimeMs;
+  expect(mtimeAfter).toBe(mtimeBefore);
+});
+
+test('Case 7: 100 concurrent callers → exactly 1 ping', async () => {
+  const ping = jest.fn().mockImplementation(async () => {
+    // Slight delay to encourage stampede behavior.
+    await new Promise((r) => setTimeout(r, 10));
+    return true;
+  });
+
+  const calls = Array.from({ length: 100 }, () => maybeSendHeartbeat(true, ping));
+  await Promise.all(calls);
+  await flushHeartbeat();
+
+  expect(ping).toHaveBeenCalledTimes(1);
+});
+
+test('Case 8: no cache dir (stampPath=null) → ping per "process", no crash', async () => {
+  // Replace state with stampPath=null to simulate Lambda / restricted env.
+  replaceHeartbeatStateForTest(null);
+  const ping = jest.fn().mockResolvedValue(true);
+
+  // First call fires.
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+
+  // 1h cache holds within the same "process" even without a stamp file.
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(1);
+
+  // Backdate cache, call again — fires because no stamp gate exists.
+  const state = getHeartbeatStateForTest();
+  state.lastCheckedMs = Date.now() - 2 * 60 * 60 * 1000;
+  await maybeSendHeartbeat(true, ping);
+  await flushHeartbeat();
+  expect(ping).toHaveBeenCalledTimes(2);
+});
+
+test('Case 9: ping returns false → stamp NOT written; retry on success works', async () => {
+  const failingPing = jest.fn().mockResolvedValue(false);
+  await maybeSendHeartbeat(true, failingPing);
+  await flushHeartbeat();
+  expect(failingPing).toHaveBeenCalledTimes(1);
+  expect(fs.existsSync(tempStampPath)).toBe(false);
+
+  // Backdate cache, swap to success.
+  const state = getHeartbeatStateForTest();
+  state.lastCheckedMs = Date.now() - 2 * 60 * 60 * 1000;
+
+  const successPing = jest.fn().mockResolvedValue(true);
+  await maybeSendHeartbeat(true, successPing);
+  await flushHeartbeat();
+  expect(successPing).toHaveBeenCalledTimes(1);
+  expect(fs.existsSync(tempStampPath)).toBe(true);
+});

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -143,7 +143,7 @@ test('Case 6: AXONFLOW_TELEMETRY=off mid-run → 0 pings, stamp unchanged', asyn
 test('Case 7: 100 concurrent callers → exactly 1 ping', async () => {
   const ping = jest.fn().mockImplementation(async () => {
     // Slight delay to encourage stampede behavior.
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise(r => setTimeout(r, 10));
     return true;
   });
 

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -19,10 +19,10 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   HeartbeatState,
-  USE_DEFAULT_CACHE_DIR,
   getHeartbeatStateForTest,
   maybeSendHeartbeat,
   replaceHeartbeatStateForTest,
+  restoreHeartbeatStateForTest,
 } from '../src/heartbeat';
 
 let tempStampPath: string;
@@ -37,12 +37,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Restore original state.
-  replaceHeartbeatStateForTest(USE_DEFAULT_CACHE_DIR);
-  // (Singleton replacement above doesn't expose the previous instance; the
-  // module-level state remains the new default singleton — tests don't
-  // rely on the original state being the literal pre-test object, only on
-  // freshness per test, which is guaranteed by the beforeEach replacement.)
+  // Restore the original state captured in beforeEach so we don't leak
+  // test state into other test files.
+  restoreHeartbeatStateForTest(originalState);
 });
 
 // Helper to wait for the in-flight Promise to resolve so the test can


### PR DESCRIPTION
## Summary

Move SDK telemetry from "ping per `new AxonFlow()`" to the cross-language contract:

> AxonFlow emits at most one anonymous heartbeat per environment every 7 days during SDK activity.

Mirrors Go SDK reference, Python, Java; contract in axonflow-enterprise.

## How

- New `src/heartbeat.ts` with cross-platform stamp file, 1-hour in-memory cache, in-flight Promise gate, **stamp-on-DELIVERY** semantics.
- Single hook point via private `_fetch(input, init)` wrapper. All 47 raw `await fetch(url, ...)` call sites in `client.ts` migrated.
- `sendTelemetryPingNow(): Promise<boolean>` is the new pure-network function; `sendTelemetryPing(): void` is the legacy fire-and-forget shim for existing tests.

## Tests

- `tests/heartbeat.test.ts` — 9-case matrix.
- `tests/heartbeat-e2e.test.ts` — 4-run cycle.
- 884/884 existing tests pass.

## Test plan

- [x] `npx jest` green (28 suites, 884 passed)
- [x] `npx tsc --noEmit` green
- [ ] CI green