### PR TITLE
[skip-runtime-e2e] ci(definition-of-done): mechanical gate enforcing HARD RULE #0

### DIFF
--- a/.github/workflows/definition-of-done.yml
+++ b/.github/workflows/definition-of-done.yml
@@ -1,0 +1,137 @@
+name: Definition of Done
+
+# Enforces CLAUDE.md HARD RULE #0: a user-facing feature is not done until
+# demonstrated through its actual runtime. See axonflow-claude-plugin#59
+# for the doctrine + lint-no-mocks rationale.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-no-mocks-in-runtime-e2e:
+    name: Lint — no mocks in runtime-e2e/
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: |
+          if [ -x scripts/lint-no-mocks-in-runtime-e2e.sh ]; then
+            ./scripts/lint-no-mocks-in-runtime-e2e.sh
+          else
+            echo "lint-no-mocks-in-runtime-e2e.sh not present — skipping (older branch)."
+          fi
+
+  runtime-e2e-required:
+    name: Runtime E2E required for user-facing changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect user-facing surface changes
+        id: detect
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          # TypeScript SDK user-facing surface: the published source compiled
+          # to dist/, the package.json entry points + exports map that
+          # consumers import against, and the examples/ programs that show
+          # consumers how to wire the SDK into their apps.
+          USER_FACING_GLOBS=(
+            'src/'
+            'package.json'
+            'examples/'
+          )
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" || true)
+          echo "Changed files in PR:" >&2
+          printf '  %s\n' $CHANGED >&2
+
+          MATCHED=""
+          for f in $CHANGED; do
+            for pat in "${USER_FACING_GLOBS[@]}"; do
+              case "$f" in
+                "$pat"*|*"/$pat"*)
+                  MATCHED="$MATCHED $f"
+                  break
+                  ;;
+              esac
+            done
+          done
+
+          RUNTIME_E2E_TOUCHED=$(echo "$CHANGED" | grep -c '^runtime-e2e/' || true)
+
+          {
+            echo "user_facing_changed=$([ -n "$MATCHED" ] && echo true || echo false)"
+            echo "runtime_e2e_touched=$RUNTIME_E2E_TOUCHED"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$MATCHED" ]; then
+            echo "User-facing files changed:" >&2
+            for f in $MATCHED; do echo "  - $f" >&2; done
+          fi
+
+      - name: Check escape-hatch justification
+        id: hatch
+        if: steps.detect.outputs.user_facing_changed == 'true' && steps.detect.outputs.runtime_e2e_touched == '0'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -uo pipefail
+          if [[ "$PR_TITLE" == *"[skip-runtime-e2e]"* ]]; then
+            if echo "$PR_BODY" | grep -q '## Skip-runtime-e2e justification'; then
+              echo "Escape hatch active." >&2
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::PR title carries [skip-runtime-e2e] but body has no '## Skip-runtime-e2e justification' section."
+              exit 1
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce runtime-e2e/ presence
+        if: steps.detect.outputs.user_facing_changed == 'true' && steps.detect.outputs.runtime_e2e_touched == '0' && steps.hatch.outputs.skip != 'true'
+        run: |
+          cat <<'EOF' >&2
+          ::error::This PR touches real SDK code (src/, package.json, examples/)
+          but does not add or update any runtime-e2e/ test in the same PR.
+
+          Per CLAUDE.md HARD RULE #0:
+          A user-facing feature is not done until you have demonstrated it
+          working through its actual runtime — a real `import { AxonFlow }`
+          with a real `fetch` against a real running AxonFlow agent.
+
+          Mocks, stubs, jest.fn(), msw, nock, capture-stub harnesses do NOT
+          count as runtime proof.
+
+          To resolve, do ONE of:
+            1. Add a test under runtime-e2e/<feature>/ that invokes the
+               feature through the actual user-facing surface (compiled
+               dist/ imported and called against a live agent).
+            2. If genuinely internal (build / deps / lint baseline / docs),
+               add `[skip-runtime-e2e]` to PR title AND a
+               `## Skip-runtime-e2e justification` section to PR body.
+
+          See: axonflow-internal-docs/engineering/E2E_EXAMPLES_TESTING_WORKFLOW.md
+          EOF
+          exit 1
+
+      - name: All clear
+        if: steps.detect.outputs.user_facing_changed == 'false' || steps.detect.outputs.runtime_e2e_touched != '0' || steps.hatch.outputs.skip == 'true'
+        run: |
+          if [ "${{ steps.detect.outputs.user_facing_changed }}" = 'false' ]; then
+            echo "No user-facing surface changed. Gate not applicable." >&2
+          elif [ "${{ steps.detect.outputs.runtime_e2e_touched }}" != '0' ]; then
+            echo "User-facing change detected and runtime-e2e/ updated in same PR. ✓" >&2
+          else
+            echo "Escape hatch active with valid justification. ✓" >&2
+          fi

--- a/runtime-e2e/README.md
+++ b/runtime-e2e/README.md
@@ -1,0 +1,39 @@
+<!-- allow-mocks-here: this README names forbidden mock libraries explicitly so contributors recognise them. The lint script greps for those names; the marker tells it this file is documentation, not a test. -->
+# SDK runtime tests
+
+Per CLAUDE.md HARD RULE #0: a user-facing feature is not done until you
+have demonstrated it working through the SDK's actual runtime — a real
+`fetch` call from a real `import { AxonFlow }` against a real running
+AxonFlow agent.
+
+**Tests in this directory MUST hit a real endpoint.** No `mockFetch`,
+no `jest.mock`, no `msw`, no `nock`, no fixture servers. The
+`scripts/lint-no-mocks-in-runtime-e2e.sh` lint enforces this; a
+forbidden mock pattern fails CI.
+
+**Convention.** Each test lives in its own subdirectory like
+`runtime-e2e/<feature>/`. Each subdirectory has a `test.mjs` (or
+`test.ts`) that the runner can invoke directly with `node`.
+
+**How to run locally.** Set `AXONFLOW_AGENT_URL` (default
+`http://localhost:8080`). Bring up a local agent — the easiest path
+is `cd ../axonflow-enterprise && docker compose -f docker-compose.yml
+-f docker-compose.community-saas.yml up -d`. Then:
+
+```
+export AXONFLOW_AGENT_URL=http://localhost:8080
+# Register a community-saas tenant
+RESP=$(curl -s -X POST $AXONFLOW_AGENT_URL/api/v1/register \
+  -H "Content-Type: application/json" -d '{"label":"sdk-runtime-e2e"}')
+export AXONFLOW_TENANT_ID=$(echo "$RESP" | jq -r .tenant_id)
+export AXONFLOW_TENANT_SECRET=$(echo "$RESP" | jq -r .secret)
+
+for d in runtime-e2e/*/; do
+  node "$d/test.mjs" || exit 1
+done
+```
+
+**What counts as a test.** Each `test.mjs` exits non-zero if the SDK's
+real wire output to a real agent isn't what you expect. Best evidence
+pattern: capture an agent log line that echoes a value the SDK should
+have sent (e.g. `X-Axonflow-Client: sdk-typescript/<version>`).

--- a/runtime-e2e/x-axonflow-client/test.mjs
+++ b/runtime-e2e/x-axonflow-client/test.mjs
@@ -1,0 +1,48 @@
+// runtime-e2e/x-axonflow-client/test.mjs
+// Real-stack assertion: the SDK's compiled getAuthHeaders emits
+// X-Axonflow-Client: sdk-typescript/<VERSION> on every governed request.
+// Per CLAUDE.md HARD RULE #0 — this test MUST hit a real agent.
+
+import { AxonFlow, VERSION } from '../../dist/esm/index.js';
+
+const endpoint = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+const tenantId = process.env.AXONFLOW_TENANT_ID;
+const tenantSecret = process.env.AXONFLOW_TENANT_SECRET;
+if (!tenantId || !tenantSecret) {
+  console.error('AXONFLOW_TENANT_ID + AXONFLOW_TENANT_SECRET must be set; register a community-saas tenant first');
+  process.exit(2);
+}
+
+const expected = `sdk-typescript/${VERSION}`;
+const client = new AxonFlow({ endpoint, clientId: tenantId, clientSecret: tenantSecret });
+
+// Use the agent's scope-mismatch path to trigger an echo of X-Axonflow-Client
+// in the agent's [AUTH] log line. Inject a known plugin-aud token via fetch wrap;
+// the agent will reject with 401 + scope_mismatch and the agent log will reflect
+// exactly what the SDK sent.
+const PLUGIN_AUD_TOKEN = process.env.AXONFLOW_E2E_PLUGIN_TOKEN;
+if (!PLUGIN_AUD_TOKEN) {
+  console.error('AXONFLOW_E2E_PLUGIN_TOKEN must be set to a token with aud=axonflow.saas.plugin');
+  console.error('See ../README.md for how to mint one.');
+  process.exit(2);
+}
+const origFetch = globalThis.fetch;
+globalThis.fetch = async (url, init = {}) => {
+  init.headers = { ...(init.headers || {}), 'X-License-Token': PLUGIN_AUD_TOKEN };
+  return origFetch(url, init);
+};
+
+console.log(`Asserting wire X-Axonflow-Client = ${expected}`);
+try {
+  await client.mcpCheckInput({ connectorType: 'postgres', statement: 'SELECT 1' });
+  console.error('UNEXPECTED 200 — agent should have rejected scope_mismatch');
+  process.exit(1);
+} catch (err) {
+  const msg = (err && err.message) || String(err);
+  if (msg.includes(`client "${expected}"`)) {
+    console.log(`PASS: agent reflected ${expected} in scope_mismatch response`);
+    process.exit(0);
+  }
+  console.error(`FAIL: scope_mismatch response did not echo ${expected}; got: ${msg}`);
+  process.exit(1);
+}

--- a/scripts/lint-no-mocks-in-runtime-e2e.sh
+++ b/scripts/lint-no-mocks-in-runtime-e2e.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# lint-no-mocks-in-runtime-e2e.sh
+#
+# Per HARD RULE #0 in CLAUDE.md: runtime-e2e/ tests MUST hit a real endpoint
+# (real plugin in real host CLI; real SDK with real fetch against a real
+# running agent). Mocks, stubs, simulators, capture-stub harnesses do NOT
+# count as runtime proof.
+#
+# This script greps runtime-e2e/ for forbidden mock-pattern strings and
+# fails the build if any are found. It runs in CI as part of the
+# definition-of-done.yml gate.
+#
+# To bypass for a specific file (rare, must justify in PR):
+#   add a line `# allow-mocks-here: <reason>` near the offending line and
+#   the lint will skip that file. Reviewers should challenge any usage.
+
+set -uo pipefail
+
+SCAN_DIR="${1:-runtime-e2e}"
+
+if [ ! -d "$SCAN_DIR" ]; then
+  echo "lint-no-mocks: $SCAN_DIR not present, nothing to scan."
+  exit 0
+fi
+
+# Forbidden patterns. Each one represents a way to fake a runtime response.
+# Add to this list as new mock libraries arrive in the codebase.
+PATTERNS=(
+  'mockFetch'                    # jest fetch mock
+  'jest\.mock'                   # jest module mock
+  'jest\.fn'                     # jest stub
+  'sinon\.stub'                  # sinon test double
+  'unittest\.mock'               # python stdlib mock
+  'MagicMock'                    # python mock class
+  'httpx_mock\.add_response'     # python httpx mock
+  'wiremock'                     # java/jvm wiremock
+  'WireMockServer'               # wiremock builder
+  'stubFor'                      # wiremock stub
+  'httptest\.NewServer'          # go httptest stub server
+  'capture-stub\.py'             # local capture harness
+  'fixture-server'               # generic fixture server
+  'msw\.setupServer'             # jsdom mock service worker
+  'nock\.'                       # nock http stubs (node)
+)
+
+EXIT=0
+COUNT=0
+
+# Build a regex from PATTERNS; escape literal dots already in the pattern source
+REGEX=$(IFS='|'; echo "${PATTERNS[*]}")
+
+# Use plain grep -r so we catch untracked files too (CI sees tracked PR
+# content, but local dev/pre-commit may run against new files not yet added).
+matches=$(grep -rnE "$REGEX" "$SCAN_DIR" 2>/dev/null || true)
+
+if [ -z "$matches" ]; then
+  echo "lint-no-mocks: $SCAN_DIR is clean (no forbidden mock patterns found)."
+  exit 0
+fi
+
+# Filter out lines explicitly allowed via the inline marker.
+while IFS= read -r line; do
+  file=$(echo "$line" | cut -d: -f1)
+  if [ -n "$file" ] && grep -q "allow-mocks-here:" "$file" 2>/dev/null; then
+    continue
+  fi
+  echo "  $line"
+  COUNT=$((COUNT + 1))
+  EXIT=1
+done <<< "$matches"
+
+if [ "$EXIT" -ne 0 ]; then
+  echo ""
+  echo "lint-no-mocks: $COUNT forbidden mock-pattern hit(s) in $SCAN_DIR." >&2
+  echo "" >&2
+  echo "Per CLAUDE.md HARD RULE #0, runtime-e2e/ tests MUST hit a real endpoint." >&2
+  echo "Mocks, stubs, fixture-servers, and capture harnesses do NOT count as" >&2
+  echo "runtime proof. The runtime-e2e/ test for a feature must invoke the" >&2
+  echo "feature through its actual user-facing surface (host CLI tool/skill," >&2
+  echo "real SDK fetch to a running agent, etc.)." >&2
+  echo "" >&2
+  echo "If a specific test legitimately needs a stub (rare — usually means" >&2
+  echo "it's not actually a runtime test and belongs elsewhere), add a" >&2
+  echo "  # allow-mocks-here: <reason>" >&2
+  echo "comment on the line and a reviewer must explicitly approve it." >&2
+fi
+
+exit "$EXIT"


### PR DESCRIPTION
## Summary

Adds the mechanical CI gate that backs CLAUDE.md HARD RULE #0 (runtime
proof is definition of done) to `axonflow-sdk-typescript`. Mirrors the
pilot at axonflow-claude-plugin#59 plus the openclaw, cursor, and codex
follow-ups (#101 / #48 / #48 respectively). One of four SDK
counterparts; the Go, Python, and Java SDKs are landing the same shape
in parallel.

## What landed

- **`scripts/lint-no-mocks-in-runtime-e2e.sh`** — greps `runtime-e2e/`
  for forbidden mock-pattern strings (`mockFetch`, `jest.mock`,
  `jest.fn`, `msw.setupServer`, `nock.`, `sinon.stub`,
  `httptest.NewServer`, `MagicMock`, `unittest.mock`,
  `httpx_mock.add_response`, `wiremock`, `WireMockServer`, `stubFor`,
  `capture-stub.py`, `fixture-server`). Files can opt out per-line via
  an `allow-mocks-here: <reason>` comment.
- **`.github/workflows/definition-of-done.yml`** — `pull_request` gate
  that:
  1. Runs the lint above.
  2. Detects whether the PR touches the SDK's user-facing surface —
     `src/` (the published source compiled to `dist/`), `package.json`
     (entry points + exports map), and `examples/` (consumer-facing
     wiring programs).
  3. If user-facing surface changed and `runtime-e2e/` was not also
     touched in the same PR, blocks the merge unless the PR title
     contains `[skip-runtime-e2e]` AND the body has a
     `## Skip-runtime-e2e justification` section.
- **`runtime-e2e/` scaffold** — README documenting the convention and
  a seed test under `runtime-e2e/x-axonflow-client/test.mjs` that
  imports from the compiled `dist/esm/index.js`, wires a real
  `globalThis.fetch`, and asserts the agent's scope-mismatch response
  echoes `X-Axonflow-Client: sdk-typescript/<VERSION>` — proving that
  the SDK actually emits the header on the wire (no mocks). The test
  is shaped to be invoked from a runner; CI wiring is follow-up work.

## Why this exists

The 2026-05-05 X-Axonflow-Client incident proved that mocks-only test
evidence at PR-merge time hides silently-broken features. Two of the
bonus fixes shipped on mock evidence were verified non-functional only
after live runtime testing 2 hours after merge. CLAUDE.md HARD RULE #0
now says runtime proof is definition of done; this PR is the
mechanical gate that backs that rule on the TypeScript SDK side.

## Skip-runtime-e2e justification

This PR is internal-infra-only — it adds the lint, the gate, and
seed scaffolding. Nothing under `src/`, `package.json`, or `examples/`
changes. The seed test under `runtime-e2e/x-axonflow-client/test.mjs`
is itself a real-stack runtime test (no mocks); it just isn't wired
to a CI live-agent job in this PR. So there is no user-facing
SDK behavior change to runtime-prove here.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/definition-of-done.yml'))"` parses cleanly
- [x] `./scripts/lint-no-mocks-in-runtime-e2e.sh` exits 0 (clean) on this branch
- [x] DCO sign-off present (`Signed-off-by:` trailer on the commit)
- [ ] CI green on this PR — definition-of-done job self-passes via the `[skip-runtime-e2e]` escape hatch + justification section above
- [ ] Follow-up: wire `runtime-e2e/x-axonflow-client/test.mjs` into a live-agent CI job (separate PR; needs registered tenant + plugin-aud token in CI secrets)