### PR TITLE
feat!: v8.0 — decision history API + telemetry simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
+
+**Major release.** The headline feature is the new decision-history client API:
+`listDecisions` for paging through recorded decisions, plus a runnable example
+showing the full record → list → explain audit flow. Bundled into a major
+because the v8 line also tightens the telemetry contract — see `Removed` at
+the bottom of this entry for that.
+
+### Added
+
+- **`listDecisions(opts?: ListDecisionsOptions)` client method.** Pages over
+  recorded decision history from the orchestrator, mirroring `GET
+  /api/v1/decisions`. Companion to the v7.4.0 `explainDecision` method —
+  callers can now both list and drill in. Returns `DecisionSummary[]`.
+  See `examples/list-decisions/`.
+- **`examples/explain-decision/`** end-to-end runnable example covering
+  the full decision audit flow: record → list → explain.
+- **Typed `RateLimitError` envelope** on `listDecisions` 429 responses.
+  `RateLimitError.fromTierEnvelope()` parses the V1 limit/tier/upgrade
+  envelope (`limitType`, `tier`, `upgrade.{wording,compareUrl,buyUrl}`)
+  so callers can route Free → Pro upgrade hints. Backward-compatible —
+  the existing daily-quota positional constructor still works.
+- **Public re-exports.** `ListDecisionsOptions`, `DecisionSummary`,
+  `UpgradeInfo`, `ExplainPolicy`, `ExplainRule` are now exported from
+  the package public surface (`@axonflow/sdk`).
+
+### Migration guide (v7 → v8)
+
+- **`AxonFlowConfig.telemetry` field removed.** TypeScript code referencing
+  this field will fail to typecheck. Migration: remove the field from your
+  `AxonFlowConfig` literal. If you were using it to disable telemetry,
+  set `AXONFLOW_TELEMETRY=off` in the environment instead — that's the
+  sole opt-out lever as of v8. If you were using it to force-enable, the
+  default is now ON for every mode so the field is no longer needed.
+- **No public method-signature changes** beyond the field removal above.
+  `npm install @axonflow/sdk@^8.0.0` and rebuild against v8 with no other
+  source changes.
+
+### Removed
+
+- **`AxonFlowConfig.telemetry` field** (was `boolean | undefined`).
+  `AXONFLOW_TELEMETRY=off` is now the sole opt-out path. Tests that need
+  to defend against contaminated dev environments should clear the env
+  var with `delete process.env.AXONFLOW_TELEMETRY` (or assignment of `''`)
+  in their `beforeEach`.
+- **Sandbox-mode silent telemetry suppression.** Sandbox-mode clients
+  (constructed via `AxonFlow.sandbox(...)` or `mode: 'sandbox'`) now fire
+  telemetry on the same heartbeat schedule as production-mode clients.
+  Pings are tagged `stream="sandbox"` in the payload so analytics can
+  distinguish dev pings from production heartbeat — see the
+  checkpoint-service `IsValidIncomingStream` allowlist for the wire-side
+  gate.
+
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The TypeScript SDK now sends an

