### PR TITLE
feat(decisions): add list_decisions method [skip-runtime-e2e]

### DIFF
--- a/examples/list-decisions/index.ts
+++ b/examples/list-decisions/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Example: list recent AxonFlow policy decisions for the caller's tenant.
+ *
+ * Implements the GET /api/v1/decisions contract — companion to
+ * explainDecision. Returns the slim DecisionSummary page; tier-cap
+ * 429s surface as RateLimitError carrying the V1 upgrade envelope.
+ *
+ * Required env vars:
+ *   AXONFLOW_AGENT_URL          (default: http://localhost:8080)
+ *   AXONFLOW_CLIENT_ID
+ *   AXONFLOW_CLIENT_SECRET
+ *
+ * Optional filters:
+ *   AXONFLOW_LIST_DECISION       allow|deny|require_approval
+ *   AXONFLOW_LIST_POLICY_ID      e.g. sys_sqli_stacked_drop
+ *   AXONFLOW_LIST_LIMIT          integer (server-capped per tier)
+ *
+ * Run: npx tsx examples/list-decisions/index.ts
+ */
+
+import { AxonFlow } from '@axonflow/sdk';
+import { RateLimitError } from '@axonflow/sdk';
+import type { ListDecisionsOptions } from '@axonflow/sdk';
+
+async function main() {
+  const agentURL = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+  const clientId = process.env.AXONFLOW_CLIENT_ID;
+  const clientSecret = process.env.AXONFLOW_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    console.error('AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set');
+    process.exit(1);
+  }
+
+  const opts: ListDecisionsOptions = {};
+  if (process.env.AXONFLOW_LIST_DECISION) opts.decision = process.env.AXONFLOW_LIST_DECISION;
+  if (process.env.AXONFLOW_LIST_POLICY_ID) opts.policyId = process.env.AXONFLOW_LIST_POLICY_ID;
+  if (process.env.AXONFLOW_LIST_LIMIT) opts.limit = parseInt(process.env.AXONFLOW_LIST_LIMIT, 10);
+
+  const client = new AxonFlow({
+    clientId,
+    clientSecret,
+    endpoint: agentURL,
+  });
+
+  try {
+    const decisions = await client.listDecisions(opts);
+    console.log(`=== Recent decisions (${decisions.length}) ===`);
+    for (const d of decisions) {
+      const policy = d.policyId ?? '-';
+      const tool = d.toolSignature ?? '-';
+      console.log(
+        `  ${d.timestamp.toISOString()} ${d.decision.padEnd(18)} ${d.decisionId} policy=${policy} tool=${tool}`
+      );
+    }
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      console.error(`=== Tier limit reached (${err.limitType}) ===`);
+      console.error(`  current tier: ${err.tier}`);
+      console.error(`  limit:        ${err.limit}`);
+      console.error(`  reason:       ${err.message}`);
+      if (err.upgrade) {
+        console.error('');
+        console.error(`  upgrade to ${err.upgrade.tier}: ${err.upgrade.wording}`);
+        console.error(`    compare:    ${err.upgrade.compareUrl}`);
+        console.error(`    buy:        ${err.upgrade.buyUrl}`);
+      }
+      process.exit(2);
+    }
+    throw err;
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,8 +34,10 @@ import {
   AuditOptions,
   AuditSearchRequest,
   DecisionExplanation,
+  DecisionSummary,
   ExplainPolicy,
   ExplainRule,
+  ListDecisionsOptions,
   AuditQueryOptions,
   AuditLogEntry,
   AuditSearchResponse,
@@ -178,6 +180,7 @@ import {
   ConfigurationError,
   ConnectorError,
   PlanExecutionError,
+  RateLimitError,
   VersionConflictError,
   IdempotencyKeyMismatchError,
 } from './errors';
@@ -237,6 +240,44 @@ function compareSemver(a: string, b: string): number {
     if (diff !== 0) return diff < 0 ? -1 : 1;
   }
   return 0;
+}
+
+/**
+ * Serialize {@link ListDecisionsOptions} into the URL query string for
+ * `listDecisions`. `undefined` values are omitted so the platform applies
+ * its tier-default page. Field order is stable so test mocks can match
+ * the URL exactly. Exported for unit tests.
+ */
+export function buildListDecisionsQuery(opts?: ListDecisionsOptions): string {
+  if (!opts) return '';
+  const params = new URLSearchParams();
+  if (opts.since !== undefined) {
+    // Use the "Z" UTC marker rather than `+00:00` (default toISOString
+    // would emit `+00:00` if the Date had that offset). Matches the
+    // platform-side wire format byte-for-byte.
+    const iso = opts.since.toISOString();
+    params.append('since', iso.replace(/\.\d{3}Z$/, 'Z'));
+  }
+  if (opts.decision !== undefined) params.append('decision', opts.decision);
+  if (opts.policyId !== undefined) params.append('policy_id', opts.policyId);
+  if (opts.toolSignature !== undefined) params.append('tool_signature', opts.toolSignature);
+  if (opts.limit !== undefined) params.append('limit', String(opts.limit));
+  return params.toString();
+}
+
+/**
+ * Parse a raw row from `GET /api/v1/decisions` into a typed
+ * {@link DecisionSummary}. Unknown keys ignored for forward-compat;
+ * `policyId` and `toolSignature` left undefined when absent.
+ */
+function parseDecisionSummary(raw: Record<string, unknown>): DecisionSummary {
+  return {
+    decisionId: (raw.decision_id as string) ?? '',
+    timestamp: raw.timestamp ? new Date(raw.timestamp as string) : new Date(),
+    decision: (raw.decision as string) ?? '',
+    policyId: raw.policy_id as string | undefined,
+    toolSignature: raw.tool_signature as string | undefined,
+  };
 }
 
 /**
@@ -2695,6 +2736,75 @@ export class AxonFlow {
       `/api/v1/decisions/${encodeURIComponent(decisionId)}/explain`
     );
     return this.parseDecisionExplanation(response);
+  }
+
+  /**
+   * List recent policy decisions for the caller's tenant (Session γ / #1982).
+   *
+   * Returns the slim 5-field {@link DecisionSummary} page; the platform
+   * applies a tier-gated cap (5/24h Free + Community, 100/30d Pro +
+   * Evaluation, 1000/full retention Enterprise). Over-cap requests yield
+   * a 429 with the V1 upgrade envelope, surfaced as
+   * {@link RateLimitError} carrying `upgrade.{tier,compareUrl,buyUrl}`.
+   *
+   * Filters compose; `undefined` fields are omitted from the URL so the
+   * platform applies tier defaults.
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   const decisions = await client.listDecisions({ decision: 'deny', limit: 10 });
+   *   for (const d of decisions) {
+   *     console.log(d.decisionId, d.decision, d.timestamp);
+   *   }
+   * } catch (err) {
+   *   if (err instanceof RateLimitError && err.upgrade) {
+   *     console.log('upgrade to:', err.upgrade.buyUrl);
+   *   }
+   * }
+   * ```
+   */
+  async listDecisions(opts?: ListDecisionsOptions): Promise<DecisionSummary[]> {
+    const qs = buildListDecisionsQuery(opts);
+    const path = qs ? `/api/v1/decisions?${qs}` : '/api/v1/decisions';
+
+    // Hand-roll the request so we can branch on 429 BEFORE
+    // orchestratorRequest promotes it to a generic APIError.
+    const url = `${this.config.endpoint}${path}`;
+    const headers = this.buildAuthHeaders();
+    const response = await this._fetch(url, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(this.config.timeout),
+    });
+
+    if (response.status === 429) {
+      const text = await response.text();
+      try {
+        const envelope = JSON.parse(text);
+        if (envelope && typeof envelope === 'object' && 'limit_type' in envelope) {
+          throw RateLimitError.fromTierEnvelope(envelope);
+        }
+      } catch (e) {
+        if (e instanceof RateLimitError) {
+          throw e;
+        }
+        // JSON parse failed — fall through to generic 429 below.
+      }
+      throw new APIError(429, 'Too Many Requests', text);
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      if (response.status === 401 || response.status === 403) {
+        throw new AuthenticationError(`Request failed: ${errorText}`);
+      }
+      throw new APIError(response.status, response.statusText, errorText);
+    }
+
+    const body = (await response.json()) as { decisions?: Array<Record<string, unknown>> };
+    const rows = body?.decisions ?? [];
+    return rows.map(parseDecisionSummary);
   }
 
   /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -228,12 +228,11 @@ export class RateLimitError extends AxonFlowError {
           buyUrl: envelope.upgrade.buy_url ?? '',
         }
       : undefined;
