### PR TITLE
chore(changelog): hygiene scrub for 2026-05-09 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
+## [8.0.0] - 2026-05-09 — Decision history API + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:
 `listDecisions` for paging through recorded decisions, plus a runnable example
@@ -16,90 +16,75 @@ the bottom of this entry for that.
 ### Added
 
 - **`listDecisions(opts?: ListDecisionsOptions)` client method.** Pages over
-  recorded decision history from the orchestrator, mirroring `GET
-  /api/v1/decisions`. Companion to the v7.4.0 `explainDecision` method —
-  callers can now both list and drill in. Returns `DecisionSummary[]`.
-  See `examples/list-decisions/`.
+ recorded decision history from the orchestrator, mirroring `GET
+ /api/v1/decisions`. Companion to the v7.4.0 `explainDecision` method —
+ callers can now both list and drill in. Returns `DecisionSummary[]`.
+ See `examples/list-decisions/`.
 - **`examples/explain-decision/`** end-to-end runnable example covering
-  the full decision audit flow: record → list → explain.
+ the full decision audit flow: record → list → explain.
 - **Typed `RateLimitError` envelope** on `listDecisions` 429 responses.
-  `RateLimitError.fromTierEnvelope()` parses the V1 limit/tier/upgrade
-  envelope (`limitType`, `tier`, `upgrade.{wording,compareUrl,buyUrl}`)
-  so callers can route Free → Pro upgrade hints. Backward-compatible —
-  the existing daily-quota positional constructor still works.
+ `RateLimitError.fromTierEnvelope()` parses the V1 limit/tier/upgrade
+ envelope (`limitType`, `tier`, `upgrade.{wording,compareUrl,buyUrl}`)
+ so callers can route Free → Pro upgrade hints. Backward-compatible —
+ the existing daily-quota positional constructor still works.
 - **Public re-exports.** `ListDecisionsOptions`, `DecisionSummary`,
-  `UpgradeInfo`, `ExplainPolicy`, `ExplainRule` are now exported from
-  the package public surface (`@axonflow/sdk`).
+ `UpgradeInfo`, `ExplainPolicy`, `ExplainRule` are now exported from
+ the package public surface (`@axonflow/sdk`).
 
 ### Migration guide (v7 → v8)
 
 - **`AxonFlowConfig.telemetry` field removed.** TypeScript code referencing
-  this field will fail to typecheck. Migration: remove the field from your
-  `AxonFlowConfig` literal. If you were using it to disable telemetry,
-  set `AXONFLOW_TELEMETRY=off` in the environment instead — that's the
-  sole opt-out lever as of v8. If you were using it to force-enable, the
-  default is now ON for every mode so the field is no longer needed.
+ this field will fail to typecheck. Migration: remove the field from your
+ `AxonFlowConfig` literal. If you were using it to disable telemetry,
+ set `AXONFLOW_TELEMETRY=off` in the environment instead — that's the
+ sole opt-out lever as of v8. If you were using it to force-enable, the
+ default is now ON for every mode so the field is no longer needed.
 - **No public method-signature changes** beyond the field removal above.
-  `npm install @axonflow/sdk@^8.0.0` and rebuild against v8 with no other
-  source changes.
+ `npm install @axonflow/sdk@^8.0.0` and rebuild against v8 with no other
+ source changes.
 
-### Removed
+### Telemetry
 
-- **`AxonFlowConfig.telemetry` field** (was `boolean | undefined`).
-  `AXONFLOW_TELEMETRY=off` is now the sole opt-out path. Tests that need
-  to defend against contaminated dev environments should clear the env
-  var with `delete process.env.AXONFLOW_TELEMETRY` (or assignment of `''`)
-  in their `beforeEach`.
-- **Sandbox-mode silent telemetry suppression.** Sandbox-mode clients
-  (constructed via `AxonFlow.sandbox(...)` or `mode: 'sandbox'`) now fire
-  telemetry on the same heartbeat schedule as production-mode clients.
-  Pings are tagged `stream="sandbox"` in the payload so analytics can
-  distinguish dev pings from production heartbeat — see the
-  checkpoint-service `IsValidIncomingStream` allowlist for the wire-side
-  gate.
-
-### Telemetry payload (v1 schema, axonflow-enterprise#2008)
-
-- New heartbeat fields: `telemetry_type: "sdk"`, `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
-- `classifyEndpoint` no longer returns `community-saas` — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
+- **`AXONFLOW_TELEMETRY=off` is the sole opt-out.** `AxonFlowConfig.telemetry` field removed; sandbox-mode clients now fire on the same 7-day heartbeat schedule as production (was suppressed pre-v8), tagged `stream="sandbox"` so dev pings stay distinguishable.
+- **Heartbeat payload v1 schema additions** on the wire: new `telemetry_type` and `deployment_mode` fields. Existing receivers continue working unchanged — strictly additive.
 
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The TypeScript SDK now sends an
 `X-Axonflow-Client` identification header on every governed request, which
 the agent uses to derive the SDK request scope and validate it against any
-license token's audience claim per the ADR-050 license matrix.
+license token's audience claim per the license matrix.
 
 ### Added
 
 - **`X-Axonflow-Client: sdk-typescript/<version>` header** on every
-  governed outbound request. Set automatically by the SDK transport;
-  not configurable. Agents at v7.7.0+ derive request scope from this
-  header and reject cross-quadrant token misuse (e.g. a SaaS Plugin Pro
-  token paired with an SDK request) at the validator boundary. Older
-  agents (pre-v7.7.0) ignore the header and continue to work unchanged.
+ governed outbound request. Set automatically by the SDK transport;
+ not configurable. Agents at v7.7.0+ derive request scope from this
+ header and reject cross-quadrant token misuse (e.g. a SaaS Plugin Pro
+ token paired with an SDK request) at the validator boundary. Older
+ agents (pre-v7.7.0) ignore the header and continue to work unchanged.
 
 ### Compatibility
 
 - **No public API changes.** Existing v7.0.x callers
-  `npm install @axonflow/sdk@^7.1.0` and rebuild against v7.1.0 with no
-  source changes.
+ `npm install @axonflow/sdk@^7.1.0` and rebuild against v7.1.0 with no
+ source changes.
 - **Backward-compatible against pre-v7.7.0 agents.** The header is
-  silently dropped by older agents; the SDK behaves identically against
-  v7.0.x / v7.1.x / v7.6.x agents as before.
+ silently dropped by older agents; the SDK behaves identically against
+ v7.0.x / v7.1.x / v7.6.x agents as before.
 - **Forward-compatible.** Future agent releases that require the header
-  on specific governed surfaces will work with this SDK without further
-  client changes.
+ on specific governed surfaces will work with this SDK without further
+ client changes.
 
 ### Companion releases (same day)
 
 - **Platform v7.7.0** — V1 SaaS Plugin Pro launch, license matrix,
-  per-tenant tier resolution, GDPR right-to-erasure
-  ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
+ per-tenant tier resolution, GDPR right-to-erasure
+ ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
 - **Go SDK v7.1.0** / **Python SDK v7.1.0** /
-  **Java SDK v7.1.0** — same `X-Axonflow-Client` injection
+ **Java SDK v7.1.0** — same `X-Axonflow-Client` injection
 - **Plugins** — Claude Code / Cursor / Codex v1.2.0; OpenClaw v2.2.0
-  with Pro license token paste activating Pro features
+ with Pro license token paste activating Pro features
 
 axonflow-sdk-rust remains at v0.1.0 (preview); SDK-Rust will gain the
 header in a future preview release.
@@ -130,7 +115,7 @@ Major release across the AxonFlow SDK family. Companion releases ship the same d
 
 ### Fixed
 
-- The `DO_NOT_TRACK=1 is deprecated...` `console.warn` is no longer emitted on every client construction when `DO_NOT_TRACK=1` is set.
+- The `DO_NOT_TRACK=1 is deprecated.` `console.warn` is no longer emitted on every client construction when `DO_NOT_TRACK=1` is set.
 
 ## [6.2.0] - 2026-04-28 — listProviders() + example modernization
 
@@ -145,14 +130,14 @@ Minor release. New LLM-provider listing API closes the parity gap with the Java 
 - **`examples/basic/`** — rewritten to use the modern Gateway-Mode (`getPolicyApprovedContext` + `auditLLMCall`) and Proxy-Mode (`proxyLLMCall`) APIs. The previous version used the deprecated `protect()` helper (deprecated in v6.0.0).
 - **`examples/connectors/`** — `installConnector()` now uses the correct snake-case `connector_id` (was `connectorId`) and supplies the required `tenant_id` (sourced from `AXONFLOW_TENANT_ID`, falls back to `AXONFLOW_CLIENT_ID`).
 - **`examples/planning/`** — `PlanStep` field rename: `step.dependsOn` (was `step.dependencies`).
-- **`examples/proxy-mode/`** — `client.executeQuery(...)` → `client.proxyLLMCall(...)` (renamed in v6.0.0).
+- **`examples/proxy-mode/`** — `client.executeQuery(.)` → `client.proxyLLMCall(.)` (renamed in v6.0.0).
 - **All examples** — standardized on `import { AxonFlow } from '@axonflow/sdk'`; replaced the decommissioned `staging-eu.getaxonflow.com` default with `http://localhost:8080`.
 - **`examples/README.md`** — corrected env-var names (`AXONFLOW_CLIENT_ID` / `AXONFLOW_CLIENT_SECRET`, not `AXONFLOW_API_KEY` / `AXONFLOW_TENANT`); runner instructions use `tsx` instead of `ts-node`.
 
 ### Changed
 