--- a/README.md
+++ b/README.md
@@ -511,10 +511,12 @@ const axonflow = new AxonFlow({
 
 **Note:** VPC endpoints require AWS VPC peering setup with AxonFlow infrastructure.
 
-## Sandbox Mode (Testing)
+## Sandbox Mode (Local Testing)
 
 ```typescript
-// Use sandbox mode for testing without affecting production
+// Quick sandbox client pointed at the local docker-compose default
+// (http://localhost:8080). Use a custom endpoint if you need to point
+// sandbox at a hosted environment.
 const axonflow = AxonFlow.sandbox('demo-client', 'demo-secret');
 
 // Test with PII detection (will be blocked)
@@ -529,6 +531,13 @@ try {
   console.log('Correctly blocked:', error.message);
 }
 ```
+
+> Sandbox-mode clients fire telemetry like every other client — anonymous SDK
+> heartbeat, classification-only payload, opt-out via `AXONFLOW_TELEMETRY=off`.
+> Pings are tagged `stream="sandbox"` server-side so dev/test usage is
+> distinguishable from production heartbeat. Pre-v8 sandbox mode silently
+> suppressed pings; that suppression was removed in v8.0 to leave a single,
+> ops-controlled opt-out lever.
 
 ## What Gets Protected?
 
@@ -1003,6 +1012,12 @@ const axonflow = new AxonFlow({
 
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
 No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
+
+`AXONFLOW_TELEMETRY=off` is the **sole opt-out lever** as of v8.0. The
+v7.x `telemetry` config field has been removed; the previous silent
+suppression of sandbox-mode pings has also been removed (sandbox-mode
+pings now fire and are tagged `stream="sandbox"` so they're
+distinguishable from production heartbeat).
 
 ### Scope of `AXONFLOW_TELEMETRY=off`
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,7 @@
-// Disable telemetry during tests to prevent sendTelemetryPing from
-// interfering with fetch mocks in unrelated test files.
+// Disable telemetry during tests so the test process never accidentally
+// fires real pings to checkpoint.getaxonflow.com — referenced from
+// jest.config.js's setupFiles (runs once per test worker, before any test
+// file is loaded). Tests that want to exercise the gate clear the env via
+// `delete process.env.AXONFLOW_TELEMETRY` (or assignment of '') in their
+// own beforeEach. v8.0: this env var is the SOLE telemetry opt-out.
 process.env.AXONFLOW_TELEMETRY = 'off';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "7.1.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/runtime-e2e/sandbox_telemetry_stream_tag/README.md
+++ b/runtime-e2e/sandbox_telemetry_stream_tag/README.md
@@ -1,0 +1,45 @@
+# Runtime proof — Sandbox-mode telemetry fires with stream=sandbox (v8)
+
+Verifies the v8 contract: a `AxonFlow.sandbox(...)`-constructed client produces
+an anonymous heartbeat ping that lands in checkpoint DynamoDB with the row
+tagged `stream="sandbox"`.
+
+## When to run
+
+**Post-deploy verification.** Two infrastructure prerequisites:
+
+1. **`axonflow-enterprise` PR #2005 deployed** — without the server-side
+   wire-allowlist, the Lambda hardcodes `stream=heartbeat` regardless of
+   payload, and this test will fail at the assertion step. Confirm with:
+   ```sh
+   curl -sS -X POST -H 'Content-Type: application/json' \
+     -d '{"sdk":"typescript","sdk_version":"8.0.0","stream":"community_saas_operational","instance_id":"x"}' \
+     https://checkpoint.getaxonflow.com/v1/ping
+   # Expect HTTP 400 "invalid stream value"
+   ```
+2. **AWS credentials** with read on `/aws/lambda/prod-axonflow-checkpoint`.
+
+## Usage
+
+```sh
+AWS_REGION=us-east-1 ./test.sh
+```
+
+## What it asserts
+
+1. Builds the SDK locally (`npm run build`) — TypeScript npm registry is
+   blocked per HARD RULE #6, so we link the local build instead of pulling
+   from npm.
+2. Runs a tiny Node program against the local SDK that calls
+   `AxonFlow.sandbox(...)` pointed at an unreachable agent endpoint
+   (`http://localhost:65530`). Pre-v8 this would have produced no
+   telemetry; post-v8 the SDK fires its anonymous heartbeat.
+3. The Lambda's CloudWatch audit log records an `event_stored` row with
+   `sdk=typescript/8` AND `stream=sandbox`.
+
+## Pre-v8 behavior (regression-guard context)
+
+In v7.x, `AxonFlow.sandbox()` set `mode: 'sandbox'` and the SDK gate
+short-circuited at `mode !== 'sandbox'`. This silent suppression is the
+specific hole this test guards against re-introducing. If a future
+refactor restores any mode-based gate, this test fires loudly.

--- a/runtime-e2e/sandbox_telemetry_stream_tag/test.sh
+++ b/runtime-e2e/sandbox_telemetry_stream_tag/test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Runtime proof — TypeScript SDK v8 sandbox-mode telemetry fires with stream=sandbox.
+#
+# Builds a tiny Node program that uses the LOCAL SDK build in sandbox mode
+# against an unreachable agent endpoint. The SDK fires its anonymous
+# telemetry ping during the AxonFlow constructor's heartbeatReady chain.
+# We then query the deployed checkpoint Lambda's CloudWatch logs for the
+# audit line that should record stream=sandbox in DynamoDB.
+#
+# Pre-v8 this test would have produced ZERO pings (sandbox-mode silent
+# suppression). Post-v8 we expect exactly one ping with stream=sandbox.
+#
+# Stack-state assumptions:
+#   - axonflow-enterprise PR #2005 is deployed (server-side stream allowlist
+#     accepts and persists "sandbox" — without that, this row is stored
+#     as stream=heartbeat, defeating the test's purpose).
+#   - AWS credentials with read access on /aws/lambda/prod-axonflow-checkpoint.
+#
+# HARD RULE #6 — TypeScript npm registry is blocked. We use the LOCAL build
+# (dist/) via a relative file:../.. install. Do NOT switch this to
+# npm install @axonflow/sdk@8 — it will fail on the publish boundary.
+#
+# Usage:
+#   AWS_REGION=us-east-1 ./test.sh
+
+set -uo pipefail
+
+REGION=${AWS_REGION:-us-east-1}
+LOG_GROUP=${LOG_GROUP:-/aws/lambda/prod-axonflow-checkpoint}
+RUN_TAG=$(date -u +%s)
+SDK_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+# 1. Make sure the local SDK is built. The runtime-e2e program imports
+#    from the compiled ESM dist, not src — that's the surface real
+#    customers see.
+if [ ! -f "$SDK_ROOT/dist/esm/index.js" ]; then
+  echo "Building local SDK..."
+  (cd "$SDK_ROOT" && npm run build) || {
+    red "FAIL: SDK build failed"
+    exit 1
+  }
+fi
+
+# 2. Build a transient Node program that imports the local SDK + creates a
+#    Sandbox client. The unreachable :65530 endpoint is intentional — we
+#    only want the anonymous heartbeat to fire, not any platform call.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/package.json" <<EOF
+{
+  "name": "sandbox-rt-${RUN_TAG}",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@axonflow/sdk": "file:${SDK_ROOT}"
+  }
+}
+EOF
+
+cat > "$WORK/main.mjs" <<'EOF'
+import { AxonFlow } from '@axonflow/sdk';
+
+// Belt-and-braces: jest.setup.ts sets AXONFLOW_TELEMETRY=off in test
+// processes. We're outside Jest here, but if the operator's shell rcfile
+// sets it (it does on the dev box), telemetry would be silenced and the
+// test would fail for the wrong reason. Clear it.
+delete process.env.AXONFLOW_TELEMETRY;
+
+const stamp = () => new Date().toISOString();
+console.log(`[${stamp()}] Constructing AxonFlow.sandbox at unreachable endpoint...`);
+
+// AxonFlow.sandbox() defaults endpoint to http://localhost:8080. Override
+// with a clearly-dead port so no platform fetch can succeed — only the
+// telemetry path to checkpoint.getaxonflow.com proceeds.
+const client = new AxonFlow({
+  clientId: 'rt-test',
+  clientSecret: 'rt-test',
+  mode: 'sandbox',
+  endpoint: 'http://localhost:65530',
+});
+
+console.log(`[${stamp()}] Constructor returned. Awaiting heartbeatReady (bounded ~3s)...`);
+
+// Race the heartbeat against a 5s upper-bound so the script always exits.
+await Promise.race([
+  client.heartbeatReady,
+  new Promise(r => setTimeout(r, 5000)),
+]);
+
+console.log(`[${stamp()}] heartbeatReady settled (or 5s timeout). Done.`);
+EOF
+
+T0_MS=$(($(date -u +%s)*1000))
+echo "Run tag: $RUN_TAG"
+echo "T0 (ms): $T0_MS"
+echo
+
+(
+  cd "$WORK"
+  npm install --silent --no-audit --no-fund 2>&1 | tail -3
+  node main.mjs 2>&1
+)
+
+echo
+echo "Waiting 10s for CloudWatch log delivery..."
+sleep 10
+
+# 3. Look for the audit row our run produced — match by sdk=typescript/8.
+echo "Querying CloudWatch logs since T0 for sdk=typescript/8 event_stored entries..."
+HITS=$(aws --region "$REGION" logs filter-log-events \
+  --log-group-name "$LOG_GROUP" \
+  --start-time "$T0_MS" \
+  --filter-pattern '"event_stored" "sdk=typescript/8"' \
+  --query 'events[*].message' \
+  --output text 2>&1)
+
+if [ -z "$HITS" ]; then
+  red "FAIL: no event_stored sdk=typescript/8 row landed in checkpoint logs since T0"
+  red "  Expected: one audit row tagged stream=sandbox"
+  red "  CloudWatch query window: $T0_MS → now"
+  exit 1
+fi
+
+echo "Audit rows found:"
+echo "$HITS"
+echo
+
+if echo "$HITS" | grep -q 'stream=sandbox'; then
+  green "PASS: TypeScript SDK sandbox-mode ping landed with stream=sandbox"
+else
+  red "FAIL: audit row did not include stream=sandbox"
+  red "  This usually means PR #2005 (server-side allowlist) is not yet deployed —"
+  red "  the server still hardcodes stream=heartbeat regardless of payload."
+  exit 1
+fi

--- a/src/client.ts
+++ b/src/client.ts
@@ -296,12 +296,10 @@ export class AxonFlow {
     retry: { enabled: boolean; maxAttempts: number; delay: number };
     cache: { enabled: boolean; ttl: number };
   };
-  // Stores the explicit telemetry override (true / false / undefined) and the
-  // user's original `mode` so the heartbeat gate's _preRequestHook can match
-  // the legacy `sendTelemetryPing` gating semantics. Auto-detected sandbox
-  // (when explicitMode is undefined) leaves telemetry on at the default.
-  private telemetryEnabled: boolean | undefined;
-  private explicitMode: string | undefined;
+  // v8.0: telemetry is gated solely by the AXONFLOW_TELEMETRY env var
+  // (re-evaluated inside maybeSendHeartbeat on every gate run). The v7.x
+  // `telemetryEnabled` field + `explicitMode` capture used to feed the
+  // mode-based default-suppression rule are gone.
   private interceptors: {
     canHandle(aiCall: any): boolean;
     extractRequest(aiCall: any): AIRequest;
@@ -372,10 +370,6 @@ export class AxonFlow {
     // Interceptors removed in v3.0.0 (deprecated wrapOpenAIClient/wrapAnthropicClient)
     this.interceptors = [];
 
-    // Capture for the heartbeat gate (see _preRequestHook).
-    this.telemetryEnabled = config.telemetry;
-    this.explicitMode = config.mode;
-
     if (this.config.debug) {
       // Determine auth method for logging
       const authMethod = hasCredentials ? 'client-credentials' : 'community (no auth)';
@@ -415,20 +409,13 @@ export class AxonFlow {
    * asynchronously so user API calls are never delayed by telemetry.
    */
   private async _preRequestHook(): Promise<void> {
-    // Replicate the legacy sendTelemetryPing gating decision precisely:
-    //   - explicit telemetry === false → off
-    //   - explicit telemetry === true  → on
-    //   - explicit explicitMode === 'sandbox' (user-provided) → off
-    //   - undefined explicitMode (auto-detected) → on regardless of mode
-    let enabled: boolean;
-    if (this.telemetryEnabled === false) {
-      enabled = false;
-    } else if (this.telemetryEnabled === true) {
-      enabled = true;
-    } else {
-      enabled = this.explicitMode !== 'sandbox';
-    }
-    await maybeSendHeartbeat(enabled, () =>
+    // v8.0: telemetry is ON by default for every mode. The v7.x
+    // mode-based default-suppression and telemetryEnabled-config-override
+    // levers were removed. AXONFLOW_TELEMETRY=off (re-checked inside
+    // maybeSendHeartbeat on every call) is the sole opt-out path.
+    // Sandbox-mode pings still fire and are tagged stream="sandbox" in
+    // the payload — see telemetry.ts sendTelemetryPingNow.
+    await maybeSendHeartbeat(true, () =>
       sendTelemetryPingNow({
         mode: this.config.mode,
         endpoint: this.config.endpoint,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -80,25 +80,21 @@ function resolveCheckpointUrl(): string {
 }
 
 /**
- * Determine whether telemetry should be sent based on mode and explicit config.
+ * Determine whether telemetry should be sent.
  *
- * Default behavior:
- * - explicitly-set sandbox mode: OFF
- * - all other modes: ON
+ * `AXONFLOW_TELEMETRY=off` in the environment is the SOLE opt-out path.
+ * Telemetry is otherwise ON by default, regardless of mode (sandbox / production
+ * / anything else). Sandbox-mode pings are tagged `stream="sandbox"` in the
+ * payload so analytics can still distinguish them — see TelemetryPayload.stream.
  *
- * The explicit `telemetryEnabled` config field overrides the default when defined.
+ * Historical context: v7.x supported a `telemetry?: boolean` config field
+ * and a `mode !== 'sandbox'` default-suppression rule. Both were removed in
+ * v8.0 to leave a single, ops-controlled opt-out lever and avoid silent
+ * suppression that masks real adoption signal. See CHANGELOG v8.0.0.
  */
-function shouldSendTelemetry(
-  explicitMode: string | undefined,
-  telemetryEnabled?: boolean
-): boolean {
-  // Explicit config override takes priority
-  if (telemetryEnabled !== undefined) {
-    return telemetryEnabled;
-  }
-
-  // Default: ON everywhere except explicitly-set sandbox mode.
-  return explicitMode !== 'sandbox';
+function shouldSendTelemetry(): boolean {
+  // AXONFLOW_TELEMETRY=off is the SOLE opt-out path.
+  return process.env.AXONFLOW_TELEMETRY?.trim().toLowerCase() !== 'off';
 }
 
 export interface TelemetryPayload {
@@ -117,6 +113,14 @@ export interface TelemetryPayload {
   endpoint_type: EndpointType;
   features: string[];
   instance_id: string;
+  /**
+   * Heartbeat sub-stream classifier. Sandbox-mode clients emit `"sandbox"`
+   * so analytics can distinguish dev/test pings from production heartbeat;
+   * production-mode clients omit the field and the server defaults the row
+   * to `stream="heartbeat"`. The wire-allowlist is enforced server-side —
+   * see checkpoint-service IsValidIncomingStream.
+   */
+  stream?: string;
 }
 
 export type EndpointType =
@@ -287,6 +291,11 @@ export async function sendTelemetryPingNow(options: {
 }): Promise<boolean> {
   const checkpointUrl = resolveCheckpointUrl();
 
+  // Stream classifier: sandbox-mode clients self-tag so analytics can
+  // distinguish dev/test pings from production. Production-mode clients
+  // omit the field entirely and the server defaults to "heartbeat". The
+  // optional-property pattern preserves byte-identical wire shape for the
+  // production case relative to v7.x.
   const payload: TelemetryPayload = {
     sdk: 'typescript',
     sdk_version: VERSION,
@@ -298,6 +307,7 @@ export async function sendTelemetryPingNow(options: {
     endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
+    ...(options.mode === 'sandbox' ? { stream: 'sandbox' } : {}),
   };
 
   try {
@@ -346,12 +356,15 @@ export async function sendTelemetryPingNow(options: {
  * Kept for the existing test surface. Production code goes through
  * `maybeSendHeartbeat` in heartbeat.ts instead. This shim performs the
  * gating + fire-and-forget POST without consulting the 7-day stamp file.
+ *
+ * v8.0: `AXONFLOW_TELEMETRY=off` is the sole gate. The v7.x `explicitMode`
+ * and `telemetryEnabled` parameters were removed — the latter together with
+ * the `AxonFlowConfig.telemetry` field, the former together with the
+ * mode-based default-suppression rule.
  */
 export function sendTelemetryPing(options: {
   mode: string;
-  explicitMode?: string;
   endpoint: string;
-  telemetryEnabled?: boolean;
   debug?: boolean;
 }): void {
   // Check env-level opt-out first
@@ -359,9 +372,7 @@ export function sendTelemetryPing(options: {
     return;
   }
 
-  // Check mode-based default and config override.
-  // Use explicitMode (user's original input) so auto-detected sandbox doesn't disable telemetry.
-  if (!shouldSendTelemetry(options.explicitMode, options.telemetryEnabled)) {
+  if (!shouldSendTelemetry()) {
     return;
   }
 
@@ -373,6 +384,9 @@ export function sendTelemetryPing(options: {
 
   const checkpointUrl = resolveCheckpointUrl();
 
+  // Stream classifier: sandbox-mode clients self-tag so analytics can
+  // distinguish dev/test pings from production. Production-mode clients
+  // omit the field entirely and the server defaults to "heartbeat".
   const payload: TelemetryPayload = {
     sdk: 'typescript',
     sdk_version: VERSION,
@@ -384,6 +398,7 @@ export function sendTelemetryPing(options: {
     endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
+    ...(options.mode === 'sandbox' ? { stream: 'sandbox' } : {}),
   };
 
   // Fire-and-forget: detect platform version then send ping.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -78,17 +78,6 @@ export interface AxonFlowConfig {
     enabled: boolean;
     ttl?: number; // Time to live in milliseconds
   };
-
-  /**
-   * Enable or disable anonymous usage telemetry.
-   *
-   * When undefined, defaults to ON for production mode and OFF for sandbox mode.
-   * Set explicitly to `true` or `false` to override the default.
-   *
-   * Telemetry can also be disabled globally via the
-   * `AXONFLOW_TELEMETRY=off` environment variable.
-   */
-  telemetry?: boolean;
 }
 
 export interface RetryConfig {

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '7.1.0';
+export const VERSION = '8.0.0';

--- a/tests/telemetry-shared-deadline.test.ts
+++ b/tests/telemetry-shared-deadline.test.ts
@@ -90,9 +90,7 @@ describe('telemetry — shared deadline (regression for #1707)', () => {
     const start = Date.now();
     sendTelemetryPing({
       mode: 'production',
-      explicitMode: 'production',
       endpoint: 'http://127.0.0.1:1', // would be unreachable in reality; mock swaps the behavior
-      telemetryEnabled: true,
       debug: false,
     });
 

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,13 +1,18 @@
 /**
  * Telemetry Module Tests
  *
- * Verifies the anonymous usage telemetry ping behavior:
- * - Opt-out via AXONFLOW_TELEMETRY=off env var (DO_NOT_TRACK is no longer honored)
- * - Default ON for all modes except sandbox
- * - Config-level override of defaults
+ * Verifies the anonymous usage telemetry ping behavior under the v8 contract:
+ * - Opt-out via AXONFLOW_TELEMETRY=off env var (DO_NOT_TRACK is not honored)
+ * - Default ON for every mode (mode-based suppression removed in v8.0)
+ * - Sandbox-mode pings tagged stream="sandbox"; other modes omit the field
  * - Payload format correctness
  * - Silent failure on network errors
  * - Custom endpoint via AXONFLOW_CHECKPOINT_URL
+ *
+ * Note: jest.setup.ts sets AXONFLOW_TELEMETRY=off process-wide so unrelated
+ * test files don't accidentally fire pings to checkpoint.getaxonflow.com.
+ * Tests in this file that exercise the gate clear the env var in beforeEach
+ * via `delete process.env.AXONFLOW_TELEMETRY`.
  */
 
 import { sendTelemetryPing, TelemetryPayload } from '../src/telemetry';
@@ -151,22 +156,29 @@ describe('sendTelemetryPing', () => {
   });
 
   // ============================================================
-  // Default mode-based behavior
+  // Default mode-based behavior (v8: ON for every mode)
   // ============================================================
   describe('default mode-based behavior', () => {
-    it('should NOT send when user explicitly sets sandbox mode', () => {
-      sendTelemetryPing({
-        mode: 'sandbox',
-        explicitMode: 'sandbox',
-        endpoint: 'https://api.axonflow.com',
-      });
+    // v8: telemetry is ON for every mode. The mode-based suppression that
+    // used to disable sandbox-mode pings was removed — sandbox-mode pings
+    // now fire and are tagged stream="sandbox" in the payload so analytics
+    // can distinguish them server-side. See CHANGELOG v8.0.0 → Removed.
+    const modes = ['sandbox', 'production', 'staging', 'development'];
 
-      expect(mockFetch).not.toHaveBeenCalled();
+    modes.forEach(mode => {
+      it(`should fire ping for mode=${mode}`, async () => {
+        sendTelemetryPing({
+          mode,
+          endpoint: 'https://api.axonflow.com',
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
+      });
     });
 
-    it('should send when sandbox is auto-detected (no explicitMode)', async () => {
-      // This covers the case where TS SDK auto-selects sandbox because no credentials.
-      // Only explicitly-set sandbox should disable telemetry.
+    it('should fire ping with stream=sandbox in sandbox mode', async () => {
       sendTelemetryPing({
         mode: 'sandbox',
         endpoint: 'https://api.axonflow.com',
@@ -174,10 +186,18 @@ describe('sendTelemetryPing', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
+      // Both: ping fires AND payload carries stream="sandbox".
       expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
+      const postCall = mockFetch.mock.calls.find(
+        (call: [string, { method?: string }]) => call[1]?.method === 'POST'
+      );
+      expect(postCall).toBeDefined();
+      const payload: TelemetryPayload = JSON.parse(postCall![1].body);
+      expect(payload.stream).toBe('sandbox');
+      expect(payload.deployment_mode).toBe('sandbox');
     });
 
-    it('should send by default for production mode', async () => {
+    it('should omit the stream field for production mode', async () => {
       sendTelemetryPing({
         mode: 'production',
         endpoint: 'https://api.axonflow.com',
@@ -185,10 +205,16 @@ describe('sendTelemetryPing', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
+      const postCall = mockFetch.mock.calls.find(
+        (call: [string, { method?: string }]) => call[1]?.method === 'POST'
+      );
+      expect(postCall).toBeDefined();
+      const payload: TelemetryPayload = JSON.parse(postCall![1].body);
+      // omit-when-not-sandbox: server defaults absent stream → "heartbeat".
+      expect(payload.stream).toBeUndefined();
     });
 
-    it('should send by default for staging mode', async () => {
+    it('should omit the stream field for staging mode', async () => {
       sendTelemetryPing({
         mode: 'staging',
         endpoint: 'https://api.axonflow.com',
@@ -196,18 +222,11 @@ describe('sendTelemetryPing', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
-    });
-
-    it('should send by default for development mode', async () => {
-      sendTelemetryPing({
-        mode: 'development',
-        endpoint: 'https://api.axonflow.com',
-      });
-
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
+      const postCall = mockFetch.mock.calls.find(
+        (call: [string, { method?: string }]) => call[1]?.method === 'POST'
+      );
+      const payload: TelemetryPayload = JSON.parse(postCall![1].body);
+      expect(payload.stream).toBeUndefined();
     });
   });
 
@@ -250,67 +269,13 @@ describe('sendTelemetryPing', () => {
   });
 
   // ============================================================
-  // Config override of defaults
+  // Config override removed in v8.0
   // ============================================================
-  describe('config telemetryEnabled override', () => {
-    it('should send in explicit sandbox mode when telemetryEnabled=true', async () => {
-      sendTelemetryPing({
-        mode: 'sandbox',
-        explicitMode: 'sandbox',
-        endpoint: 'https://api.axonflow.com',
-        telemetryEnabled: true,
-      });
-
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
-    });
-
-    it('should NOT send in production mode when telemetryEnabled=false', () => {
-      sendTelemetryPing({
-        mode: 'production',
-        endpoint: 'https://api.axonflow.com',
-        telemetryEnabled: false,
-      });
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it('DNT=1 alone does NOT override telemetryEnabled=true (DNT no longer honored)', async () => {
-      process.env.DO_NOT_TRACK = '1';
-
-      sendTelemetryPing({
-        mode: 'production',
-        endpoint: 'https://api.axonflow.com',
-        telemetryEnabled: true,
-      });
-
-      await new Promise(resolve => setTimeout(resolve, 50));
-      expect(mockFetch).toHaveBeenCalledTimes(2); // health + checkpoint
-    });
-
-    it('AXONFLOW_TELEMETRY=off takes priority over telemetryEnabled=true', () => {
-      process.env.AXONFLOW_TELEMETRY = 'off';
-
-      sendTelemetryPing({
-        mode: 'production',
-        endpoint: 'https://api.axonflow.com',
-        telemetryEnabled: true,
-      });
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it('config override false skips regardless of mode', () => {
-      sendTelemetryPing({
-        mode: 'production',
-        endpoint: 'https://api.axonflow.com',
-        telemetryEnabled: false,
-      });
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-  });
+  // The `telemetryEnabled` config field was removed in v8.0 along with the
+  // mode-based default-suppression rule. AXONFLOW_TELEMETRY=off is the SOLE
+  // opt-out path; programmatic suppression is no longer supported. The v7.x
+  // `describe('config telemetryEnabled override')` block was removed with the
+  // field. See CHANGELOG v8.0.0 → Removed.
 
   // ============================================================
   // Payload format
@@ -351,7 +316,6 @@ describe('sendTelemetryPing', () => {
       sendTelemetryPing({
         mode: 'production',
         endpoint: 'https://api.axonflow.com',
-        telemetryEnabled: true,
       });
 
       await new Promise(resolve => setTimeout(resolve, 50));


### PR DESCRIPTION
## Summary

Combined major release for the TypeScript SDK. Bundles a new decision-history client API (`listDecisions` + runnable explain example, already on main) with a telemetry contract simplification that removes silent customer-side suppression paths.

After this lands:

- **`AXONFLOW_TELEMETRY=off` is the sole opt-out** for SDK telemetry — same pattern as HashiCorp checkpoint, Docker, Datadog Agent.
- **Sandbox-mode clients now fire telemetry**, tagged `stream="sandbox"` so they're distinguishable from production heartbeat in analytics.
- **`AxonFlowConfig.telemetry` field is removed** — the config-level kill switch is gone.

## Why combined into a major

The telemetry contract had two redundant levers (env var + programmatic field) and one silent-suppression path (mode-based). Cleanup is technically a breaking change, so it must ride a major version bump. We bundled the planned decision-history feature work into the same major instead of releasing a v7.2.0 right before a v8.0.0 — fewer customer-facing version transitions. Mirrors getaxonflow/axonflow-sdk-go#160.

## Migration

```ts
// v7.x
const client = new AxonFlow({
  clientId: '…',
  clientSecret: '…',
  telemetry: false, // ← TS will fail to compile against v8
});

// v8 — drop the field, set the env var instead
const client = new AxonFlow({
  clientId: '…',
  clientSecret: '…',
});
// AXONFLOW_TELEMETRY=off in the shell / process env
```

No method-signature changes beyond the field removal. `npm install @axonflow/sdk@^8.0.0` and rebuild against v8 with no other source changes.

## Dependency note

This PR's runtime-e2e test (`runtime-e2e/sandbox_telemetry_stream_tag/`) depends on **getaxonflow/axonflow-enterprise#2005** (server-side stream allowlist) being deployed. Pre-deploy the row will be tagged `stream=heartbeat` regardless of payload (server hardcodes), and the test's stream-tag assertion fails. The unit tests + behavioral correctness in this PR are independent and pass standalone.

## Test plan

### Unit + build

- [x] `npm test` — 28/29 suites pass. Telemetry suites (`tests/telemetry.test.ts`, `tests/telemetry-shared-deadline.test.ts`, `tests/heartbeat*.test.ts`) all green.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.
- [x] `npm run build` clean.
- [x] `bash -n runtime-e2e/sandbox_telemetry_stream_tag/test.sh` clean.
- [x] `scripts/lint-no-mocks-in-runtime-e2e.sh runtime-e2e/sandbox_telemetry_stream_tag/` clean.

The 1 pre-existing test/client.test.ts failure (5 `Protect Method`/`Health Check` cases) reproduces on `origin/main` against this dev box and is **localhost:8080 environment-dependent**: the tests assert fail-open behavior, but with a live agent on localhost:8080 the path returns the agent's structured response instead. CI on `main` is green because CI doesn't have a local agent. Not caused by this PR.

### Runtime proof (3-rule DoD, HARD RULE #0)

The runtime-e2e file exists and satisfies the mechanical CI gate, but **the test has not yet been executed against the deployed Lambda**. Per HARD RULE #0, runtime proof is the rule, not the file's existence. The proof is gated on:

- [ ] axonflow-enterprise#2005 (server-side stream allowlist) deployed via `deploy-checkpoint.yml`.
- [ ] Then run `runtime-e2e/sandbox_telemetry_stream_tag/test.sh` against the live Lambda. Expected: an audit row tagged `sdk=typescript/8 stream=sandbox` lands in DynamoDB and CloudWatch within ~10s.

I will not request merge of this PR until those two items are checked. Pre-deploy I'm declaring "tests exist + unit-test parity is correct"; full runtime proof comes after #2005 deploys.

### Release tagging (gated on user authorization)

- [ ] Tag `v8.0.0` on the merged commit.
- [ ] Publish to npm.

Per the project's release-approval rule, you authorize each release individually.

## Self-review

Hunk-by-hunk review on the v8 diff. 5-question protocol per substantive hunk.

1. **`src/types/config.ts`** — single field removal (`telemetry?: boolean`). Q: any other code reading `config.telemetry`? Verified: `grep -rn 'config\.telemetry'` → none after this PR.
2. **`src/telemetry.ts`** — gate function collapsed from 3 conditions to 1 (env var only). Doc rewritten with v7→v8 history. `sendTelemetryPing` shim's `explicitMode` + `telemetryEnabled` parameters removed. `TelemetryPayload.stream?` added with optional-property pattern so production-mode payloads are byte-identical to v7.x; sandbox-mode payloads carry `stream="sandbox"`. Q: does the existing `isOptedOut()` still gate before reaching `shouldSendTelemetry()`? Yes — both check the same env var; mild redundancy, harmless. Q: heartbeat path? Verified: `heartbeat.ts:211` still calls `isOptedOut()` first inside `maybeSendHeartbeat`.
3. **`src/client.ts`** — drop `private telemetryEnabled` + `private explicitMode` fields. `_preRequestHook` now calls `maybeSendHeartbeat(true, …)` unconditionally; the env-var gate inside `maybeSendHeartbeat` is the sole opt-out. Q: any constructor logic that depended on `this.telemetryEnabled`? Verified: only the `_preRequestHook` site.
4. **`tests/telemetry.test.ts`** — major refactor: removed `describe('config telemetryEnabled override')`, rewrote `default mode-based behavior` table-driven, removed v7-only sandbox-default-off test, added `should fire ping with stream=sandbox in sandbox mode` covering the new contract, added stream-omit-for-non-sandbox cases for production + staging. Q: was the env-var clear pattern correct? Yes — `delete process.env.AXONFLOW_TELEMETRY` in `beforeEach` clears the `jest.setup.ts`-set value so the gate fires.
5. **`tests/telemetry-shared-deadline.test.ts`** — drop `explicitMode` + `telemetryEnabled: true` parameter that no longer exists. Test still passes; the regression coverage (shared-deadline timing for #1707) is unaffected.
6. **`jest.setup.ts`** — comment expanded to explain the v8 contract. Behavior unchanged.
7. **`README.md`** — Sandbox section reframed (no longer suppresses telemetry). Telemetry section gained a clarifying paragraph: `AXONFLOW_TELEMETRY=off` is the sole opt-out lever as of v8.0.
8. **`CHANGELOG.md`** — new v8.0.0 entry above v7.1.0. Headline names the feature theme (decision history API); telemetry change kept concise at the bottom under `Removed`. Migration guide walks through `telemetry` field removal.
9. **`runtime-e2e/sandbox_telemetry_stream_tag/`** — new directory; `test.sh` + `README.md`. Real ping against deployed checkpoint Lambda, no mocks. Lint-clean per `lint-no-mocks-in-runtime-e2e.sh`. Q: HARD RULE #6 (TS npm registry blocked)? Yes — uses `file:${SDK_ROOT}` install of the local build, never `npm install @axonflow/sdk@8`.
10. **`package.json` / `package-lock.json` / `src/version.ts`** — version `7.1.0` → `8.0.0`. Verified `version.ts` was re-stamped via `node scripts/stamp-version.js`.

## Risk

- **Breaking** for any customer currently setting `telemetry: false` — they will see a TS compile error (or silent type-check pass under `noImplicitAny: false`), then telemetry fires until they set the env var. No production code I've grepped uses this field outside test files.
- **Sandbox-mode behavior changed** — sandbox clients used to produce zero pings, now produce one ping per machine per 7 days. CHANGELOG calls this out explicitly under `Removed`.

## Linked

- axonflow-enterprise#2005 — server-side stream allowlist (companion change; must be deployed for the runtime-e2e to fully succeed).
- axonflow-enterprise#2006 — CloudWatch alarms (independent companion).
- getaxonflow/axonflow-sdk-go#160 — Go SDK reference implementation this PR mirrors.