### PR TITLE
docs(examples): add explain-decision example [skip-runtime-e2e]

### DIFF
--- a/examples/explain-decision/index.ts
+++ b/examples/explain-decision/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Example: explain a previously-made AxonFlow policy decision.
+ *
+ * Implements the ADR-043 explainability flow. Given a decision_id (typically
+ * surfaced on the response of a blocked governed call, an audit_logs row, or
+ * the `explain_decision` MCP tool), this example fetches the structured
+ * explanation and renders the matched policies, risk level, and override
+ * availability.
+ *
+ * Required env vars:
+ *   AXONFLOW_AGENT_URL          (default: http://localhost:8080)
+ *   AXONFLOW_CLIENT_ID          (default: community)
+ *   AXONFLOW_CLIENT_SECRET      (default: empty)
+ *   AXONFLOW_DECISION_ID        the decision to explain
+ *
+ * Get a decision_id quickly by hitting a known-blocked policy:
+ *
+ *   curl -u "$AXONFLOW_CLIENT_ID:$AXONFLOW_CLIENT_SECRET" \
+ *        -X POST $AXONFLOW_AGENT_URL/api/v1/mcp/check-input \
+ *        -H 'Content-Type: application/json' \
+ *        -d '{"connector_type":"postgres","operation":"execute",
+ *             "statement":"SELECT 1; DROP TABLE users;--","user_token":"u1"}'
+ *
+ * then read decision_id from the block response or the most recent audit row.
+ *
+ * Run: npx tsx examples/explain-decision/index.ts
+ */
+
+import { AxonFlow } from '@axonflow/sdk';
+
+async function main() {
+  const decisionId = process.env.AXONFLOW_DECISION_ID;
+  if (!decisionId) {
+    console.error(
+      'AXONFLOW_DECISION_ID must be set (a decision_id from a recent blocked call)',
+    );
+    process.exit(2);
+  }
+
+  const agentURL = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+  const clientId = process.env.AXONFLOW_CLIENT_ID || 'community';
+  const clientSecret = process.env.AXONFLOW_CLIENT_SECRET || '';
+
+  console.log(`Initializing AxonFlow client at ${agentURL}...`);
+  const client = new AxonFlow({
+    clientId,
+    clientSecret,
+    endpoint: agentURL,
+  });
+
+  console.log(`Explaining decision ${decisionId}...\n`);
+  const exp = await client.explainDecision(decisionId);
+
+  console.log('=== Decision Explanation ===');
+  console.log(`  decision_id: ${exp.decisionId}`);
+  console.log(`  timestamp:   ${exp.timestamp.toISOString()}`);
+  console.log(`  decision:    ${exp.decision}`);
+  console.log(`  reason:      ${exp.reason}`);
+  if (exp.riskLevel) console.log(`  risk_level:  ${exp.riskLevel}`);
+  if (exp.toolSignature) console.log(`  tool:        ${exp.toolSignature}`);
+
+  console.log(`\n  policy_matches (${exp.policyMatches.length}):`);
+  exp.policyMatches.forEach((m, i) => {
+    const name = m.policyName || '(unnamed)';
+    const action = m.action || '-';
+    const risk = m.riskLevel || '-';
+    console.log(
+      `    [${i}] ${m.policyId} (${name}) — action=${action} risk=${risk} allow_override=${!!m.allowOverride}`,
+    );
+  });
+
+  if (exp.matchedRules && exp.matchedRules.length > 0) {
+    console.log(`\n  matched_rules (${exp.matchedRules.length}):`);
+    for (const r of exp.matchedRules) {
+      const ruleId = r.ruleId || '(no rule id)';
+      const matchedOn = r.matchedOn || '-';
+      console.log(`    ${r.policyId} on ${ruleId}: matched=${matchedOn}`);
+    }
+  }
+
+  console.log(`\n  override_available:           ${exp.overrideAvailable}`);
+  if (exp.overrideExistingId) {
+    console.log(`  override_existing_id:         ${exp.overrideExistingId}`);
+  }
+  console.log(
+    `  historical_hit_count_session: ${exp.historicalHitCountSession}`,
+  );
+  if (exp.policySourceLink) {
+    console.log(`  policy_source_link:           ${exp.policySourceLink}`);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes the example-parity gap: `client.explainDecision()` shipped in April but no runnable example existed. Mirror the Rust SDK pattern (axonflow-sdk-rust#29 / commit `2360282`) so a caller can copy a complete demo without reading the SDK source.

## Scope

- New `examples/explain-decision/index.ts` (sibling of `examples/basic/`).
- Reads `AXONFLOW_DECISION_ID` from env, calls `await client.explainDecision(...)`, prints every ADR-043 field: matched policies, matched rules, decision, reason, risk level, override availability, historical hit count.
- Defaults `AXONFLOW_CLIENT_ID` to `community`.

## Three-rule definition of done

**Rule 0 — Runtime proof.** Live run against the local community stack at `localhost:8080` (agent v7.7.0 / orchestrator v7.7.0):

Step 1 — trigger a real decision via curl (yields `decision_id=7a4876eb-3fd5-4467-a412-b0b42833e165`, policy `sys_sqli_drop_table`, risk `critical`).

Step 2:
\`\`\`bash
AXONFLOW_AGENT_URL=http://localhost:8080 \\
AXONFLOW_CLIENT_ID=community \\
AXONFLOW_CLIENT_SECRET="" \\
AXONFLOW_DECISION_ID=7a4876eb-3fd5-4467-a412-b0b42833e165 \\
npx tsx examples/explain-decision/index.ts
\`\`\`

Output:
\`\`\`
Initializing AxonFlow client at http://localhost:8080...
Explaining decision 7a4876eb-3fd5-4467-a412-b0b42833e165...

=== Decision Explanation ===
  decision_id: 7a4876eb-3fd5-4467-a412-b0b42833e165
  timestamp:   2026-05-07T12:16:36.779Z
  decision:    deny
  reason:      Detects DROP TABLE statement
  risk_level:  critical

  policy_matches (1):
    [0] sys_sqli_drop_table (DROP TABLE Statement) — action=- risk=critical allow_override=false

  override_available:           false
  historical_hit_count_session: 0
\`\`\`

**Rule 1 — Self-review.** Hunk-by-hunk:
- Field accesses match \`src/types/decisions.ts\` exactly (camelCase per the SDK's parsing layer): \`decisionId\`, \`timestamp\`, \`decision\`, \`reason\`, \`riskLevel\`, \`toolSignature\`, \`policyMatches[{policyId, policyName, action, riskLevel, allowOverride}]\`, \`matchedRules\`, \`overrideAvailable\`, \`overrideExistingId\`, \`historicalHitCountSession\`, \`policySourceLink\`. ✓
- Optional fields guarded by truthy checks before printing. ✓
- \`matchedRules\` typed as optional array; the \`if exp.matchedRules && exp.matchedRules.length > 0\` guard handles both undefined and empty correctly. ✓

**Rule 2 — No deferred bugs.** None found in path. The example runs cleanly against the v7.7.0 platform.

## ⛔ Do not merge — V1.1 release window

Per the \`feedback_v1_1_no_merge_during_release_window.md\` guideline.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).