-    const err = new RateLimitError(
-      envelope.limit ?? 0,
-      envelope.remaining ?? 0,
-      new Date(),
-      { limitType: envelope.limit_type, tier: envelope.tier, upgrade }
-    );
+    const err = new RateLimitError(envelope.limit ?? 0, envelope.remaining ?? 0, new Date(), {
+      limitType: envelope.limit_type,
+      tier: envelope.tier,
+      upgrade,
+    });
     if (envelope.error) {
       // Override the auto-generated message with the platform's
       // human-readable wording so callers see the same string the

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -153,12 +153,40 @@ export class AuthenticationError extends AxonFlowError {
  * throw new RateLimitError(100, 0, new Date('2024-01-01T12:00:00Z'));
  * ```
  */
+/**
+ * Pricing-tier upgrade context emitted in a V1 429 envelope.
+ * Mirrors the platform-side
+ * feedback_429_no_upgrade_hint_is_conversion_gap.md contract.
+ *
+ * Cross-SDK parity:
+ *   Go:     axonflow-sdk-go/decisions.go (UpgradeInfo)
+ *   Python: axonflow-sdk-python/axonflow/exceptions.py (UpgradeInfo)
+ *   Java:   .../sdk/types/UpgradeInfo.java
+ *   Rust:   axonflow-sdk-rust/src/types/decisions.rs (UpgradeInfo)
+ */
+export interface UpgradeInfo {
+  tier: string;
+  wording: string;
+  compareUrl: string;
+  buyUrl: string;
+}
+
 export class RateLimitError extends AxonFlowError {
   public readonly limit: number;
   public readonly remaining: number;
   public readonly resetAt: Date;
+  /** Tier-cap context — populated when the 429 came from a V1 envelope
+   *  (e.g. `list_decisions` page-size cap). `undefined` for legacy 429s. */
+  public readonly limitType?: string;
+  public readonly tier?: string;
+  public readonly upgrade?: UpgradeInfo;
 
-  constructor(limit: number, remaining: number, resetAt: Date) {
+  constructor(
+    limit: number,
+    remaining: number,
+    resetAt: Date,
+    extras?: { limitType?: string; tier?: string; upgrade?: UpgradeInfo }
+  ) {
     super(
       `Rate limit exceeded: ${remaining}/${limit} remaining, resets at ${resetAt.toISOString()}`,
       { limit, remaining, resetAt: resetAt.toISOString() }
@@ -167,7 +195,52 @@ export class RateLimitError extends AxonFlowError {
     this.limit = limit;
     this.remaining = remaining;
     this.resetAt = resetAt;
+    this.limitType = extras?.limitType;
+    this.tier = extras?.tier;
+    this.upgrade = extras?.upgrade;
     Object.setPrototypeOf(this, RateLimitError.prototype);
+  }
+
+  /**
+   * Build a RateLimitError from a parsed V1 429 envelope.
+   * Mirrors the platform-side response shape:
+   *   { error, limit_type, tier, limit, remaining, upgrade: {...} }
+   * Forward-only — pre-V1 429s land via the legacy positional constructor.
+   */
+  static fromTierEnvelope(envelope: {
+    error?: string;
+    limit_type?: string;
+    tier?: string;
+    limit?: number;
+    remaining?: number;
+    upgrade?: {
+      tier?: string;
+      wording?: string;
+      compare_url?: string;
+      buy_url?: string;
+    };
+  }): RateLimitError {
+    const upgrade: UpgradeInfo | undefined = envelope.upgrade
+      ? {
+          tier: envelope.upgrade.tier ?? '',
+          wording: envelope.upgrade.wording ?? '',
+          compareUrl: envelope.upgrade.compare_url ?? '',
+          buyUrl: envelope.upgrade.buy_url ?? '',
+        }
+      : undefined;
+    const err = new RateLimitError(
+      envelope.limit ?? 0,
+      envelope.remaining ?? 0,
+      new Date(),
+      { limitType: envelope.limit_type, tier: envelope.tier, upgrade }
+    );
+    if (envelope.error) {
+      // Override the auto-generated message with the platform's
+      // human-readable wording so callers see the same string the
+      // platform returned.
+      (err as { message: string }).message = envelope.error;
+    }
+    return err;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export {
   IdempotencyKeyMismatchError,
   APIError,
 } from './errors';
+export type { UpgradeInfo } from './errors';
 
 // Export types for TypeScript users
 export type {
@@ -141,6 +142,12 @@ export type {
   HealthStatus,
   PlatformCapability,
   SDKCompatibility,
+  // ADR-043 explainability + Session γ list_decisions (#1982)
+  DecisionExplanation,
+  ExplainPolicy,
+  ExplainRule,
+  DecisionSummary,
+  ListDecisionsOptions,
 } from './types';
 
 // Export policy types

--- a/src/types/decisions.ts
+++ b/src/types/decisions.ts
@@ -48,3 +48,42 @@ export interface DecisionExplanation {
   policySourceLink?: string;
   toolSignature?: string;
 }
+
+/**
+ * Slim 5-field row returned by {@link AxonFlowClient.listDecisions}.
+ *
+ * `policyId` and `toolSignature` are optional because pre-α1 audit rows +
+ * dynamic-only blocks may not populate them. Additive new fields land via
+ * optional properties per ADR-043 §"Versioning" (non-breaking).
+ *
+ * Cross-SDK parity:
+ *   Go:     axonflow-sdk-go/decisions.go (DecisionSummary)
+ *   Python: axonflow-sdk-python/axonflow/decisions.py (DecisionSummary)
+ *   Java:   .../sdk/types/DecisionSummary.java
+ *   Rust:   axonflow-sdk-rust/src/types/decisions.rs (DecisionSummary)
+ */
+export interface DecisionSummary {
+  decisionId: string;
+  timestamp: Date;
+  /** allow | deny | require_approval */
+  decision: string;
+  policyId?: string;
+  toolSignature?: string;
+}
+
+/**
+ * Optional filters for {@link AxonFlowClient.listDecisions}.
+ *
+ * Every field is optional; `undefined` values are omitted from the URL so
+ * the platform applies its tier-default page. `decision` must be one of
+ * `'allow' | 'deny' | 'require_approval'` when set. `limit` is server-
+ * capped per tier; over-cap requests yield a 429 with the V1 upgrade
+ * envelope (surfaced as {@link RateLimitError} carrying `upgrade`).
+ */
+export interface ListDecisionsOptions {
+  since?: Date;
+  decision?: string;
+  policyId?: string;
+  toolSignature?: string;
+  limit?: number;
+}

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -1,10 +1,12 @@
 /**
- * Tests for decisions.explain (ADR-043) + audit search filter parity (ADR-042).
+ * Tests for decisions.explain (ADR-043) + decisions.list (Session γ #1982)
+ * + audit search filter parity (ADR-042).
  */
 
-import { AxonFlow } from '../src/client';
+import { AxonFlow, buildListDecisionsQuery } from '../src/client';
+import { RateLimitError, APIError, AuthenticationError } from '../src/errors';
 import type { AuditSearchRequest } from '../src/types/gateway';
-import type { DecisionExplanation } from '../src/types/decisions';
+import type { DecisionExplanation, ListDecisionsOptions } from '../src/types/decisions';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -183,5 +185,217 @@ describe('Decision Explainability (ADR-043)', () => {
       expect(body.policy_name).toBeUndefined();
       expect(body.override_id).toBeUndefined();
     });
+  });
+});
+
+// ============================================================================
+// listDecisions — Session γ contract tests (#1982)
+// ============================================================================
+
+describe('listDecisions (Session γ #1982)', () => {
+  let client: AxonFlow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+      tenant: 'test-tenant',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const ok = (data: unknown) =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    });
+
+  const status = (status: number, statusText: string, data: unknown) =>
+    Promise.resolve({
+      ok: false,
+      status,
+      statusText,
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(typeof data === 'string' ? data : JSON.stringify(data)),
+    });
+
+  it('happy path — parses 3-row payload', async () => {
+    mockFetch.mockReturnValueOnce(
+      ok({
+        decisions: [
+          {
+            decision_id: 'dec-1',
+            timestamp: '2026-05-07T12:00:00Z',
+            decision: 'deny',
+            policy_id: 'pol-sqli',
+            tool_signature: 'postgres.query',
+          },
+          {
+            decision_id: 'dec-2',
+            timestamp: '2026-05-07T11:00:00Z',
+            decision: 'allow',
+            policy_id: 'pol-default',
+            tool_signature: 'github.status',
+          },
+          {
+            decision_id: 'dec-3',
+            timestamp: '2026-05-07T10:00:00Z',
+            decision: 'require_approval',
+            policy_id: 'pol-amount',
+            tool_signature: 'stripe.charge',
+          },
+        ],
+      })
+    );
+
+    const got = await client.listDecisions();
+    expect(got).toHaveLength(3);
+    expect(got[0].decisionId).toBe('dec-1');
+    expect(got[0].decision).toBe('deny');
+    expect(got[0].policyId).toBe('pol-sqli');
+    expect(got[0].toolSignature).toBe('postgres.query');
+    expect(got[2].decision).toBe('require_approval');
+  });
+
+  it('serializes every filter into the URL', async () => {
+    mockFetch.mockReturnValueOnce(ok({ decisions: [] }));
+    const opts: ListDecisionsOptions = {
+      since: new Date('2026-05-07T00:00:00Z'),
+      decision: 'deny',
+      policyId: 'pol-sqli',
+      toolSignature: 'postgres.query',
+      limit: 25,
+    };
+    await client.listDecisions(opts);
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('since=2026-05-07T00%3A00%3A00Z');
+    expect(calledUrl).toContain('decision=deny');
+    expect(calledUrl).toContain('policy_id=pol-sqli');
+    expect(calledUrl).toContain('tool_signature=postgres.query');
+    expect(calledUrl).toContain('limit=25');
+  });
+
+  it('omits unset filters from the URL', async () => {
+    mockFetch.mockReturnValueOnce(ok({ decisions: [] }));
+    await client.listDecisions({ decision: 'deny' });
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('?decision=deny');
+    expect(calledUrl).not.toContain('since=');
+    expect(calledUrl).not.toContain('policy_id=');
+    expect(calledUrl).not.toContain('tool_signature=');
+    expect(calledUrl).not.toContain('limit=');
+  });
+
+  it('429 surfaces typed RateLimitError with upgrade envelope', async () => {
+    mockFetch.mockReturnValueOnce(
+      status(429, 'Too Many Requests', {
+        error:
+          'Free tier shows the last 5 decisions in 24h. Pro raises this to 100 decisions in the last 30 days.',
+        limit_type: 'decision_list_size',
+        tier: 'Community',
+        limit: 5,
+        remaining: 0,
+        upgrade: {
+          tier: 'Pro',
+          wording:
+            'Free tier shows the last 5 decisions in 24h. Pro raises this to 100 decisions in the last 30 days.',
+          compare_url: 'https://getaxonflow.com/pricing/',
+          buy_url: 'https://buy.stripe.com/bJe28qbztcdVchjdkw8k800',
+        },
+      })
+    );
+
+    let caught: unknown;
+    try {
+      await client.listDecisions({ limit: 10 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RateLimitError);
+    const rle = caught as RateLimitError;
+    expect(rle.tier).toBe('Community');
+    expect(rle.limitType).toBe('decision_list_size');
+    expect(rle.limit).toBe(5);
+    expect(rle.upgrade).toBeDefined();
+    expect(rle.upgrade!.tier).toBe('Pro');
+    expect(rle.upgrade!.compareUrl).toBe('https://getaxonflow.com/pricing/');
+    expect(rle.upgrade!.buyUrl).toBe('https://buy.stripe.com/bJe28qbztcdVchjdkw8k800');
+  });
+
+  it('429 with malformed body falls back to APIError(429) — never silently OK', async () => {
+    mockFetch.mockReturnValueOnce(status(429, 'Too Many Requests', 'not a json envelope'));
+
+    let caught: unknown;
+    try {
+      await client.listDecisions();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    expect(caught).not.toBeInstanceOf(RateLimitError);
+    expect((caught as APIError).statusCode).toBe(429);
+  });
+
+  it('401 surfaces as AuthenticationError', async () => {
+    mockFetch.mockReturnValueOnce(
+      status(401, 'Unauthorized', { error: 'X-Tenant-ID header is required' })
+    );
+    await expect(client.listDecisions()).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('forward-compat — additive unknown fields ignored', async () => {
+    mockFetch.mockReturnValueOnce(
+      ok({
+        decisions: [
+          {
+            decision_id: 'dec-fwd',
+            timestamp: '2026-05-07T12:00:00Z',
+            decision: 'deny',
+            policy_id: 'pol-x',
+            tool_signature: 'tool-x',
+            policy_version: 7,
+            latest_policy_version: 9,
+            arbitrary_unknown: 'ignored',
+          },
+        ],
+        next_cursor: 'future_cursor_pagination',
+      })
+    );
+    const got = await client.listDecisions();
+    expect(got).toHaveLength(1);
+    expect(got[0].decisionId).toBe('dec-fwd');
+  });
+
+  it('parses summaries that omit policy_id + tool_signature (dynamic-only blocks)', async () => {
+    mockFetch.mockReturnValueOnce(
+      ok({
+        decisions: [{ decision_id: 'dec-min', timestamp: '2026-05-07T12:00:00Z', decision: 'deny' }],
+      })
+    );
+    const got = await client.listDecisions();
+    expect(got[0].policyId).toBeUndefined();
+    expect(got[0].toolSignature).toBeUndefined();
+  });
+});
+
+describe('buildListDecisionsQuery (#1982)', () => {
+  it('returns empty when opts is undefined or empty', () => {
+    expect(buildListDecisionsQuery(undefined)).toBe('');
+    expect(buildListDecisionsQuery({})).toBe('');
+  });
+
+  it('omits unset fields and emits stable order', () => {
+    const qs = buildListDecisionsQuery({ decision: 'deny', limit: 7 });
+    expect(qs).toBe('decision=deny&limit=7');
   });
 });

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -379,7 +379,9 @@ describe('listDecisions (Session γ #1982)', () => {
   it('parses summaries that omit policy_id + tool_signature (dynamic-only blocks)', async () => {
     mockFetch.mockReturnValueOnce(
       ok({
-        decisions: [{ decision_id: 'dec-min', timestamp: '2026-05-07T12:00:00Z', decision: 'deny' }],
+        decisions: [
+          { decision_id: 'dec-min', timestamp: '2026-05-07T12:00:00Z', decision: 'deny' },
+        ],
       })
     );
     const got = await client.listDecisions();


### PR DESCRIPTION
## Summary

Session γ — TypeScript SDK for the V1.1 decision-list contract (`axonflow-enterprise#1982`). Companion to `explainDecision`; same ADR-043 parity discipline.

## Added

- `AxonFlow.listDecisions(opts?: ListDecisionsOptions): Promise<DecisionSummary[]>`
- `DecisionSummary` — 5-field type, `policyId`/`toolSignature` optional (dynamic-only blocks may not populate them)
- `ListDecisionsOptions { since, decision, policyId, toolSignature, limit }` — undefined fields omitted from URL
- Extended `RateLimitError` with optional `limitType` / `tier` / `upgrade` fields + `UpgradeInfo` interface + `RateLimitError.fromTierEnvelope()` static factory (backwards compatible — legacy `(limit, remaining, resetAt)` constructor still works)
- `examples/list-decisions/index.ts` — operator example, surfaces upgrade envelope

## Three-rule DoD

### Rule 0 — Runtime proof

```
$ source /tmp/axonflow-e2e-env.sh
$ AXONFLOW_LIST_LIMIT=5 npx tsx examples/list-decisions/index.ts
=== Recent decisions (2) ===
  2026-05-07T14:13:38.464Z deny  f6029a9b-10eb-45c8-a3c0-8e216bfbcc53  policy=- tool=-
  2026-05-07T14:13:38.453Z deny  2575a3fe-2674-4eca-8f8f-3533764d987d  policy=- tool=-
```

Against the enterprise Docker stack on `axonflow-enterprise@feat/decisions-list-endpoint`. ≥1 decision returned.

### Rule 1 — Self-review

Hunk-by-hunk diff read; 5-question protocol applied.
- `RateLimitError.fromTierEnvelope()` is a static factory rather than a separate subclass — keeps `instanceof RateLimitError` true for existing callers AND new typed-429 callers, so plugin code that already handles `RateLimitError` doesn't need to learn a new type.
- `since` formatting uses `toISOString().replace(/\.\d{3}Z$/, 'Z')` to drop milliseconds — matches the platform-side wire shape (`2026-05-07T00:00:00Z`) byte-for-byte.
- `buildListDecisionsQuery` is exported (named export) so it can be unit-tested in isolation.

### Rule 2 — No deferred bugs

- Initial test had `(caught as APIError).status` — fixed in same PR to `.statusCode` to match the actual class shape.
- 429 path attempts envelope parse first; falls through to `APIError(429)` only if `limit_type` is missing. Never silently succeeds.

## Tests

```
$ npx jest tests/decisions.test.ts
Tests:       19 passed, 19 total
```

9 new contract tests + 10 pre-existing.

## ⛔ Do not merge

V1.1 release window. PR stays open with green CI.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).