-- **SDK default endpoint** is now `http://localhost:8080` (was `https://staging-eu.getaxonflow.com`). Constructing `new AxonFlow({...})` without an explicit `endpoint` previously routed every request to a host that was decommissioned 2026-04-09. Production callers passing an explicit `endpoint` are unaffected.
-- **`AxonFlow.sandbox(...)`** now targets `http://localhost:8080` for the same reason. Override via the regular constructor for hosted environments.
+- **SDK default endpoint** is now `http://localhost:8080` (was `https://staging-eu.getaxonflow.com`). Constructing `new AxonFlow({.})` without an explicit `endpoint` previously routed every request to a host that was decommissioned 2026-04-09. Production callers passing an explicit `endpoint` are unaffected.
+- **`AxonFlow.sandbox(.)`** now targets `http://localhost:8080` for the same reason. Override via the regular constructor for hosted environments.
 
 ## [6.1.0] - 2026-04-25 — Plugin Batch 1 explainability fields on MCP responses
 
@@ -163,15 +148,15 @@ Coordinated cycle: Python v6.8.0 / Go v5.8.0 / Java v6.1.0 ship same day with th
 ### Added
 
 - **`MCPCheckInputResponse`** gains 5 optional Plugin Batch 1 fields:
-  - `decision_id?: string` — audit correlator
-  - `risk_level?: 'low' | 'medium' | 'high' | 'critical'`
-  - `policy_matches?: MCPExplainPolicy[]` — per-policy explainability records (snake_case wire shape)
-  - `override_available?: boolean` — whether session override is permitted for the matched policies
-  - `override_existing_id?: string` — already-active override consumed by this decision (if any)
+ - `decision_id?: string` — audit correlator
+ - `risk_level?: 'low' | 'medium' | 'high' | 'critical'`
+ - `policy_matches?: MCPExplainPolicy[]` — per-policy explainability records (snake_case wire shape)
+ - `override_available?: boolean` — whether session override is permitted for the matched policies
+ - `override_existing_id?: string` — already-active override consumed by this decision (if any)
 - **`MCPCheckOutputResponse`** gains 3 optional fields:
-  - `decision_id?: string`
-  - `policy_matches?: MCPExplainPolicy[]`
-  - `redacted_message?: string` — text-redaction counterpart to `redacted_data` (used when the connector returned a string message rather than tabular rows; e.g. execute-style responses)
+ - `decision_id?: string`
+ - `policy_matches?: MCPExplainPolicy[]`
+ - `redacted_message?: string` — text-redaction counterpart to `redacted_data` (used when the connector returned a string message rather than tabular rows; e.g. execute-style responses)
 - **`MCPExplainPolicy`** — new exported interface for the per-policy explainability record on MCP responses (snake_case wire shape). Fields: `policy_id`, `policy_name?`, `action?`, `risk_level?`, `allow_override?`, `policy_description?`. Distinct from the existing camelCase `ExplainPolicy` (in `src/types/decisions.ts`), which is the hand-decoded view returned by `client.explainDecision()`. Both describe the same logical record; the dual-name distinction follows the SDK's existing wire-vs-decoded convention. A future release may consolidate.
 
 All fields are optional. Pre-v7.1.0 platforms return `undefined` for every field; callers should treat absence as "context not available" rather than an error.
@@ -248,40 +233,40 @@ Two platform-side spec corrections filed alongside this work, for issues the aud
 ### Added
 
 - **Rich `ApproveStepResponse` / `RejectStepResponse`** — both types now carry
-  the same shape as the step-gate response: `decision` resolves to `"allow"` /
-  `"block"`, `retry_context` mirrors the gate retry state, `approved_by` /
-  `approved_at` / `rejected_by` / `rejected_at` carry reviewer identity,
-  `approval_id` is the deterministic HITL queue UUID, `policies_matched`
-  reconstructs the governance trail. Legacy fields (`workflow_id`, `step_id`,
-  `status`) are preserved for back-compat.
+ the same shape as the step-gate response: `decision` resolves to `"allow"` /
+ `"block"`, `retry_context` mirrors the gate retry state, `approved_by` /
+ `approved_at` / `rejected_by` / `rejected_at` carry reviewer identity,
+ `approval_id` is the deterministic HITL queue UUID, `policies_matched`
+ reconstructs the governance trail. Legacy fields (`workflow_id`, `step_id`,
+ `status`) are preserved for back-compat.
 - **`plan_id` on both approve/reject responses** — populated when the response
-  comes from the MAP plan-scoped endpoint (`/api/v1/plans/{id}/steps/{step_id}/approve|reject`);
-  empty on WCP plane responses. Same SDK types work across both endpoints.
+ comes from the MAP plan-scoped endpoint (`/api/v1/plans/{id}/steps/{step_id}/approve|reject`);
+ empty on WCP plane responses. Same SDK types work across both endpoints.
 - **`getPendingPlanApprovals`** — new client method that lists MAP-plane
-  pending approvals (`GET /api/v1/plans/approvals/pending`), the counterpart
-  of `getPendingApprovals` for the WCP plane. Accepts an optional `plan_id`
-  filter via `PendingApprovalsOptions` so reviewer tools can scope the listing
-  to one plan. Available on Evaluation+ licenses (same tier gate as the MAP
-  step approve/reject endpoints).
+ pending approvals (`GET /api/v1/plans/approvals/pending`), the counterpart
+ of `getPendingApprovals` for the WCP plane. Accepts an optional `plan_id`
+ filter via `PendingApprovalsOptions` so reviewer tools can scope the listing
+ to one plan. Available on Evaluation+ licenses (same tier gate as the MAP
+ step approve/reject endpoints).
 - **`PendingApproval.plan_id`** — populated on MAP-plane entries, absent on
-  WCP-plane entries. Mirrors the approve/reject asymmetry. `PendingApproval`
-  also gains `step_index`, `decision`, `decision_reason`, `policies_matched`,
-  `step_input`, and `approval_status` so reviewer tools can render the full
-  approval context without a second request.
+ WCP-plane entries. Mirrors the approve/reject asymmetry. `PendingApproval`
+ also gains `step_index`, `decision`, `decision_reason`, `policies_matched`,
+ `step_input`, and `approval_status` so reviewer tools can render the full
+ approval context without a second request.
 
 ### Fixed
 
 - **`approveStep` / `rejectStep` / `getPendingApprovals` endpoint URLs** — all
-  three previously targeted non-existent paths under `/api/v1/workflow-control/`
-  and would fail against a real AxonFlow server. Corrected to the canonical
-  `/api/v1/workflows/{id}/steps/{step_id}/(approve|reject)` and
-  `/api/v1/workflows/approvals/pending` routes. Customers using these methods
-  against a live deployment were receiving 404s; this release makes them work.
+ three previously targeted non-existent paths under `/api/v1/workflow-control/`
+ and would fail against a real AxonFlow server. Corrected to the canonical
+ `/api/v1/workflows/{id}/steps/{step_id}/(approve|reject)` and
+ `/api/v1/workflows/approvals/pending` routes. Customers using these methods
+ against a live deployment were receiving 404s; this release makes them work.
 - **`PendingApprovalsResponse` field names aligned with the wire shape** — the
-  interface previously declared `approvals` and `total`, which never matched
-  the server response (`pending_approvals` and `count`). Renamed to
-  `pending_approvals` / `count`. Callers that read `response.approvals` or
-  `response.total` need to update to the new names.
+ interface previously declared `approvals` and `total`, which never matched
+ the server response (`pending_approvals` and `count`). Renamed to
+ `pending_approvals` / `count`. Callers that read `response.approvals` or
+ `response.total` need to update to the new names.
 
 ### Deprecated
 
