### PR TITLE
docs(telemetry): scope AXONFLOW_TELEMETRY=off to its actual data layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,10 @@ const axonflow = new AxonFlow({
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
 No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
 
+### Scope of `AXONFLOW_TELEMETRY=off`
+
+`AXONFLOW_TELEMETRY=off` disables the anonymous SDK heartbeat (version, OS, architecture). On **self-hosted** and **in-VPC** deployments, that heartbeat is the only data the SDK sends to AxonFlow, so setting `=off` means we receive nothing. On **Community SaaS** (`try.getaxonflow.com`) the hosted service also processes operational data — registrations, audit logs, policy enforcement records, workflow state, plan data, and request-header metadata aggregated for usage analytics — as part of running the platform; that operational data flow is governed by the [Privacy Policy](https://getaxonflow.com/privacy/), not by `AXONFLOW_TELEMETRY`.
+
 `DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
 
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.


### PR DESCRIPTION
## Summary
Adds a "Scope of \`AXONFLOW_TELEMETRY=off\`" subsection clarifying the flag's actual reach: heartbeat opt-out on self-hosted / in-VPC (where it's the only SDK data path), separate from the operational data Community SaaS processes as part of running the hosted service.

## Coordinated rollout
Same canonical wording landing across 11 repos as separate PRs (5 SDK READMEs, 4 plugin READMEs, axonflow-enterprise multi-file, axonflow-docs multi-file, axonflow-landing privacy.html long form).

## Test plan
- [x] Self-reviewed every hunk per HARD RULE #1 5-question protocol — single hunk, content matches commit msg, URLs valid (`https://docs.getaxonflow.com/docs/telemetry`, `https://getaxonflow.com/privacy/`), accurate scope description, customer-shippable copy.
- README markdown only.

## NOT MERGE — user review pending
Per primary-session direction.