### PR TITLE
docs(changelog): scrub profile-field noise [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,6 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.0.1] - 2026-05-08 — Drop telemetry `profile` field (env-var collision)
-
-### Removed
-
-- **`profile` field on the v1 telemetry payload** and the
-  `process.env.AXONFLOW_PROFILE` read that backed it. The env var name
-  collides with the existing governance `AXONFLOW_PROFILE`
-  (`dev | default | strict | compliance`), so populating the telemetry
-  field from it produced rejected pings whenever a customer had
-  governance set to `strict` / `compliance` / etc.
-  Topology classification continues to ride on the `deployment_mode`
-  field (unchanged). No migration needed — clients that did not set
-  `AXONFLOW_PROFILE` for telemetry purposes see no behaviour change;
-  clients that did can stop setting it.
-
 ## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:
@@ -75,7 +60,7 @@ the bottom of this entry for that.
 
 ### Telemetry payload (v1 schema, axonflow-enterprise#2008)
 
-- New heartbeat fields: `telemetry_type: "sdk"`, `profile` (from `AXONFLOW_PROFILE`, `unknown` when unset), `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
+- New heartbeat fields: `telemetry_type: "sdk"`, `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
 - `classifyEndpoint` no longer returns `community-saas` — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
 
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.0.1",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.0.1",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.0.1",
+  "version": "8.0.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.0.1';
+export const VERSION = '8.0.0';


### PR DESCRIPTION
## Summary

Scrub all references to the v1-telemetry `profile` field from CHANGELOG.md and revert the patch version bump. **The `profile` field never reached any tagged customer release** — its CHANGELOG mentions are internal noise.

User direction: *"This never made it to any customer so why it should be in changelog when we removed it already before the release."*

## What changed

- **`CHANGELOG.md`** — deleted the `[8.0.1] - Drop telemetry profile field (env-var collision)` section entirely; scrubbed the `profile` mention from the `[8.0.0]` "Telemetry payload (v1 schema, ...)" bullet.
- **`package.json`** — reverted `"version": "8.0.1"` → `"8.0.0"`.
- **`package-lock.json`** — reverted both top-level + root-package `version` entries `8.0.1` → `8.0.0`.
- **`src/version.ts`** — re-stamped via `npm run stamp-version` (now `VERSION = '8.0.0'`).

## What is preserved

The remaining v8.0.0 narrative is unchanged: `listDecisions(opts)`, `examples/explain-decision/`, the typed `RateLimitError` envelope on 429, `ListDecisionsOptions`/`DecisionSummary`/`UpgradeInfo` re-exports, the `AxonFlowConfig.telemetry` removal in the v7→v8 migration guide, sandbox-mode telemetry, `telemetry_type: "sdk"` field, `classifyDeploymentMode`, and the `classifyEndpoint` change.

## Skip-runtime-e2e justification

This is a documentation correction with three matching version-marker reverts. The code state was already settled in the prior release train (`ad7429d` dropped the runtime read of `process.env.AXONFLOW_PROFILE` for telemetry on `main`). No user-facing behaviour changes; version-specific test suites (`tests/telemetry.test.ts` + `tests/client-header.test.ts`) all 31 pass.

The 5 pre-existing failures in `test/client.test.ts` are unrelated to this change (they fail identically on `main` with this branch stashed) — out of scope for the doc-only correction.

## References

- getaxonflow/axonflow-enterprise#2033 — original env-var collision bug
- getaxonflow/axonflow-enterprise#2035 — code-side fix (already shipped to `main` via #221 as `ad7429d`)

## Self-review

- Confirmed only the `[8.0.1]` section + the single `profile` clause inside `[8.0.0]`'s "Telemetry payload" bullet were removed.
- Confirmed all three version markers (`package.json` + `package-lock.json` × 2 + `src/version.ts` via stamp-version) are reverted in lockstep.
- No stray `8.0.1` references remain that point at our SDK (transitive `cliui@8.0.1` / `node-notifier@^8.0.1` deps untouched as expected).
- No AI attribution anywhere; DCO sign-off present.