@@ -290,42 +275,42 @@ Two platform-side spec corrections filed alongside this work, for issues the aud
 ### Unchanged
 
 - `approveStep(workflowId, stepId)` / `rejectStep(workflowId, stepId, reason?)`
-  signatures are unchanged — only the response fields grew. Callers that only
-  read `workflow_id` / `step_id` / `status` keep working.
+ signatures are unchanged — only the response fields grew. Callers that only
+ read `workflow_id` / `step_id` / `status` keep working.
 
 ## [5.5.0] - 2026-04-21
 
 ### Added
 
 - **`retry_context` and `idempotency_key` support on the step gate** — `StepGateResponse`
-  now carries a non-nullable `retry_context` object on every gate call with the true
-  `(workflow_id, step_id)` lifecycle: `gate_count`, `completion_count`,
-  `prior_completion_status` (`'none' | 'completed' | 'gated_not_completed'`),
-  `prior_output_available`, `prior_output`, `prior_completion_at`, `first_attempt_at`,
-  `last_attempt_at`, `last_decision`, and `idempotency_key`. Prefer these fields to
-  the legacy `cached` / `decision_source` fields.
-- **`stepGate(..., options)`** — new optional fourth argument
-  `{ includePriorOutput?: boolean }`. When `true`, the SDK sends
-  `?include_prior_output=true` and `retry_context.prior_output` is populated when a
-  prior `/complete` has landed. Existing callers that omit `options` behave unchanged.
+ now carries a non-nullable `retry_context` object on every gate call with the true
+ `(workflow_id, step_id)` lifecycle: `gate_count`, `completion_count`,
+ `prior_completion_status` (`'none' | 'completed' | 'gated_not_completed'`),
+ `prior_output_available`, `prior_output`, `prior_completion_at`, `first_attempt_at`,
+ `last_attempt_at`, `last_decision`, and `idempotency_key`. Prefer these fields to
+ the legacy `cached` / `decision_source` fields.
+- **`stepGate(., options)`** — new optional fourth argument
+ `{ includePriorOutput?: boolean }`. When `true`, the SDK sends
+ `?include_prior_output=true` and `retry_context.prior_output` is populated when a
+ prior `/complete` has landed. Existing callers that omit `options` behave unchanged.
 - **`StepGateRequest.idempotency_key`** — caller-supplied opaque business-level key
-  (max 255 chars). Immutable once recorded on the first gate call for a
-  `(workflow_id, step_id)`; subsequent gate/complete calls must pass the same key.
+ (max 255 chars). Immutable once recorded on the first gate call for a
+ `(workflow_id, step_id)`; subsequent gate/complete calls must pass the same key.
 - **`MarkStepCompletedRequest.idempotency_key`** — must match the key set on the
-  corresponding gate call, if any. Mismatch (including missing-vs-set on either side)
-  surfaces as a typed `IdempotencyKeyMismatchError`.
+ corresponding gate call, if any. Mismatch (including missing-vs-set on either side)
+ surfaces as a typed `IdempotencyKeyMismatchError`.
 - **`IdempotencyKeyMismatchError`** — typed error thrown by `stepGate` and
-  `markStepCompleted` when the platform returns HTTP 409 with
-  `error.code === "IDEMPOTENCY_KEY_MISMATCH"`. Surfaces `workflowId`, `stepId`,
-  `expectedIdempotencyKey`, `receivedIdempotencyKey`, and the human-readable `message`.
+ `markStepCompleted` when the platform returns HTTP 409 with
+ `error.code === "IDEMPOTENCY_KEY_MISMATCH"`. Surfaces `workflowId`, `stepId`,
+ `expectedIdempotencyKey`, `receivedIdempotencyKey`, and the human-readable `message`.
 - **`RetryContext`, `PriorCompletionStatus`, `StepGateOptions`** — exported TypeScript
-  types.
+ types.
 
 ### Deprecated
 
 - **`StepGateResponse.cached`** and **`StepGateResponse.decision_source`** — still
-  populated but deprecated in favor of `retry_context.gate_count > 1` and
-  `retry_context.prior_completion_status`. Planned for removal in a future major version.
+ populated but deprecated in favor of `retry_context.gate_count > 1` and
+ `retry_context.prior_completion_status`. Planned for removal in a future major version.
 
 ### Compatibility
 
@@ -338,28 +323,28 @@ callers that never set `idempotency_key` or `includePriorOutput` see no behavior
 ### Added
 
 - **Execution boundary semantics** — `RetryPolicy` type union
-  (`'idempotent' | 'reevaluate'`). Step gate requests accept `retry_policy`
-  to control cached vs fresh evaluation behavior.
+ (`'idempotent' | 'reevaluate'`). Step gate requests accept `retry_policy`
+ to control cached vs fresh evaluation behavior.
 - **Step gate response metadata** — `cached` (boolean) and `decision_source`
-  (string) fields on `StepGateResponse`.
+ (string) fields on `StepGateResponse`.
 - **Workflow checkpoints** — `getCheckpoints(workflowId)` lists step-gate
-  checkpoints. `resumeFromCheckpoint(workflowId, checkpointId)` resumes
-  from a specific checkpoint with fresh policy evaluation (Enterprise).
+ checkpoints. `resumeFromCheckpoint(workflowId, checkpointId)` resumes
+ from a specific checkpoint with fresh policy evaluation (Enterprise).
 - **Checkpoint types** — `Checkpoint`, `CheckpointListResponse`, and
-  `ResumeFromCheckpointResponse` interfaces.
+ `ResumeFromCheckpointResponse` interfaces.
 - **`AxonFlow.explainDecision(decisionId)`** — fetches the full explanation for a
-  previously-made policy decision via `GET /api/v1/decisions/:id/explain`.
-  Returns a `DecisionExplanation` with matched policies, risk level, reason,
-  override availability, existing override ID (if any), and a rolling-24h
-  session hit count for the matched rule. Shape is frozen; additive-only
-  fields ensure forward compatibility.
+ previously-made policy decision via `GET /api/v1/decisions/:id/explain`.
+ Returns a `DecisionExplanation` with matched policies, risk level, reason,
+ override availability, existing override ID (if any), and a rolling-24h
+ session hit count for the matched rule. Shape is frozen; additive-only
+ fields ensure forward compatibility.
 - **`DecisionExplanation`, `ExplainPolicy`, `ExplainRule`** — new TypeScript
-  interfaces exported from `@axonflow/sdk`.
+ interfaces exported from `@axonflow/sdk`.
 - **`AuditSearchRequest.decisionId`, `.policyName`, `.overrideId`** — three
-  new optional filter fields on `searchAuditLogs`. Use `decisionId` to gather
-  every record tied to one decision; `policyName` to find everything matched
-  by a specific policy; `overrideId` to reconstruct an override's full
-  lifecycle (`override_created` → `override_used` → `override_expired | override_revoked`).
+ new optional filter fields on `searchAuditLogs`. Use `decisionId` to gather
+ every record tied to one decision; `policyName` to find everything matched
+ by a specific policy; `overrideId` to reconstruct an override's full
+ lifecycle (`override_created` → `override_used` → `override_expired | override_revoked`).
 
 ### Compatibility
 
@@ -458,11 +443,11 @@ server-side filtering activates on v7.1.0+ platforms.
 ### Added
 
 - `AxonFlowLangGraphAdapter` class — wraps LangGraph workflows with AxonFlow governance gates and per-tool policy enforcement. Includes:
-  - `checkGate()` / `stepCompleted()` — step-level governance at LangGraph node boundaries
-  - `checkToolGate()` / `toolCompleted()` — per-tool governance within tool_call nodes (each tool gets its own gate check)
-  - `mcpToolInterceptor()` — factory returning an interceptor that enforces `mcp_check_input → handler → mcp_check_output` around every MCP tool call
-  - `waitForApproval()` — poll until a step is approved or rejected
-  - `startWorkflow()` / `completeWorkflow()` / `abortWorkflow()` / `failWorkflow()` — workflow lifecycle management
+ - `checkGate()` / `stepCompleted()` — step-level governance at LangGraph node boundaries
+ - `checkToolGate()` / `toolCompleted()` — per-tool governance within tool_call nodes (each tool gets its own gate check)
+ - `mcpToolInterceptor()` — factory returning an interceptor that enforces `mcp_check_input → handler → mcp_check_output` around every MCP tool call
+ - `waitForApproval()` — poll until a step is approved or rejected
+ - `startWorkflow()` / `completeWorkflow()` / `abortWorkflow()` / `failWorkflow()` — workflow lifecycle management
 - `WorkflowBlockedError` and `WorkflowApprovalRequiredError` exception classes
 - `MCPInterceptorOptions` and `LangGraphAdapterOptions` configuration interfaces
 - `getCircuitBreakerStatus()` — query active circuit breaker circuits and emergency stop state
