### PR TITLE
feat(license): inject X-Axonflow-Client header on every governed request

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -434,6 +434,13 @@ export class AxonFlow {
     // Include SDK version for version discovery and compatibility checks
     headers['User-Agent'] = `axonflow-sdk-typescript/${VERSION}`;
 
+    // ADR-050 §4: every governed request to the agent carries
+    // X-Axonflow-Client so the agent can derive request scope (sdk) and
+    // validate it against the token's aud.scope via HasScope(). Sourced
+    // from the bundled VERSION constant; no env override (the consumer
+    // doesn't get to spoof its own client identity to the agent).
+    headers['X-Axonflow-Client'] = `sdk-typescript/${VERSION}`;
+
     return headers;
   }
 

--- a/tests/client-header.test.ts
+++ b/tests/client-header.test.ts
@@ -1,0 +1,80 @@
+/**
+ * X-Axonflow-Client header injection — ADR-050 §4.
+ *
+ * Asserts every governed HTTP path forwards `X-Axonflow-Client: sdk-typescript/<VERSION>`
+ * so the agent can derive request scope (sdk) and validate against the
+ * token's aud.scope via HasScope().
+ *
+ * The header value is sourced from the bundled VERSION constant; the consumer
+ * cannot spoof its own client identity through config (intentional — that's
+ * the agent's defense-in-depth posture).
+ */
+
+import { AxonFlow } from '../src/client';
+import { VERSION } from '../src/version';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const EXPECTED_CLIENT = `sdk-typescript/${VERSION}`;
+
+function jsonResponse(body: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  };
+}
+
+function makeClient() {
+  return new AxonFlow({
+    clientId: 'test-client',
+    clientSecret: 'test-secret',
+    tenant: 'test-tenant',
+    endpoint: 'http://localhost:8080',
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('X-Axonflow-Client header injection', () => {
+  it('includes X-Axonflow-Client on mcpCheckInput', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true }));
+    await makeClient().mcpCheckInput({ connectorType: 'postgres', statement: 'SELECT 1' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Axonflow-Client': EXPECTED_CLIENT,
+        }),
+      }),
+    );
+  });
+
+  it('includes X-Axonflow-Client on queryConnector', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: true, data: {} }));
+    await makeClient().queryConnector('postgres', 'SELECT 1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Axonflow-Client': EXPECTED_CLIENT,
+        }),
+      }),
+    );
+  });
+
+  it('header carries the correct format: sdk-typescript/<semver>', () => {
+    // Sanity check — agent's deriveScopeFromClientHeader splits on '/' and
+    // maps "sdk-*" prefixes to scope=sdk. If we ever ship a value with extra
+    // slashes or the wrong prefix this fails loudly so we don't regress
+    // agent-side parsing in production.
+    expect(EXPECTED_CLIENT).toMatch(/^sdk-typescript\/[0-9]+\.[0-9]+\.[0-9]+/);
+    expect(EXPECTED_CLIENT.split('/')).toHaveLength(2);
+    expect(EXPECTED_CLIENT.startsWith('sdk-')).toBe(true);
+  });
+});

--- a/tests/client-header.test.ts
+++ b/tests/client-header.test.ts
@@ -51,7 +51,7 @@ describe('X-Axonflow-Client header injection', () => {
         headers: expect.objectContaining({
           'X-Axonflow-Client': EXPECTED_CLIENT,
         }),
-      }),
+      })
     );
   });
 
@@ -64,7 +64,7 @@ describe('X-Axonflow-Client header injection', () => {
         headers: expect.objectContaining({
           'X-Axonflow-Client': EXPECTED_CLIENT,
         }),
-      }),
+      })
     );
   });
 


### PR DESCRIPTION
## Summary

Per ADR-050 §4, every governed client must set `X-Axonflow-Client: <client-id>/<version>` on every request to the agent.

This is the sdk-typescript half of [getaxonflow/axonflow-enterprise#1881](https://github.com/getaxonflow/axonflow-enterprise/issues/1881).

## Changes

- `src/client.ts::getAuthHeaders()` — adds `X-Axonflow-Client: sdk-typescript/<VERSION>` to the central header builder. Every public SDK method that calls `getAuthHeaders()` now ships the header.
- `tests/client-header.test.ts` — new test (3 assertions covering mcpCheckInput + queryConnector + format check).
- All existing tests stay green: 29 suites, 887 tests passing (13 skipped, unchanged).

## Out of scope

- Agent-side header read + scope derivation + HasScope validation (separate enterprise PR)
- Same change in 4 plugins (4 separate PRs already opened: openclaw#95, claude-plugin#58, cursor-plugin#45, codex-plugin#45) and 3 other SDKs (3 separate PRs)