### PR TITLE
feat(identity): emit X-Client-ID header on every outbound request (v9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.0] - 2026-05-19 — `X-Client-ID` header on every outbound request (v9 identity)
+
+**Companion release to the v9 identity cleanup on the platform (Epic #2230).**
+Every governed request now carries an `X-Client-ID: <effective_client_id>`
+header alongside the existing Basic Auth + `X-Axonflow-Client` headers.
+Value matches the SDK's Basic Auth username — smart default `community`
+when no `clientId` is configured.
+
+### Added
+
+- **`X-Client-ID` header on outbound HTTP requests.** Server-side identity
+ decisions no longer need to re-decode Basic Auth. The agent's
+ `apiAuthMiddleware` overwrites the header with its own auth-derived
+ value, so caller-supplied values are harmless (no spoofing surface).
+ Set in `getAuthHeaders` (`src/client.ts`).
+
+### Deprecated
+
+- **`AxonFlowConfig.tenant` field strengthened `@deprecated`.** The field
+ will be REMOVED in v10. Use `clientId` for both authentication identity
+ and tenant routing — the platform derives tenant scope from the
+ authenticated `client_id`. Wire-level `tenant_id` JSON fields on
+ request payloads remain unchanged.
+
+### Compatibility
+
+- Backward-compatible against v8 and v9 platforms: v8 agents ignore the
+ unknown header; v9 agents derive identity from Basic Auth regardless.
+- No removed fields. No changed defaults.
+
 ## [8.0.0] - 2026-05-09 — Decision History API + policy_version recorded on every decision + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/runtime-e2e/x-client-id/test.mjs
+++ b/runtime-e2e/x-client-id/test.mjs
@@ -1,0 +1,40 @@
+// runtime-e2e/x-client-id/test.mjs
+// Real-stack assertion: the SDK's compiled getAuthHeaders emits
+// X-Client-ID: <effective_client_id> (v9) on every governed request.
+// Per CLAUDE.md HARD RULE #0 — this test MUST hit a real agent.
+
+import { AxonFlow } from '../../dist/esm/index.js';
+
+const endpoint = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+const tenantId = process.env.AXONFLOW_TENANT_ID;
+const tenantSecret = process.env.AXONFLOW_TENANT_SECRET;
+if (!tenantId || !tenantSecret) {
+  console.error('AXONFLOW_TENANT_ID + AXONFLOW_TENANT_SECRET must be set; see ../README.md');
+  process.exit(2);
+}
+
+// Wrap fetch so we can capture the SDK's outbound X-Client-ID off the wire.
+// Unlike X-Axonflow-Client, the agent doesn't echo X-Client-ID in error
+// responses — we just verify what the SDK actually sent.
+let captured = '';
+const origFetch = globalThis.fetch;
+globalThis.fetch = async (url, init = {}) => {
+  const headers = init.headers || {};
+  captured = headers['X-Client-ID'] || headers['x-client-id'] || '';
+  return origFetch(url, init);
+};
+
+const client = new AxonFlow({ endpoint, clientId: tenantId, clientSecret: tenantSecret });
+console.log(`Asserting wire X-Client-ID = ${tenantId}`);
+
+try {
+  await client.mcpCheckInput({ connectorType: 'postgres', statement: 'SELECT 1' });
+} catch {
+  // outcome of the call doesn't matter; only the captured header
+}
+
+if (captured !== tenantId) {
+  console.error(`FAIL: wire X-Client-ID = ${JSON.stringify(captured)}, want ${JSON.stringify(tenantId)}`);
+  process.exit(1);
+}
+console.log(`PASS: wire X-Client-ID = ${JSON.stringify(captured)}`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -469,6 +469,12 @@ export class AxonFlow {
     // doesn't get to spoof its own client identity to the agent).
     headers['X-Axonflow-Client'] = `sdk-typescript/${VERSION}`;
 
+    // X-Client-ID (v9): server-side identity decisions don't have to
+    // re-decode Basic auth. The agent's apiAuthMiddleware overwrites
+    // the header with its auth-derived value, so caller-supplied
+    // values are harmless (no spoofing surface).
+    headers['X-Client-ID'] = effectiveClientId;
+
     return headers;
   }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -34,12 +34,18 @@ export interface AxonFlowConfig {
 
   /**
    * Tenant identifier for multi-tenant deployments.
-   * This specifies WHICH organization context.
-   * Separate from authentication identity (clientId).
    *
-   * @deprecated Using tenant without clientId is deprecated.
-   * For authentication, use clientId/clientSecret instead.
-   * Keep tenant only for multi-tenant routing context.
+   * @deprecated Since v8.1.0 (v9 identity cleanup, Epic
+   * getaxonflow/axonflow-enterprise#2230). Use `clientId` for both
+   * authentication identity and tenant routing — the platform now
+   * derives tenant scope from the authenticated client_id rather than
+   * a separate tenant field. The `tenant` field is preserved for
+   * back-compat through the v8.x line and will be REMOVED in v10.
+   *
+   * Migration: replace `tenant: "your-tenant"` with
+   * `clientId: "your-tenant"` (or, if you also have credentials,
+   * `clientId: "your-tenant", clientSecret: "..."`). Wire-level
+   * `tenant_id` JSON fields on request payloads remain unchanged.
    */
   tenant?: string;
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.0.0';
+export const VERSION = '8.1.0';

--- a/tests/x-client-id-header.test.ts
+++ b/tests/x-client-id-header.test.ts
@@ -1,0 +1,72 @@
+/**
+ * X-Client-ID header verification (v9 identity).
+ *
+ * Every governed request carries X-Client-ID alongside Basic Auth. The
+ * agent's apiAuthMiddleware overwrites the header with its own auth-derived
+ * value, so a missing or wrong client-side header is harmless server-side.
+ * These tests pin SDK-emitted behaviour so future regressions are caught
+ * early.
+ */
+
+import { AxonFlow } from '../src/client';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function jsonResponse(body: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('X-Client-ID header (v9)', () => {
+  it('emits X-Client-ID: community when no clientId configured', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true }));
+    const client = new AxonFlow({ endpoint: 'http://localhost:8080' });
+    await client.mcpCheckInput({ connectorType: 'postgres', statement: 'SELECT 1' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Client-ID': 'community' }),
+      })
+    );
+  });
+
+  it('emits X-Client-ID matching the configured clientId', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true }));
+    const client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'acme-corp',
+      clientSecret: 'secret',
+    });
+    await client.mcpCheckInput({ connectorType: 'postgres', statement: 'SELECT 1' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Client-ID': 'acme-corp' }),
+      })
+    );
+  });
+
+  it('does NOT emit legacy X-Tenant-ID (agent accepts it as alias for back-compat)', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true }));
+    const client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'acme-corp',
+      clientSecret: 'secret',
+    });
+    await client.mcpCheckInput({ connectorType: 'postgres', statement: 'SELECT 1' });
+    const [, init] = mockFetch.mock.calls[0];
+    const headers = (init as { headers: Record<string, string> }).headers;
+    expect(headers).not.toHaveProperty('X-Tenant-ID');
+    expect(headers).not.toHaveProperty('x-tenant-id');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the SDK side of Epic [#2230](https://github.com/getaxonflow/axonflow-enterprise/issues/2230) (v9 identity cleanup), workstream B. Every governed request now carries an `X-Client-ID: <effective_client_id>` header alongside the existing Basic Auth + `X-Axonflow-Client` headers.

- Value matches the SDK's existing Basic Auth username — smart default `"community"` when no `clientId` is configured.
- Set in `getAuthHeaders` (`src/client.ts`), the canonical funnel.
- The agent's `apiAuthMiddleware` (PR [getaxonflow/axonflow-enterprise#2233](https://github.com/getaxonflow/axonflow-enterprise/pull/2233)) overwrites the header with its auth-derived value, so caller-supplied values are harmless (no spoofing surface).

Bumps to **v8.1.0**.

## Deprecation

Strengthens the `@deprecated` JSDoc on `AxonFlowConfig.tenant` — the field will be REMOVED in v10. Use `clientId` for both authentication identity and tenant routing. Wire-level `tenant_id` JSON fields on request payloads remain unchanged.

## Compatibility

- v8 platform + v8.1 SDK: agent ignores unknown header → backward compatible.
- v9 platform + v8.0 SDK: agent derives identity from Basic Auth → backward compatible.
- No removed fields. No changed defaults.

## R1 — mechanical

- `npx jest` clean — 897 passed, 13 skipped, 30 suites
- TS compile via Jest's ts-jest passes
- New file `tests/x-client-id-header.test.ts` covers the new code path

## R2 — functional (real HTTP transport through `mockFetch`)

Tests in `x-client-id-header.test.ts` route a real `mcpCheckInput` through the SDK's `getAuthHeaders` → fetch path, capturing the headers object that the SDK passes to `fetch()`. This is the same object that gets serialized onto the wire — there's no intermediate `Request.setHeader()` call to assert against. Mutation evidence below confirms the assertion fails when the SDK doesn't set the header.

Captured outbound headers (from Jest run):

| Header | community default | configured client |
|---|---|---|
| `Authorization` | `Basic Y29tbXVuaXR5Og==` | `Basic YWNtZS1jb3JwOnNlY3JldA==` |
| `X-Axonflow-Client` | `sdk-typescript/8.1.0` | `sdk-typescript/8.1.0` |
| `X-Client-ID` | `community` | `acme-corp` |
| `X-Tenant-ID` | (absent) | (absent) |

## R3 — hostile self-review

- **Mutation test (per `feedback_mutation_test_to_prove_assertion_not_tautological.md`):** removed `headers['X-Client-ID'] = effectiveClientId;` in scratch copy → 2/3 new tests FAILED. Restored. Assertions are not tautological.
- **Anti-spoofing:** TS SDK has no `extraHeaders` config field that could override `X-Client-ID`. Server-side, the agent's `apiAuthMiddleware` overwrites the header regardless.
- **Cross-SDK coherence:** header NAME (`X-Client-ID`) and value shape (raw effective client_id, no prefix) match Go/Python/Java/Rust PRs in the same release train.
- **Negative test** pins that the SDK does NOT emit `X-Tenant-ID` — the agent accepts it as an alias through v9 for back-compat, but SDK-side we standardize on `X-Client-ID`.

## Workstream coordination

- Independent of Phase 5/6/7/8 of #2230 (different repos).
- Per `feedback_sub_sessions_admin_merge_when_ci_green_r3_done.md`, this PR admin-merges on green CI + R3 done; no master gating.