@@ -500,10 +485,10 @@ server-side filtering activates on v7.1.0+ platforms.
 ### Breaking Changes
 
 - **Removed `total_steps` from `CreateWorkflowRequest`**. Requires Platform v4.5.0+ (recommended v5.0.0+).
-  Total steps are auto-computed when the workflow reaches a terminal state.
+ Total steps are auto-computed when the workflow reaches a terminal state.
 - **`mcpCheckInput()` default `operation` changed from `"query"` to `"execute"`**. Callers relying on
-  the implicit `"query"` default must now pass `operation: "query"` explicitly.
-  Aligns TypeScript SDK behavior with Python, Java, and Go SDKs.
+ the implicit `"query"` default must now pass `operation: "query"` explicitly.
+ Aligns TypeScript SDK behavior with Python, Java, and Go SDKs.
 
 ### Note
 
@@ -544,10 +529,10 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 ### Added
 
 - **MCP Policy-Check Endpoints** (Platform v4.6.0+): Standalone policy validation for external orchestrators (LangGraph, CrewAI) to enforce AxonFlow policies without executing connector queries
-  - `mcpCheckInput(options)`: Validate SQL/commands against input policies (SQLi detection, dangerous query blocking, PII in queries, dynamic policies). Returns `allowed: true` or `blockReason` with details
-  - `mcpCheckOutput(options)`: Validate MCP response data against output policies (PII redaction, exfiltration limits, dynamic policies). Returns original or redacted data with `policyInfo`
-  - New types: `MCPCheckInputOptions`, `MCPCheckInputResponse`, `MCPCheckOutputOptions`, `MCPCheckOutputResponse`
-  - Supports both query-style (`responseData`) and execute-style (`message` + `metadata`) output validation
+ - `mcpCheckInput(options)`: Validate SQL/commands against input policies (SQLi detection, dangerous query blocking, PII in queries, dynamic policies). Returns `allowed: true` or `blockReason` with details
+ - `mcpCheckOutput(options)`: Validate MCP response data against output policies (PII redaction, exfiltration limits, dynamic policies). Returns original or redacted data with `policyInfo`
+ - New types: `MCPCheckInputOptions`, `MCPCheckInputResponse`, `MCPCheckOutputOptions`, `MCPCheckOutputResponse`
+ - Supports both query-style (`responseData`) and execute-style (`message` + `metadata`) output validation
 
 ---
 
@@ -583,16 +568,16 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 
 ### Added
 
