### PR TITLE
test(2275): 401-not-retried regression + README retry-config honesty [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`must not retry on 401 — regression for issue #2275`** test in
+ `tests/audit-tool-call.test.ts` — locks in that the TypeScript SDK
+ issues exactly one outbound `fetch` per `auditToolCall` and never
+ retries on HTTP 401. Backstops
+ [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)
+ where a customer's misconfigured deployment caused a tight 401 retry
+ loop against `community-saas` (~30 401/hour from a single source IP).
+ Mutation-tested: injecting a 2-attempt retry into `orchestratorRequest`
+ makes the assertion fail, confirming the test isn't tautological.
+
+### Changed
+
+- **README "A note on HTTP retries"** clarifies that the SDK does not
+ wrap HTTP calls in an internal retry loop, 401 is terminal, and any
+ caller-side retry wrapper MUST exclude `AuthenticationError`. The
+ previous example block in "Configuration Options" showed a `retry:
+ { enabled, maxAttempts, delay }` config that the SDK accepts on the
+ constructor but never wires into `_fetch` / `orchestratorRequest` —
+ removed from the example so customers don't write retry-storm code
+ against a config that does nothing. The config type
+ (`AxonFlowConfig.retry`) is retained for backward compatibility; it
+ is silently ignored.
+
 ## [8.1.0] - 2026-05-19 — `X-Client-ID` header on every outbound request (v9 identity)
 
 **Companion release to the v9 identity cleanup on the platform (Epic #2230).**

--- a/README.md
+++ b/README.md
@@ -475,13 +475,6 @@ const axonflow = new AxonFlow({
   tenant: 'your-tenant-id',         // For multi-tenant setups
   debug: true,                       // Enable debug logging
 
-  // Retry configuration
-  retry: {
-    enabled: true,
-    maxAttempts: 3,
-    delay: 1000
-  },
-
   // Cache configuration
   cache: {
     enabled: true,
@@ -489,6 +482,18 @@ const axonflow = new AxonFlow({
   }
 });
 ```
+
+> **A note on HTTP retries.** The TypeScript SDK does **not** wrap its
+> HTTP calls in an internal retry loop. Each `auditToolCall`,
+> `proxyLLMCall`, `mcpCheckInput`, etc. issues exactly one outbound
+> request and surfaces the response (or throws on error) to the caller.
+>
+> In particular, **401 Unauthorized is terminal** — the SDK throws
+> `AuthenticationError` and does not retry. Retrying a 401 with the
+> same credential just compounds load on the agent; refresh the token
+> via the customer portal and reconfigure the SDK instead. If you need
+> retries for transient infra errors (5xx, network), wrap the SDK call
+> in your own retry helper but **do not retry on `AuthenticationError`**.
 
 ### VPC Private Endpoint (Low-Latency)
 

--- a/tests/audit-tool-call.test.ts
+++ b/tests/audit-tool-call.test.ts
@@ -132,6 +132,27 @@ describe('auditToolCall', () => {
     await expect(client.auditToolCall({ toolName: 'search_database' })).rejects.toThrow();
   });
 
+  // Regression test for getaxonflow/axonflow-enterprise#2275: 401 must be
+  // terminal — the SDK MUST NOT retry an auth failure, because retrying
+  // with the same invalid token just compounds the storm on the agent
+  // (716 × 401 / 24h observed from one source IP against community-saas
+  // on 2026-05-19, ~30/hour, not human pacing).
+  //
+  // TypeScript SDK is structurally safe: `orchestratorRequest` calls
+  // `_fetch` exactly once and throws `AuthenticationError` on 401 or 403
+  // without a retry loop. This test makes the contract explicit by
+  // asserting `mockFetch` was invoked exactly once.
+  it('must not retry on 401 — regression for issue #2275', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ error: 'unauthorized' }, 401));
+
+    await expect(client.auditToolCall({ toolName: 'search_database' })).rejects.toThrow();
+
+    // Exactly one outbound fetch — no retry. If a future change to
+    // `orchestratorRequest` or `_fetch` adds status-code-based retry
+    // that includes 401, this assertion fails.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('should include error_message for failed tool calls', async () => {
     mockFetch.mockReturnValueOnce(
       mockResponse({


### PR DESCRIPTION
## Summary

Adds an explicit regression test asserting HTTP 401 responses on `/api/v1/audit/tool-call` are terminal AND removes a misleading `retry: { ... }` example from the README that documented config the SDK never honors.

Backstops issue [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275), where a customer's misconfigured deployment caused a tight 401 retry loop against `community-saas` — 716 × 401 in 24 hours from a single source IP, User-Agent `node`, sub-second burst pattern consistent with a caller-side retry-on-exception wrapper.

## Audit finding (no SDK code change required)

TypeScript SDK was already structurally safe — `orchestratorRequest` (`src/client.ts:4386-4419`) calls `_fetch` exactly once and throws `AuthenticationError` on 401/403:

```typescript
const response = await this._fetch(url, options);
if (!response.ok) {
  const errorText = await response.text();
  if (response.status === 401 || response.status === 403) {
    throw new AuthenticationError(`Request failed: ${errorText}`);
  }
  ...
}
```

But the README's "Configuration Options" block (line 466-491) showed:

```typescript
// Retry configuration
retry: {
  enabled: true,
  maxAttempts: 3,
  delay: 1000
}
```

— config that the constructor accepts (`AxonFlowConfig.retry`) but never wires into `_fetch` or `orchestratorRequest`. Customers reading the README would reasonably assume the SDK retries on their behalf, and if they then layered their own retry wrapper (catching `AuthenticationError`), they'd compound into a retry storm.

## Changes

1. **`tests/audit-tool-call.test.ts`** — adds `must not retry on 401 — regression for issue #2275` asserting `mockFetch.toHaveBeenCalledTimes(1)` on a 401 response.

2. **`README.md`** — removes the misleading `retry: { ... }` example, replaces with an "A note on HTTP retries" callout: SDK does not wrap HTTP calls in an internal retry loop, 401 is terminal, caller-side retry wrappers MUST exclude `AuthenticationError`.

3. **`AxonFlowConfig.retry` type** — RETAINED for backward compatibility (silently ignored, as it always was). Removing the type would break customer code that passes `retry: {...}` at construction time.

## Mutation test (proves the assertion isn't tautological)

Per `feedback_mutation_test_to_prove_assertion_not_tautological.md`: injected a 2-attempt retry loop into `orchestratorRequest`'s 401 branch:

```diff
 if (response.status === 401 || response.status === 403) {
+  for (let i = 0; i < 2; i++) {
+    await this._fetch(url, options);
+  }
   throw new AuthenticationError(`Request failed: ${errorText}`);
 }
```

Test result with mutation: **FAILED** —
```
expect(mockFetch).toHaveBeenCalledTimes(1);
                  ^
Expected number of calls: 1
Received number of calls: 3
```

→ confirms the assertion distinguishes "401 is terminal" vs "401 retries."

## Companion work in #2275

The other 4 SDKs (Python, Go, Java, Rust) get the same regression test in their respective repos. Plugins (claude/cursor/codex/openclaw) get a similar audit + 401 throttle in follow-on PRs (user clarified the storm was primarily seen on plugins, not the SDK).

## Skip-runtime-e2e justification

Test + docs only; no new SDK feature surface and no wire-protocol change. The existing `runtime-e2e/` runners stay intact.

## Test plan

- [x] `npx jest tests/audit-tool-call.test.ts` — all 7 tests pass locally
- [x] Mutation test: injecting a 401 retry loop fails the assertion
- [ ] CI green on this PR