### PR TITLE
chore(ci): cancel orphaned PR runs + prune Node matrix on PR

### DIFF
--- a/.github/workflows/definition-of-done.yml
+++ b/.github/workflows/definition-of-done.yml
@@ -6,11 +6,16 @@ name: Definition of Done
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    # Drop `edited` — re-runs the gate on title/body edits without any code change.
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint-no-mocks-in-runtime-e2e:

--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 
@@ -31,6 +35,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Set up Python (for harness driver)
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 
@@ -40,8 +44,11 @@ jobs:
     needs: lint
 
     strategy:
+      # PR runs only Node 20.x (current LTS / release toolchain). Push to
+      # main and workflow_dispatch run the full matrix to catch
+      # version-specific drift.
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: ${{ fromJson(github.event_name == 'pull_request' && '["20.x"]' || '["18.x", "20.x", "22.x"]') }}
       fail-fast: false
 
     steps:

--- a/.github/workflows/validate-version-alignment.yml
+++ b/.github/workflows/validate-version-alignment.yml
@@ -38,6 +38,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-versions:
     name: Validate Version Alignment

--- a/.github/workflows/wire-shape-contract.yml
+++ b/.github/workflows/wire-shape-contract.yml
@@ -37,6 +37,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   wire-shape:
     name: Validate Wire Shape


### PR DESCRIPTION
Same shape as axonflow-sdk-java#176 + axonflow-sdk-python#194. Concurrency on 5 workflows + node matrix prune on test.yml (PR: 20.x; push/dispatch: 18.x+20.x+22.x). Heartbeat setup-node now uses npm cache. Public repo, dev-velocity work.