-- **failWorkflow()** (#1187): Fail a workflow with optional reason
-  - `async failWorkflow(workflowId: string, reason?: string): Promise<void>`
-  - Sends `POST /api/v1/workflows/{id}/fail`
+- **failWorkflow()**: Fail a workflow with optional reason
+ - `async failWorkflow(workflowId: string, reason?: string): Promise<void>`
+ - Sends `POST /api/v1/workflows/{id}/fail`
 - **HITL Queue API** (Enterprise): Human-in-the-loop approval queue management
-  - `listHITLQueue(opts?)`: list pending approvals with filtering
-  - `getHITLRequest(requestId)`: get approval details
-  - `approveHITLRequest(requestId, review)`: approve a request
-  - `rejectHITLRequest(requestId, review)`: reject a request
-  - `getHITLStats()`: dashboard statistics
-  - New types: `HITLApprovalRequest`, `HITLQueueListOptions`, `HITLQueueListResponse`, `HITLReviewInput`, `HITLStats`
+ - `listHITLQueue(opts?)`: list pending approvals with filtering
+ - `getHITLRequest(requestId)`: get approval details
+ - `approveHITLRequest(requestId, review)`: approve a request
+ - `rejectHITLRequest(requestId, review)`: reject a request
+ - `getHITLStats()`: dashboard statistics
+ - New types: `HITLApprovalRequest`, `HITLQueueListOptions`, `HITLQueueListResponse`, `HITLReviewInput`, `HITLStats`
 
 ## [3.3.1] - 2026-02-12
 
@@ -610,86 +595,86 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 
 ### Added
 
-- **WCP Approval Gates** (Issue #1169): HITL approval and rejection for workflow steps
-  - `approveStep(workflowId, stepId)` - Approve a pending workflow step
-  - `rejectStep(workflowId, stepId, reason?)` - Reject a step with optional reason
-  - `getPendingApprovals(options?)` - List steps awaiting human approval
+- **WCP Approval Gates**: HITL approval and rejection for workflow steps
+ - `approveStep(workflowId, stepId)` - Approve a pending workflow step
+ - `rejectStep(workflowId, stepId, reason?)` - Reject a step with optional reason
+ - `getPendingApprovals(options?)` - List steps awaiting human approval
 
-- **MAP Plan Cancellation** (Issue #1072): Cancel running multi-agent plans
-  - `cancelPlan(planId, reason?)` - Cancel a plan with optional reason
+- **MAP Plan Cancellation**: Cancel running multi-agent plans
+ - `cancelPlan(planId, reason?)` - Cancel a plan with optional reason
 
-- **MAP Plan Update** (Issue #1072): Modify plan configuration before or during execution
-  - `updatePlan(planId, request)` - Update execution mode, domain, or version
+- **MAP Plan Update**: Modify plan configuration before or during execution
+ - `updatePlan(planId, request)` - Update execution mode, domain, or version
 
-- **MAP Plan Versioning and Rollback** (Issue #1072): Version history and rollback support
-  - `getPlanVersions(planId)` - List plan version history
-  - `rollbackPlan(planId, version)` - Rollback to a previous version (returns 409 on version conflict)
-  - New types: `RollbackPlanResponse` (with `planId`, `version`, `previousVersion`, `status`), `PlanVersion`
+- **MAP Plan Versioning and Rollback**: Version history and rollback support
+ - `getPlanVersions(planId)` - List plan version history
+ - `rollbackPlan(planId, version)` - Rollback to a previous version (returns 409 on version conflict)
+ - New types: `RollbackPlanResponse` (with `planId`, `version`, `previousVersion`, `status`), `PlanVersion`
 
-- **Webhook Subscriptions** (Issue #1169): Event notification management
-  - `createWebhook(request)` - Create a webhook subscription for gate decisions, workflow events
-  - `listWebhooks()` - List active webhook subscriptions
-  - `getWebhook(webhookId)` - Get webhook subscription details
-  - `updateWebhook(webhookId, request)` - Update webhook URL, events, or secret
-  - `deleteWebhook(webhookId)` - Delete a webhook subscription
-  - New type: `WebhookSubscription`
+- **Webhook Subscriptions**: Event notification management
+ - `createWebhook(request)` - Create a webhook subscription for gate decisions, workflow events
+ - `listWebhooks()` - List active webhook subscriptions
+ - `getWebhook(webhookId)` - Get webhook subscription details
+ - `updateWebhook(webhookId, request)` - Update webhook URL, events, or secret
+ - `deleteWebhook(webhookId)` - Delete a webhook subscription
+ - New type: `WebhookSubscription`
 
-- **Unified Execution Cancellation** (EPIC #1074): Cancel running executions across both MAP and WCP subsystems
-  - `cancelExecution(executionId, reason?)` - Cancel a unified execution via `POST /api/v1/unified/executions/{id}/cancel`
-  - Propagates to MAP `cancelPlan()` or WCP `abortWorkflow()` based on execution type
+- **Unified Execution Cancellation**: Cancel running executions across both MAP and WCP subsystems
+ - `cancelExecution(executionId, reason?)` - Cancel a unified execution via `POST /api/v1/unified/executions/{id}/cancel`
+ - Propagates to MAP `cancelPlan()` or WCP `abortWorkflow()` based on execution type
 
-- **Unified Execution Tracking** (Issue #1075 - EPIC #1074): Consistent status tracking for MAP plans and WCP workflows
-  - `getExecutionStatus(executionId)` - Get unified execution status by ID
-  - `listUnifiedExecutions(options)` - List executions with type/status filters
-  - `ExecutionStatus` type with unified fields for both MAP and WCP executions
-  - `ExecutionType` enum: `map_plan`, `wcp_workflow`
-  - `ExecutionStatusValue` enum: `pending`, `running`, `completed`, `failed`, `cancelled`, `aborted`, `expired`
-  - `StepStatusValue` enum: `pending`, `running`, `completed`, `failed`, `skipped`, `blocked`, `approval`
-  - `UnifiedStepType` enum: `llm_call`, `tool_call`, `connector_call`, `human_task`, `synthesis`, `action`, `gate`
-  - `UnifiedStepStatus` type with step-level details (duration, cost, policy decisions)
-  - `ExecutionHelpers` utilities: `isTerminal()`, `isStepTerminal()`, `isStepBlocking()`, `calculateProgress()`, `getCurrentStep()`, `calculateTotalCost()`, `isMapPlan()`, `isWcpWorkflow()`
-  - Consistent response format across MAP Multi-Agent Planning and WCP Workflow Control Plane
+- **Unified Execution Tracking**: Consistent status tracking for MAP plans and WCP workflows
+ - `getExecutionStatus(executionId)` - Get unified execution status by ID
+ - `listUnifiedExecutions(options)` - List executions with type/status filters
+ - `ExecutionStatus` type with unified fields for both MAP and WCP executions
+ - `ExecutionType` enum: `map_plan`, `wcp_workflow`
+ - `ExecutionStatusValue` enum: `pending`, `running`, `completed`, `failed`, `cancelled`, `aborted`, `expired`
+ - `StepStatusValue` enum: `pending`, `running`, `completed`, `failed`, `skipped`, `blocked`, `approval`
+ - `UnifiedStepType` enum: `llm_call`, `tool_call`, `connector_call`, `human_task`, `synthesis`, `action`, `gate`
+ - `UnifiedStepStatus` type with step-level details (duration, cost, policy decisions)
+ - `ExecutionHelpers` utilities: `isTerminal()`, `isStepTerminal()`, `isStepBlocking()`, `calculateProgress()`, `getCurrentStep()`, `calculateTotalCost()`, `isMapPlan()`, `isWcpWorkflow()`
+ - Consistent response format across MAP Multi-Agent Planning and WCP Workflow Control Plane
 
-- **Workflow Control Plane** (Issue #834): Governance gates for external orchestrators
-  - "LangChain runs the workflow. AxonFlow decides when it's allowed to move forward."
-  - `createWorkflow()` - Register workflows from LangChain/LangGraph/CrewAI/external
-  - `stepGate()` - Check if step is allowed to proceed (allow/block/require_approval)
-  - `markStepCompleted()` - Mark a step as completed with optional output data
-  - `getWorkflow()` - Get workflow status and step history
-  - `listWorkflows()` - List workflows with filters (status, source, pagination)
-  - `completeWorkflow()` - Mark workflow as completed
-  - `abortWorkflow()` - Abort workflow with reason
-  - `resumeWorkflow()` - Resume after approval
-  - New types: `WorkflowStatus`, `WorkflowSource`, `GateDecision`, `StepType`, `ApprovalStatus`, `MarkStepCompletedRequest`
-  - Helper utilities in `WorkflowHelpers`: `isAllowed()`, `isBlocked()`, `requiresApproval()` (gate decisions)
-  - Helper utilities in `WorkflowHelpers`: `isTerminal()` (workflow status)
+- **Workflow Control Plane**: Governance gates for external orchestrators
+ - "LangChain runs the workflow. AxonFlow decides when it's allowed to move forward."
+ - `createWorkflow()` - Register workflows from LangChain/LangGraph/CrewAI/external
+ - `stepGate()` - Check if step is allowed to proceed (allow/block/require_approval)
+ - `markStepCompleted()` - Mark a step as completed with optional output data
+ - `getWorkflow()` - Get workflow status and step history
+ - `listWorkflows()` - List workflows with filters (status, source, pagination)
+ - `completeWorkflow()` - Mark workflow as completed
+ - `abortWorkflow()` - Abort workflow with reason
+ - `resumeWorkflow()` - Resume after approval
+ - New types: `WorkflowStatus`, `WorkflowSource`, `GateDecision`, `StepType`, `ApprovalStatus`, `MarkStepCompletedRequest`
+ - Helper utilities in `WorkflowHelpers`: `isAllowed()`, `isBlocked()`, `requiresApproval()` (gate decisions)
+ - Helper utilities in `WorkflowHelpers`: `isTerminal()` (workflow status)
 
-- **Workflow Policy Enforcement** (Issues #1019, #1020, #1021): Policy transparency for workflow operations
-  - `StepGateResponse` now includes `policiesEvaluated` and `policiesMatched` fields with `PolicyMatch` type
-  - `PolicyMatch` interface with `policy_id`, `policy_name`, `action`, `reason` for policy transparency
-  - `PolicyEvaluationResult` interface for MAP execution with `allowed`, `applied_policies`, `risk_score`
-  - Workflow operations (`workflow_created`, `workflow_step_gate`, `workflow_completed`) logged to audit trail
+- **Workflow Policy Enforcement**: Policy transparency for workflow operations
+ - `StepGateResponse` now includes `policiesEvaluated` and `policiesMatched` fields with `PolicyMatch` type
+ - `PolicyMatch` interface with `policy_id`, `policy_name`, `action`, `reason` for policy transparency
+ - `PolicyEvaluationResult` interface for MAP execution with `allowed`, `applied_policies`, `risk_score`
+ - Workflow operations (`workflow_created`, `workflow_step_gate`, `workflow_completed`) logged to audit trail
 
 - **MAS FEAT Compliance Module** (Enterprise): Singapore financial services AI governance
-  - AI System Registry: `masfeat.registerSystem()`, `masfeat.getSystem()`, `masfeat.updateSystem()`, `masfeat.listSystems()`, `masfeat.activateSystem()`, `masfeat.retireSystem()`, `masfeat.getRegistrySummary()`
-  - 3-Dimensional Risk Rating: Customer Impact × Model Complexity × Human Reliance
-  - Materiality Classification: High (sum≥12), Medium (sum≥8), Low (sum<8)
-  - FEAT Assessments: `masfeat.createAssessment()`, `masfeat.getAssessment()`, `masfeat.updateAssessment()`, `masfeat.listAssessments()`, `masfeat.submitAssessment()`, `masfeat.approveAssessment()`, `masfeat.rejectAssessment()`
-  - Assessment Lifecycle: pending → in_progress → completed → approved/rejected
-  - Kill Switch: `masfeat.getKillSwitch()`, `masfeat.configureKillSwitch()`, `masfeat.checkKillSwitch()`, `masfeat.triggerKillSwitch()`, `masfeat.restoreKillSwitch()`, `masfeat.enableKillSwitch()`, `masfeat.disableKillSwitch()`, `masfeat.getKillSwitchHistory()`
-  - Automatic model shutdown based on accuracy, bias, and error rate thresholds
-  - New types: `AISystemRegistry`, `AISystemUseCase`, `MaterialityClassification`, `SystemStatus`, `FEATAssessment`, `FEATAssessmentStatus`, `FEATPillar`, `KillSwitch`, `KillSwitchStatus`, `KillSwitchEvent`, `KillSwitchEventType`, `RegistrySummary`
+ - AI System Registry: `masfeat.registerSystem()`, `masfeat.getSystem()`, `masfeat.updateSystem()`, `masfeat.listSystems()`, `masfeat.activateSystem()`, `masfeat.retireSystem()`, `masfeat.getRegistrySummary()`
+ - 3-Dimensional Risk Rating: Customer Impact × Model Complexity × Human Reliance
+ - Materiality Classification: High (sum≥12), Medium (sum≥8), Low (sum<8)
+ - FEAT Assessments: `masfeat.createAssessment()`, `masfeat.getAssessment()`, `masfeat.updateAssessment()`, `masfeat.listAssessments()`, `masfeat.submitAssessment()`, `masfeat.approveAssessment()`, `masfeat.rejectAssessment()`
+ - Assessment Lifecycle: pending → in_progress → completed → approved/rejected
+ - Kill Switch: `masfeat.getKillSwitch()`, `masfeat.configureKillSwitch()`, `masfeat.checkKillSwitch()`, `masfeat.triggerKillSwitch()`, `masfeat.restoreKillSwitch()`, `masfeat.enableKillSwitch()`, `masfeat.disableKillSwitch()`, `masfeat.getKillSwitchHistory()`
+ - Automatic model shutdown based on accuracy, bias, and error rate thresholds
+ - New types: `AISystemRegistry`, `AISystemUseCase`, `MaterialityClassification`, `SystemStatus`, `FEATAssessment`, `FEATAssessmentStatus`, `FEATPillar`, `KillSwitch`, `KillSwitchStatus`, `KillSwitchEvent`, `KillSwitchEventType`, `RegistrySummary`
 
-- **MCP Exfiltration Detection** (Issue #966): `MCPPolicyInfo` now includes `exfiltration_check` with row/volume limit information
-  - `ExfiltrationCheckInfo` type with `rows_returned`, `row_limit`, `bytes_returned`, `byte_limit`, `within_limits` fields
-  - Prevents large-scale data extraction via MCP queries
-  - Configurable via `MCP_MAX_ROWS_PER_QUERY` and `MCP_MAX_BYTES_PER_QUERY` environment variables
+- **MCP Exfiltration Detection**: `MCPPolicyInfo` now includes `exfiltration_check` with row/volume limit information
+ - `ExfiltrationCheckInfo` type with `rows_returned`, `row_limit`, `bytes_returned`, `byte_limit`, `within_limits` fields
+ - Prevents large-scale data extraction via MCP queries
+ - Configurable via `MCP_MAX_ROWS_PER_QUERY` and `MCP_MAX_BYTES_PER_QUERY` environment variables
 
-- **MCP Dynamic Policies** (Issue #968): `MCPPolicyInfo` now includes `dynamic_policy_info` for Orchestrator-evaluated policies
-  - `DynamicPolicyInfo` type with `policies_evaluated`, `matched_policies`, `orchestrator_reachable`, `processing_time_ms`
-  - `DynamicPolicyMatch` type with `policy_id`, `policy_name`, `policy_type`, `action`, `reason`
-  - Supports rate limiting, budget controls, time-based access, and role-based access policies
-  - Optional feature - enable via `MCP_DYNAMIC_POLICIES_ENABLED=true`
+- **MCP Dynamic Policies**: `MCPPolicyInfo` now includes `dynamic_policy_info` for Orchestrator-evaluated policies
+ - `DynamicPolicyInfo` type with `policies_evaluated`, `matched_policies`, `orchestrator_reachable`, `processing_time_ms`
+ - `DynamicPolicyMatch` type with `policy_id`, `policy_name`, `policy_type`, `action`, `reason`
+ - Supports rate limiting, budget controls, time-based access, and role-based access policies
+ - Optional feature - enable via `MCP_DYNAMIC_POLICIES_ENABLED=true`
 
 - **`wasRedacted()` helper**: Convenience method on `ConnectorResponse` to check if any fields were redacted by PII policies
 
@@ -697,8 +682,8 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 - **`ListDynamicPoliciesOptions` filters**: Filter dynamic policies by `tier` and `organizationId`, matching static policy list options.
 
 - **proxyLLMCall()**: New primary method for Proxy Mode with improved documentation
-  - Clearly describes Proxy Mode behavior (AxonFlow makes the LLM call on your behalf)
-  - Documents when to use Proxy Mode vs Gateway Mode
+ - Clearly describes Proxy Mode behavior (AxonFlow makes the LLM call on your behalf)
+ - Documents when to use Proxy Mode vs Gateway Mode
 
 - **BudgetInfo**: `QueryResponse.budgetInfo` for budget enforcement (HTTP 402)
 
@@ -712,7 +697,7 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 ### Fixed
 
 - **`executePlan` status hardcoded**: `executePlan()` always returned `status: 'completed'` regardless of actual server response. Now reads status from response (`data.status` > `metadata.status` > default), correctly surfacing `'awaiting_approval'` for WCP confirm mode.
-- **Unified execution API URLs** (EPIC #1074): `getExecutionStatus()` and `listUnifiedExecutions()` now use correct `/api/v1/unified/executions` path (was incorrectly pointing to `/api/v1/executions` which is the Execution Replay API)
+- **Unified execution API URLs**: `getExecutionStatus()` and `listUnifiedExecutions()` now use correct `/api/v1/unified/executions` path (was incorrectly pointing to `/api/v1/executions` which is the Execution Replay API)
 - **`RollbackPlanResponse` field naming**: Response fields use camelCase (`planId`, `previousVersion`) consistent with TypeScript conventions
 - **Gateway Mode smart defaults**: Fixed fallback to `"community"` when no clientId is configured - previously defaulted to `"default"` due to tenant default value
 - **PolicyCategory**: Added `pii-singapore` to PolicyCategory type for Singapore PII detection policies (NRIC, FIN, UEN patterns)
@@ -724,13 +709,13 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 ### Added
 
 - **MCP Policy Enforcement Response Fields**: `mcpQuery()` and `mcpExecute()` now return policy enforcement metadata
-  - `redacted: boolean` - Whether any fields were redacted by PII policies
-  - `redacted_fields: string[]` - JSON paths of redacted fields (e.g., `rows[0].ssn`)
-  - `policy_info: PolicyInfo` - Full policy evaluation metadata
+ - `redacted: boolean` - Whether any fields were redacted by PII policies
+ - `redacted_fields: string[]` - JSON paths of redacted fields (e.g., `rows[0].ssn`)
+ - `policy_info: PolicyInfo` - Full policy evaluation metadata
 
 - **PolicyInfo types**: New types for policy enforcement metadata
-  - `PolicyInfo` - Contains `policies_evaluated`, `blocked`, `block_reason`, `redactions_applied`, `processing_time_ms`, `matched_policies`
-  - `PolicyMatchInfo` - Details of matched policies including `policy_id`, `policy_name`, `category`, `severity`, `action`
+ - `PolicyInfo` - Contains `policies_evaluated`, `blocked`, `block_reason`, `redactions_applied`, `processing_time_ms`, `matched_policies`
+ - `PolicyMatchInfo` - Details of matched policies including `policy_id`, `policy_name`, `category`, `severity`, `action`
 
 ---
 
@@ -739,16 +724,16 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 ### Added
 
 - **OAuth2-style client credentials**: New `clientId` and `clientSecret` configuration options following OAuth2 client credentials pattern.
-  - `clientId` is used for request identification (required for most API calls)
-  - `clientSecret` is optional - community/self-hosted deployments work without it
-  - The old `tenant` field still works as a fallback for `clientId`
+ - `clientId` is used for request identification (required for most API calls)
+ - `clientSecret` is optional - community/self-hosted deployments work without it
+ - The old `tenant` field still works as a fallback for `clientId`
 
 - **Improved error types**: Added `ConnectorError` and `PlanExecutionError` classes for better error handling in connector and MAP operations.
 
 - **Enterprise: Close PR** (`closePR`): Close a PR without merging and optionally delete the branch
-  - Useful for cleaning up test/demo PRs created by code governance examples
-  - Supports all providers: GitHub, GitLab, Bitbucket
-  - Requires enterprise portal authentication
+ - Useful for cleaning up test/demo PRs created by code governance examples
+ - Supports all providers: GitHub, GitLab, Bitbucket
+ - Requires enterprise portal authentication
 
 ### Changed
 
@@ -757,8 +742,8 @@ in v3.5.0. This major version formally acknowledges that breaking change.
 ```typescript
 // Community mode - no secret needed
 const client = new AxonFlow({
-  endpoint: 'http://localhost:8080',
-  clientId: 'my-app',  // Used for request identification
+ endpoint: 'http://localhost:8080',
+ clientId: 'my-app', // Used for request identification
 });
 ```
 
@@ -779,8 +764,8 @@ const client = new AxonFlow({
 
 - **Sensitive Data Category**: Added `'sensitive-data'` to `PolicyCategory` type union for policies that return `sensitive-data` category
 - **Provider Restrictions for Compliance**: Support for `allowed_providers` in dynamic policy action config
-  - Specify allowed providers via `actions: [{ type: 'route', config: { allowed_providers: [...] } }]`
-  - Enables GDPR, HIPAA, and RBI compliance by restricting LLM routing to specific providers
+ - Specify allowed providers via `actions: [{ type: 'route', config: { allowed_providers: [.] } }]`
+ - Enables GDPR, HIPAA, and RBI compliance by restricting LLM routing to specific providers
 - **Category field**: Added `category` field to `CreateDynamicPolicyRequest` and `UpdateDynamicPolicyRequest`
 
 ### Fixed
@@ -788,10 +773,10 @@ const client = new AxonFlow({
 - **toggleDynamicPolicy HTTP Method**: Changed from PATCH to PUT to match API specification
 - **Tenant Header Name**: Changed header from `X-Tenant-ID` to `X-Org-ID` to match API specification
 - **PolicyVersion timestamp parsing**: Fixed `getStaticPolicyVersions()` to correctly transform snake_case API fields (`changed_at`, `changed_by`, `change_type`) to camelCase interface fields
-- **Dynamic Policy Response Parsing**: Fixed all dynamic policy methods to correctly parse wrapped API responses (Issue #886)
-  - Agent proxy returns `{"policies": [...]}` and `{"policy": {...}}` wrappers
-  - Updated `listDynamicPolicies`, `getDynamicPolicy`, `createDynamicPolicy`, `updateDynamicPolicy`, `toggleDynamicPolicy`, `getEffectiveDynamicPolicies`
-  - Added fallback handling for both wrapped and unwrapped responses
+- **Dynamic Policy Response Parsing**: Fixed all dynamic policy methods to correctly parse wrapped API responses
+ - Agent proxy returns `{"policies": [.]}` and `{"policy": {.}}` wrappers
+ - Updated `listDynamicPolicies`, `getDynamicPolicy`, `createDynamicPolicy`, `updateDynamicPolicy`, `toggleDynamicPolicy`, `getEffectiveDynamicPolicies`
+ - Added fallback handling for both wrapped and unwrapped responses
 
 ## [2.0.0] - 2026-01-05
 
@@ -805,9 +790,9 @@ const client = new AxonFlow({
 - **Audit Log Reading**: Added `searchAuditLogs()` for searching audit logs with filters (user email, client ID, time range, request type)
 - **Tenant Audit Logs**: Added `getAuditLogsByTenant()` for retrieving audit logs scoped to a specific tenant
 - **Audit Types**: Added `AuditLogEntry`, `AuditSearchRequest`, `AuditQueryOptions`, and `AuditSearchResponse` types
-- **PII Redaction Support**: Added `requiresRedaction` field to `PolicyApprovalResult` (Issue #891)
-  - When `true`, PII was detected with redact action and response should be processed for redaction
-  - Supports new detection defaults: PII defaults to redact instead of block
+- **PII Redaction Support**: Added `requiresRedaction` field to `PolicyApprovalResult`
+ - When `true`, PII was detected with redact action and response should be processed for redaction
+ - Supports new detection defaults: PII defaults to redact instead of block
 
 ### Changed
 
@@ -820,18 +805,18 @@ const client = new AxonFlow({
 **Before (v1.x):**
 ```typescript
 const client = new AxonFlow({
-  endpoint: 'http://localhost:8080',
-  orchestratorEndpoint: 'http://localhost:8081',
-  portalEndpoint: 'http://localhost:8082',
-  apiKey: 'my-api-key',
+ endpoint: 'http://localhost:8080',
+ orchestratorEndpoint: 'http://localhost:8081',
+ portalEndpoint: 'http://localhost:8082',
+ apiKey: 'my-api-key',
 });
 ```
 
 **After (v2.x):**
 ```typescript
 const client = new AxonFlow({
-  endpoint: 'http://localhost:8080',
-  apiKey: 'my-api-key',
+ endpoint: 'http://localhost:8080',
+ apiKey: 'my-api-key',
 });
 ```
 
@@ -864,8 +849,8 @@ const client = new AxonFlow({
 ### Fixed
 
 - **Connector API Endpoints**: Fixed endpoints to use Orchestrator (port 8081) instead of Agent
-  - `listConnectors()` - Changed from Agent `/api/connectors` to Orchestrator `/api/v1/connectors`
-  - `installConnector()` - Fixed path to `/api/v1/connectors/{id}/install`
+ - `listConnectors()` - Changed from Agent `/api/connectors` to Orchestrator `/api/v1/connectors`
+ - `installConnector()` - Fixed path to `/api/v1/connectors/{id}/install`
 - **Dynamic Policies Endpoint**: Changed from Agent `/api/v1/policies` to Orchestrator `/api/v1/policies/dynamic`
 
 ---
@@ -875,20 +860,20 @@ const client = new AxonFlow({
 ### Added
 
 - **Execution Replay API**: Debug governed workflows with step-by-step state capture
-  - `listExecutions()` - List executions with filtering (status, time range)
-  - `getExecution()` - Get execution with all step snapshots
-  - `getExecutionSteps()` - Get individual step snapshots
-  - `getExecutionTimeline()` - Timeline view for visualization
-  - `exportExecution()` - Export for compliance/archival
-  - `deleteExecution()` - Delete execution records
+ - `listExecutions()` - List executions with filtering (status, time range)
+ - `getExecution()` - Get execution with all step snapshots
+ - `getExecutionSteps()` - Get individual step snapshots
+ - `getExecutionTimeline()` - Timeline view for visualization
+ - `exportExecution()` - Export for compliance/archival
+ - `deleteExecution()` - Delete execution records
 
 - **Cost Controls**: Budget management and LLM usage tracking
-  - `createBudget()` / `getBudget()` / `listBudgets()` - Budget CRUD
-  - `updateBudget()` / `deleteBudget()` - Budget management
-  - `getBudgetStatus()` - Check current budget usage
-  - `checkBudget()` - Pre-request budget validation
-  - `recordUsage()` - Record LLM token usage
-  - `getUsageSummary()` - Usage analytics and reporting
+ - `createBudget()` / `getBudget()` / `listBudgets()` - Budget CRUD
+ - `updateBudget()` / `deleteBudget()` - Budget management
+ - `getBudgetStatus()` - Check current budget usage
+ - `checkBudget()` - Pre-request budget validation
+ - `recordUsage()` - Record LLM token usage
+ - `getUsageSummary()` - Usage analytics and reporting
 
 ---
 
@@ -897,9 +882,9 @@ const client = new AxonFlow({
 ### Fixed
 
 - **Gateway Mode Community Support**: `getPolicyApprovedContext()` and `auditLLMCall()` now work without credentials
-  - Removed SDK-level credential check that blocked community mode usage
-  - Server decides whether to require authentication based on `DEPLOYMENT_MODE`
-  - Consistent with Go/Python SDKs behavior
+ - Removed SDK-level credential check that blocked community mode usage
+ - Server decides whether to require authentication based on `DEPLOYMENT_MODE`
+ - Consistent with Go/Python SDKs behavior
 
 ---
 
@@ -908,9 +893,9 @@ const client = new AxonFlow({
 ### Changed
 
 - **Community Mode**: Credentials are now optional for self-hosted/community deployments
-  - SDK can be initialized without `apiKey` or `licenseKey` for community features
-  - `executeQuery()` and `healthCheck()` work without credentials
-  - Auth headers are only sent when credentials are configured
+ - SDK can be initialized without `apiKey` or `licenseKey` for community features
+ - `executeQuery()` and `healthCheck()` work without credentials
+ - Auth headers are only sent when credentials are configured
 
 ### Added
 
@@ -942,9 +927,9 @@ const client = new AxonFlow({
 ### Added
 
 - **Enterprise Policy Features**:
-  - `organizationId` field in `CreateStaticPolicyRequest` for organization-tier policies
-  - `organizationId` field in `ListStaticPoliciesOptions` for filtering by organization
-  - `listPolicyOverrides()` method to list all active policy overrides
+ - `organizationId` field in `CreateStaticPolicyRequest` for organization-tier policies
+ - `organizationId` field in `ListStaticPoliciesOptions` for filtering by organization
+ - `listPolicyOverrides()` method to list all active policy overrides
 
 ---
 
@@ -953,8 +938,8 @@ const client = new AxonFlow({
 ### Added
 
 - **Code Governance Metrics & Export APIs** (Enterprise): Compliance reporting for AI-generated code
-  - `getCodeGovernanceMetrics()` - Returns aggregated statistics (PR counts, file totals, security findings)
-  - `exportCodeGovernanceData()` - Exports PR records as JSON for auditors
+ - `getCodeGovernanceMetrics()` - Returns aggregated statistics (PR counts, file totals, security findings)
+ - `exportCodeGovernanceData()` - Exports PR records as JSON for auditors
 
 - **New Types**: `CodeGovernanceMetrics`, `ExportOptions`, `ExportResponse`
 
@@ -965,21 +950,21 @@ const client = new AxonFlow({
 ### Added
 
 - **Code Governance Git Provider APIs** (Enterprise): Create PRs from LLM-generated code
-  - `validateGitProvider()` - Validate credentials before saving
-  - `configureGitProvider()` - Configure GitHub, GitLab, or Bitbucket
-  - `listGitProviders()` - List configured providers
-  - `deleteGitProvider()` - Remove a provider
-  - `createPR()` - Create PR from generated code with audit trail
-  - `listPRs()` - List PRs with filtering
-  - `getPR()` - Get PR details
-  - `syncPRStatus()` - Sync status from Git provider
+ - `validateGitProvider()` - Validate credentials before saving
+ - `configureGitProvider()` - Configure GitHub, GitLab, or Bitbucket
+ - `listGitProviders()` - List configured providers
+ - `deleteGitProvider()` - Remove a provider
+ - `createPR()` - Create PR from generated code with audit trail
+ - `listPRs()` - List PRs with filtering
+ - `getPR()` - Get PR details
+ - `syncPRStatus()` - Sync status from Git provider
 
 - **New Types**: `GitProviderType`, `FileAction`, `CodeFile`, `CreatePRRequest`, `CreatePRResponse`, `PRRecord`, `ListPRsOptions`, `ListPRsResponse`
 
 - **Supported Git Providers**:
-  - GitHub (Cloud and Enterprise Server)
-  - GitLab (Cloud and Self-Managed)
-  - Bitbucket (Cloud and Server/Data Center)
+ - GitHub (Cloud and Enterprise Server)
+ - GitLab (Cloud and Self-Managed)
+ - Bitbucket (Cloud and Server/Data Center)
 
 ---
 
@@ -988,13 +973,13 @@ const client = new AxonFlow({
 ### Added
 
 - **HITL Support**: `require_approval` action for human oversight policies
-  - Use with `createStaticPolicy()` to trigger approval workflows
-  - Enterprise: Full HITL queue integration
-  - Community: Auto-approves immediately
+ - Use with `createStaticPolicy()` to trigger approval workflows
+ - Enterprise: Full HITL queue integration
+ - Community: Auto-approves immediately
 
 - **Code Governance**: `CodeArtifact` type for LLM-generated code detection
-  - Language and code type identification
-  - Potential secrets and unsafe pattern detection
+ - Language and code type identification
+ - Potential secrets and unsafe pattern detection
 
 ---
 
@@ -1003,22 +988,22 @@ const client = new AxonFlow({
 ### Added
 
 - **Policy CRUD Methods**: Full policy management support for Unified Policy Architecture v2.0.0
-  - `listStaticPolicies()` - List policies with filtering by tier, category, enabled status
-  - `getStaticPolicy()` - Get single policy by ID
-  - `createStaticPolicy()` - Create custom policy
-  - `updateStaticPolicy()` - Update existing policy
-  - `deleteStaticPolicy()` - Delete policy
-  - `toggleStaticPolicy()` - Enable/disable policy
-  - `getEffectiveStaticPolicies()` - Get merged hierarchy for tenant
-  - `testPattern()` - Test regex pattern against input
+ - `listStaticPolicies()` - List policies with filtering by tier, category, enabled status
+ - `getStaticPolicy()` - Get single policy by ID
+ - `createStaticPolicy()` - Create custom policy
+ - `updateStaticPolicy()` - Update existing policy
+ - `deleteStaticPolicy()` - Delete policy
+ - `toggleStaticPolicy()` - Enable/disable policy
+ - `getEffectiveStaticPolicies()` - Get merged hierarchy for tenant
+ - `testPattern()` - Test regex pattern against input
 
 - **Policy Override Methods** (Enterprise):
-  - `createPolicyOverride()`, `getPolicyOverride()`, `deletePolicyOverride()`
+ - `createPolicyOverride()`, `getPolicyOverride()`, `deletePolicyOverride()`
 
 - **Dynamic Policy Methods**:
-  - `listDynamicPolicies()`, `getDynamicPolicy()`, `createDynamicPolicy()`
-  - `updateDynamicPolicy()`, `deleteDynamicPolicy()`, `toggleDynamicPolicy()`
-  - `getEffectiveDynamicPolicies()`
+ - `listDynamicPolicies()`, `getDynamicPolicy()`, `createDynamicPolicy()`
+ - `updateDynamicPolicy()`, `deleteDynamicPolicy()`, `toggleDynamicPolicy()`
+ - `getEffectiveDynamicPolicies()`
 
 - **New Types**: `StaticPolicy`, `DynamicPolicy`, `PolicyOverride`, `PolicyCategory`, `PolicyTier`, `PolicyAction`
 
@@ -1027,8 +1012,8 @@ const client = new AxonFlow({
 ### Added
 
 - **MAP Timeout Configuration** - New `mapTimeout` config option (default: 120000ms) for Multi-Agent Planning operations
-  - MAP operations involve multiple LLM calls and can take 30-60+ seconds
-  - `generatePlan()` now uses the longer MAP timeout
+ - MAP operations involve multiple LLM calls and can take 30-60+ seconds
+ - `generatePlan()` now uses the longer MAP timeout
 
 ### Fixed
 
@@ -1037,11 +1022,11 @@ const client = new AxonFlow({
 ## [1.4.1] - 2025-12-22
 
 ### Deprecated
-- **`protect()` method**: Now shows deprecation warning at runtime (#14)
-  - Root cause: `extractRequest()` uses `aiCall.toString()` which returns JS source code, not runtime values
-  - This causes `response.choices[0]` to be undefined
-  - Will be removed in v2.0.0
-  - Use Gateway Mode (`getPolicyApprovedContext` + `auditLLMCall`) or Proxy Mode (`executeQuery`) instead
+- **`protect()` method**: Now shows deprecation warning at runtime
+ - Root cause: `extractRequest()` uses `aiCall.toString()` which returns JS source code, not runtime values
+ - This causes `response.choices[0]` to be undefined
+ - Will be removed in v2.0.0
+ - Use Gateway Mode (`getPolicyApprovedContext` + `auditLLMCall`) or Proxy Mode (`executeQuery`) instead
 
 ### Changed
 - Updated README with Gateway Mode and Proxy Mode examples (removed all `protect()` examples)
@@ -1050,14 +1035,14 @@ const client = new AxonFlow({
 ## [1.4.0] - 2025-12-19
 
 ### Deprecated
-- **LLM Interceptor wrappers**: All interceptor functions now show deprecation warnings (#10)
-  - `wrapOpenAIClient()`
-  - `wrapAnthropicClient()`
-  - `wrapGeminiModel()`
-  - `wrapOllamaClient()`
-  - `wrapBedrockClient()`
-  - Will be removed in v2.0.0
-  - Use Gateway Mode or Proxy Mode instead
+- **LLM Interceptor wrappers**: All interceptor functions now show deprecation warnings
+ - `wrapOpenAIClient()`
+ - `wrapAnthropicClient()`
+ - `wrapGeminiModel()`
+ - `wrapOllamaClient()`
+ - `wrapBedrockClient()`
+ - Will be removed in v2.0.0
+ - Use Gateway Mode or Proxy Mode instead
 
 ### Changed
 - Added `@deprecated` JSDoc annotations to all interceptor exports
@@ -1066,12 +1051,12 @@ const client = new AxonFlow({
 ## [1.3.0] - 2025-12-19
 
 ### Added
-- **Proxy Mode**: Full `executeQuery()` implementation for routing requests through AxonFlow (#7)
-  - Supports all request types: `chat`, `sql`, `mcp-query`, `multi-agent-plan`, `execute-plan`
-  - Automatic policy enforcement with `PolicyViolationError` for blocked requests
-  - Rich response with policy info, metadata, and processing details
+- **Proxy Mode**: Full `executeQuery()` implementation for routing requests through AxonFlow
+ - Supports all request types: `chat`, `sql`, `mcp-query`, `multi-agent-plan`, `execute-plan`
+ - Automatic policy enforcement with `PolicyViolationError` for blocked requests
+ - Rich response with policy info, metadata, and processing details
 - **Health Check**: New `healthCheck()` method to verify agent availability
-  - Returns `HealthStatus` with status, version, uptime, and component health
+ - Returns `HealthStatus` with status, version, uptime, and component health
 - New types: `ExecuteQueryOptions`, `ExecuteQueryResponse`, `PolicyInfo`, `HealthStatus`, `RequestType`
 - Proxy Mode example at `examples/proxy-mode/index.ts`
 - Comprehensive integration tests for Proxy Mode
@@ -1083,11 +1068,11 @@ const client = new AxonFlow({
 ## [1.2.1] - 2025-12-15
 
 ### Fixed
-- Fix authorization header handling for plan generation with explicit userToken (#3)
-- Fix policy name extraction from blocked responses - now correctly extracts from `policy_info.policies_evaluated` (#4)
+- Fix authorization header handling for plan generation with explicit userToken
+- Fix policy name extraction from blocked responses - now correctly extracts from `policy_info.policies_evaluated`
 
 ### Added
-- Contract testing with real Agent API response fixtures (#6)
+- Contract testing with real Agent API response fixtures
 - Comprehensive E2E test suite (16 tests) for pre-release validation
 - ESLint linting in CI workflow
 - Codecov coverage reporting


### PR DESCRIPTION
Sweeps CHANGELOG.md to remove engineering-context references that should not be on the customer-facing release surface (ADR refs, issue/Epic/PR numbers, cross-repo references like `axonflow-enterprise#NNNN`, sister-PR cross-references).

Also re-dates the upcoming release header from 2026-05-08 → 2026-05-09 to match the actual ship day.

**Docs-only.** No code, public API, or wire-schema changes.