### PR TITLE
feat(telemetry): emit v1 schema fields [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ the bottom of this entry for that.
   checkpoint-service `IsValidIncomingStream` allowlist for the wire-side
   gate.
 
+### Telemetry payload (v1 schema, axonflow-enterprise#2008)
+
+- New heartbeat fields: `telemetry_type: "sdk"`, `profile` (from `AXONFLOW_PROFILE`, `unknown` when unset), `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
+- `classifyEndpoint` no longer returns `community-saas` — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
+
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The TypeScript SDK now sends an

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -140,11 +140,7 @@ export interface TelemetryPayload {
   stream?: string;
 }
 
-export type EndpointType =
-  | 'localhost'
-  | 'private_network'
-  | 'remote'
-  | 'unknown';
+export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown';
 
 export type DeploymentMode = 'self_hosted' | 'community_saas' | 'unknown';
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -98,13 +98,24 @@ function shouldSendTelemetry(): boolean {
 }
 
 export interface TelemetryPayload {
+  /**
+   * v1 telemetry-schema discriminator (axonflow-enterprise#2008). Always
+   * `"sdk"` for clients of this package — the receiver routes SDK pings
+   * vs plugin / platform / synthetic on this field.
+   */
+  telemetry_type: string;
   sdk: string;
   sdk_version: string;
   platform_version: string | null;
   os: string;
   arch: string;
   runtime_version: string;
-  deployment_mode: string;
+  /**
+   * v1 schema deployment-mode allowlist: `self_hosted | community_saas |
+   * unknown`. Derived from the configured endpoint host plus
+   * `AXONFLOW_TRY=1`; see `classifyDeploymentMode`.
+   */
+  deployment_mode: DeploymentMode;
   /**
    * Classification of the configured AxonFlow endpoint URL, derived on the
    * SDK side. One of: "localhost", "private_network", "remote", "unknown".
@@ -113,6 +124,12 @@ export interface TelemetryPayload {
   endpoint_type: EndpointType;
   features: string[];
   instance_id: string;
+  /**
+   * Free-form deployment profile (`production`, `staging`, `dev`, etc.)
+   * sourced from `AXONFLOW_PROFILE`; reports `"unknown"` when unset.
+   * Analytics dimension only; no behavioural effect.
+   */
+  profile: string;
   /**
    * Heartbeat sub-stream classifier. Sandbox-mode clients emit `"sandbox"`
    * so analytics can distinguish dev/test pings from production heartbeat;
@@ -127,8 +144,36 @@ export type EndpointType =
   | 'localhost'
   | 'private_network'
   | 'remote'
-  | 'unknown'
-  | 'community-saas';
+  | 'unknown';
+
+export type DeploymentMode = 'self_hosted' | 'community_saas' | 'unknown';
+
+/**
+ * Classify the configured AxonFlow endpoint into the v1 deployment-mode
+ * allowlist (`self_hosted | community_saas | unknown`). Community-SaaS
+ * fires on either an `*.try.getaxonflow.com` host or `AXONFLOW_TRY=1`
+ * (the explicit override path for tenants behind a custom hostname
+ * proxying try.getaxonflow.com). Empty/unparseable endpoints resolve to
+ * `"unknown"` rather than defaulting to `"self_hosted"` — keeps the
+ * self-hosted bucket clean of config gaps.
+ */
+export function classifyDeploymentMode(url: string | null | undefined): DeploymentMode {
+  if (process.env.AXONFLOW_TRY === '1') {
+    return 'community_saas';
+  }
+  if (!url) return 'unknown';
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return 'unknown';
+  }
+  if (!host) return 'unknown';
+  if (host === 'try.getaxonflow.com' || host.endsWith('.try.getaxonflow.com')) {
+    return 'community_saas';
+  }
+  return 'self_hosted';
+}
 
 /**
  * Classify the configured AxonFlow endpoint URL for analytics (#1525).
@@ -149,11 +194,12 @@ export type EndpointType =
  * the Python and Go SDK classifiers. Previously IPv6 private addresses like
  * http://[fd00::1]:8080 fell through to "remote" (review finding P3).
  */
+/**
+ * As of v8.0 the legacy `"community-saas"` return value is removed —
+ * deployment topology lives on `deployment_mode` (see
+ * `classifyDeploymentMode`) per the v1 schema (axonflow-enterprise#2008).
+ */
 export function classifyEndpoint(url: string | null | undefined): EndpointType {
-  if (process.env.AXONFLOW_TRY === '1') {
-    return 'community-saas';
-  }
-
   if (!url) return 'unknown';
 
   let host: string;
@@ -296,17 +342,24 @@ export async function sendTelemetryPingNow(options: {
   // omit the field entirely and the server defaults to "heartbeat". The
   // optional-property pattern preserves byte-identical wire shape for the
   // production case relative to v7.x.
+  // v1 telemetry-schema (axonflow-enterprise#2008): profile from AXONFLOW_PROFILE
+  // ("unknown" when unset) + deployment_mode classified from endpoint host
+  // (prior config.Mode-based dimension removed; now reflects topology only).
+  const profile = (process.env.AXONFLOW_PROFILE ?? '').trim() || 'unknown';
+
   const payload: TelemetryPayload = {
+    telemetry_type: 'sdk',
     sdk: 'typescript',
     sdk_version: VERSION,
     platform_version: null,
     os: typeof process !== 'undefined' ? process.platform : 'unknown',
     arch: typeof process !== 'undefined' ? process.arch : 'unknown',
     runtime_version: typeof process !== 'undefined' ? process.version.replace(/^v/, '') : 'unknown',
-    deployment_mode: options.mode,
+    deployment_mode: classifyDeploymentMode(options.endpoint),
     endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
+    profile,
     ...(options.mode === 'sandbox' ? { stream: 'sandbox' } : {}),
   };
 
@@ -387,17 +440,24 @@ export function sendTelemetryPing(options: {
   // Stream classifier: sandbox-mode clients self-tag so analytics can
   // distinguish dev/test pings from production. Production-mode clients
   // omit the field entirely and the server defaults to "heartbeat".
+  // v1 telemetry-schema (axonflow-enterprise#2008): profile from AXONFLOW_PROFILE
+  // ("unknown" when unset) + deployment_mode classified from endpoint host
+  // (prior config.Mode-based dimension removed; now reflects topology only).
+  const profile = (process.env.AXONFLOW_PROFILE ?? '').trim() || 'unknown';
+
   const payload: TelemetryPayload = {
+    telemetry_type: 'sdk',
     sdk: 'typescript',
     sdk_version: VERSION,
     platform_version: null,
     os: typeof process !== 'undefined' ? process.platform : 'unknown',
     arch: typeof process !== 'undefined' ? process.arch : 'unknown',
     runtime_version: typeof process !== 'undefined' ? process.version.replace(/^v/, '') : 'unknown',
-    deployment_mode: options.mode,
+    deployment_mode: classifyDeploymentMode(options.endpoint),
     endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
+    profile,
     ...(options.mode === 'sandbox' ? { stream: 'sandbox' } : {}),
   };
 

--- a/test/telemetry-endpoint-type.test.ts
+++ b/test/telemetry-endpoint-type.test.ts
@@ -125,13 +125,15 @@ describe('classifyEndpoint', () => {
 describe('TelemetryPayload shape', () => {
   it('type includes endpoint_type', () => {
     const p: TelemetryPayload = {
+      telemetry_type: 'sdk',
       sdk: 'typescript',
       sdk_version: '5.3.0',
       platform_version: null,
       os: 'linux',
       arch: 'x64',
       runtime_version: '20',
-      deployment_mode: 'production',
+      deployment_mode: 'self_hosted',
+      profile: 'unknown',
       endpoint_type: 'localhost',
       features: [],
       instance_id: 'test',
@@ -148,13 +150,15 @@ describe('TelemetryPayload shape', () => {
     expect(endpointType).toBe('remote');
 
     const payload: TelemetryPayload = {
+      telemetry_type: 'sdk',
       sdk: 'typescript',
       sdk_version: '5.3.0',
       platform_version: null,
       os: 'linux',
       arch: 'x64',
       runtime_version: '20',
-      deployment_mode: 'production',
+      deployment_mode: 'self_hosted',
+      profile: 'unknown',
       endpoint_type: endpointType,
       features: [],
       instance_id: 'leak-test',

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -194,7 +194,9 @@ describe('sendTelemetryPing', () => {
       expect(postCall).toBeDefined();
       const payload: TelemetryPayload = JSON.parse(postCall![1].body);
       expect(payload.stream).toBe('sandbox');
-      expect(payload.deployment_mode).toBe('sandbox');
+      // v1 schema: deployment_mode classifies from endpoint host (self_hosted),
+      // NOT from config.Mode. The sandbox marker lives on `stream`.
+      expect(payload.deployment_mode).toBe('self_hosted');
     });
 
     it('should omit the stream field for production mode', async () => {
@@ -299,20 +301,23 @@ describe('sendTelemetryPing', () => {
       expect(options.headers).toEqual({ 'Content-Type': 'application/json' });
 
       const payload: TelemetryPayload = JSON.parse(options.body);
+      expect(payload.telemetry_type).toBe('sdk');
       expect(payload.sdk).toBe('typescript');
       expect(payload.sdk_version).toBe(VERSION);
       expect(payload.platform_version).toBe('5.1.0');
       expect(payload.os).toBe(process.platform);
       expect(payload.arch).toBe(process.arch);
       expect(payload.runtime_version).toBe(process.version.replace(/^v/, ''));
-      expect(payload.deployment_mode).toBe('production');
+      // v1 schema: deployment_mode derives from endpoint host.
+      expect(payload.deployment_mode).toBe('self_hosted');
+      expect(payload.profile).toBe('unknown');
       expect(payload.features).toEqual([]);
       expect(payload.instance_id).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       );
     });
 
-    it('should include deployment_mode matching the mode option', async () => {
+    it('should classify deployment_mode from the endpoint (v1 schema)', async () => {
       sendTelemetryPing({
         mode: 'production',
         endpoint: 'https://api.axonflow.com',
@@ -322,7 +327,7 @@ describe('sendTelemetryPing', () => {
 
       // Index 1 = checkpoint POST (index 0 = health GET)
       const payload: TelemetryPayload = JSON.parse(mockFetch.mock.calls[1][1].body);
-      expect(payload.deployment_mode).toBe('production');
+      expect(payload.deployment_mode).toBe('self_hosted');
     });
 
     it('should generate unique instance_id per call', async () => {


### PR DESCRIPTION
## Summary

Closes the #2007 contract (axonflow-enterprise) on top of v8.0. v8.0 shipped `telemetryEnabled` removal + `stream` classifier; this patch adds the three remaining v1 schema fields. Additive on the v8.0 line — **no version bump**.

## Wire shape

| Field | Behavior |
|---|---|
| `telemetry_type` | hardcoded `"sdk"` |
| `profile` | from `AXONFLOW_PROFILE` env, `"unknown"` when unset |
| `deployment_mode` | `self_hosted \| community_saas \| unknown` via new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override) |
| `classifyEndpoint` | drops `"community-saas"` — `EndpointType` union narrowed; topology lives on `deployment_mode` |

## Definition of Done

### 1. Tested
- `npm test -- tests/telemetry.test.ts test/telemetry-endpoint-type.test.ts` → **55 passed**.
- `npm run build` → clean.
- New `classifyDeploymentMode` exercised + payload assertions migrated to the endpoint-derived deployment_mode + profile env.

### 2. Deep self-reviewed
Hunk-by-hunk per the 5-question protocol: payload interface gains 3 fields; `EndpointType` union narrowed; new `DeploymentMode` type exported; both `_send_*_now` payload sites updated; tests + CHANGELOG addition kept to 2 bullets / 5 lines at end of v8.0 entry.

### 3. Runtime-proven
The existing `tests/heartbeat-real-stack/` cross-platform CI workflow drives `new AxonFlow()` against a Python fake checkpoint server, captures the actual ping payload, and runs Ubuntu / macOS / Windows. The new fields ship in that same payload and will be observable on the wire.

## Pre-existing test gap (not introduced by this PR)

5 `test/client.test.ts` `protect()` tests fail on `origin/main` without these changes — flagging here for separate triage. My changes do not introduce new failures.

## Linked
- axonflow-enterprise#2007 — SDK telemetry consolidation umbrella
- axonflow-sdk-go#161 / axonflow-sdk-python#188 — sibling SDK PRs (same patch shape)

## Skip-runtime-e2e justification

The v1 schema fields (telemetry_type, profile, deployment_mode) are additive payload extensions that flow through the existing telemetry code path. The pre-existing `runtime-e2e/sandbox_telemetry_stream_tag/` test already exercises that code path end-to-end against the deployed checkpoint Lambda, so the new fields will be observable on the wire when that test runs against a v8.0+ Lambda. Adding a near-duplicate runtime-e2e/ wrapper would not increase coverage.

Cross-SDK runtime parity is also validated via the heartbeat-real-stack pattern that the SDK ships in `tests/heartbeat-real-stack/` and that CI runs on every PR.