### PR TITLE
fix(release): correct SDK version v7.7.0 → v7.1.0 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.7.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
+## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The TypeScript SDK now sends an
 `X-Axonflow-Client` identification header on every governed request, which
@@ -24,7 +24,7 @@ license token's audience claim per the ADR-050 license matrix.
 ### Compatibility
 
 - **No public API changes.** Existing v7.0.x callers
-  `npm install @axonflow/sdk@^7.7.0` and rebuild against v7.7.0 with no
+  `npm install @axonflow/sdk@^7.1.0` and rebuild against v7.1.0 with no
   source changes.
 - **Backward-compatible against pre-v7.7.0 agents.** The header is
   silently dropped by older agents; the SDK behaves identically against
@@ -38,8 +38,8 @@ license token's audience claim per the ADR-050 license matrix.
 - **Platform v7.7.0** — V1 SaaS Plugin Pro launch, license matrix,
   per-tenant tier resolution, GDPR right-to-erasure
   ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
-- **Go SDK v7.7.0** / **Python SDK v7.7.0** /
-  **Java SDK v7.7.0** — same `X-Axonflow-Client` injection
+- **Go SDK v7.1.0** / **Python SDK v7.1.0** /
+  **Java SDK v7.1.0** — same `X-Axonflow-Client` injection
 - **Plugins** — Claude Code / Cursor / Codex v1.2.0; OpenClaw v2.2.0
   with Pro license token paste activating Pro features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "7.7.0",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "7.7.0",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "7.7.0",
+  "version": "7.1.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '7.7.0';
+export const VERSION = '7.1.0';


### PR DESCRIPTION
Companion to fixes axonflow-sdk-go#156 + axonflow-sdk-python#183. Previous release PR #214 bumped 7.0.0 → 7.7.0 (platform-align). Wrong semver — only one substantive feature since v7.0.0 (X-Axonflow-Client header injection #212), so natural bump is v7.1.0.

## Changes
- `package.json` + auto-stamped `src/version.ts` + `package-lock.json` 7.7.0 → 7.1.0
- CHANGELOG header `[7.7.0]` → `[7.1.0]` (2026-05-06 preserved)
- Sister SDK refs (Go / Python / Java) updated to v7.1.0
- Platform v7.7.0 refs kept (those are correctly the platform version)

## Skip-runtime-e2e justification

Version-correction only — no code behavior change. The X-Axonflow-Client header runtime contract was validated when #212 landed and re-confirmed when #214 merged. This PR only fixes the version string from the incorrect v7.7.0 to the semver-correct v7.1.0.