### PR TITLE
docs(2275): @deprecated retry config + strike retry-mechanism prose [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  Mutation-tested: injecting a 2-attempt retry into `orchestratorRequest`
  makes the assertion fail, confirming the test isn't tautological.
 
+- **`tests/no-retry-on-401.test.ts`** extends the #2275 contract to
+ the SECOND HTTP path in the SDK — `portalRequest` (used by
+ `listGitProviders`, `loginToPortal`-gated portal calls, etc.). Covers
+ both 401 and 403 terminal-class responses. Mutation-tested: injecting
+ a 2-attempt retry into `portalRequest` makes both assertions fail at
+ `Expected: 1, Received: 2`, confirming the test specifically guards
+ the call-count contract rather than incidentally passing through
+ throw-shape assertions.
+
 ### Changed
 
 - **README "A note on HTTP retries"** clarifies that the SDK does not
@@ -31,6 +40,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  against a config that does nothing. The config type
  (`AxonFlowConfig.retry`) is retained for backward compatibility; it
  is silently ignored.
+
+- **`AxonFlowConfig.retry` field and `RetryConfig` interface marked
+ `@deprecated`** in `src/types/config.ts`. IDE hover / IntelliSense
+ was the last surface still presenting "Retry configuration" with
+ three working-looking fields — a hostile review of PR #228 surfaced
+ that the README cleanup was incomplete because typed-API customers
+ read JSDoc, not just the README. Verified `@deprecated` renders in
+ emitted `dist/cjs/types/config.d.ts`. Slated for removal in v10.
+
+- **`SDK_ARCHITECTURE.md`** — removed the non-existent
+ `src/utils/retry.ts` package-structure entry, removed
+ `retry?: RetryConfig` from the canonical `AxonFlowConfig` example,
+ and added the same "A note on HTTP retries" callout as the README.
+
+- **`TECHNICAL_SPECIFICATION.md` § Retry Strategy** — replaced the
+ fabricated `RetryConfig { maxAttempts: 3, backoffMultiplier: 2,
+ initialDelay: 100, maxDelay: 5000, retryableErrors: ['NETWORK_ERROR',
+ 'TIMEOUT'] }` interface (none of those fields exist in the SDK) with
+ honest prose pointing readers at the README callout and #2275. The
+ section header is retained so readers searching for "retry" in the
+ spec land on the negation rather than nothing.
+
+- **`TEST_PLAN.md` § Reliability** — replaced the "✅ Automatic retry
+ with exponential backoff" line (never implemented) with "✅
+ Single-attempt HTTP semantics" plus link to README + #2275.
 
 ## [8.1.0] - 2026-05-19 — `X-Client-ID` header on every outbound request (v9 identity)
 

--- a/SDK_ARCHITECTURE.md
+++ b/SDK_ARCHITECTURE.md
@@ -42,7 +42,6 @@ const response = await af.protect(() => openai.complete(prompt));
 │   │   ├── policy.ts      # Policy types
 │   │   └── response.ts    # Response types
 │   ├── utils/
-│   │   ├── retry.ts       # Retry logic
 │   │   ├── cache.ts       # Response caching
 │   │   └── logger.ts      # Debug logging
 │   └── constants.ts       # SDK constants
@@ -94,11 +93,21 @@ interface AxonFlowConfig {
   endpoint?: string;
   mode?: 'sandbox' | 'production';
   tenant?: string;
-  retry?: RetryConfig;
   cache?: CacheConfig;
   debug?: boolean;
 }
 ```
+
+> **A note on HTTP retries.** The SDK does not wrap HTTP calls in an
+> internal retry loop. Each outbound request is issued exactly once,
+> and `401 Unauthorized` is terminal — the SDK throws
+> `AuthenticationError` and does not retry. If you need retries for
+> transient infra errors (5xx, network), wrap the SDK call in your
+> own retry helper but **do not retry on `AuthenticationError`**. See
+> [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)
+> and the "A note on HTTP retries" callout in the main README.
+> `AxonFlowConfig.retry` is preserved as a deprecated, silently-ignored
+> field for backward compatibility and will be removed in v10.
 
 ## Implementation Plan
 

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -217,18 +217,24 @@ class SDKError extends Error {
 
 ### Retry Strategy
 
-```typescript
-interface RetryConfig {
-  maxAttempts: 3;
-  backoffMultiplier: 2;
-  initialDelay: 100;      // ms
-  maxDelay: 5000;        // ms
-  retryableErrors: [
-    'NETWORK_ERROR',
-    'TIMEOUT'
-  ];
-}
-```
+The SDK does **not** wrap HTTP calls in an internal retry loop. Each
+outbound request is issued exactly once and the response (or thrown
+error) is surfaced to the caller. In particular, **`401 Unauthorized`
+is terminal** — the SDK throws `AuthenticationError` and does not
+retry, because retrying a 401 with the same credential just compounds
+load on the agent
+(see [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)).
+
+If you need retries for transient infra errors (5xx, network), wrap
+the SDK call in your own retry helper but **do not retry on
+`AuthenticationError`**. For the authoritative caller-side guidance,
+see the "A note on HTTP retries" callout in the main README.
+
+The `AxonFlowConfig.retry` field (and the exported `RetryConfig`
+interface) is preserved as a deprecated, silently-ignored shape for
+backward compatibility and will be removed in v10. The earlier
+`backoffMultiplier` / `initialDelay` / `retryableErrors` design was
+never implemented.
 
 ## Deployment Modes
 

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -600,7 +600,10 @@ npm run test:load:stress
 ### Reliability
 - ✅ 99.99% availability
 - ✅ Graceful degradation when service unavailable
-- ✅ Automatic retry with exponential backoff
+- ✅ Single-attempt HTTP semantics (no internal retry loop;
+  `401 Unauthorized` is terminal — see the "A note on HTTP retries"
+  callout in the main README and
+  [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275))
 - ✅ Circuit breaker pattern implementation
 
 ### Security

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -69,7 +69,12 @@ export interface AxonFlowConfig {
   mapTimeout?: number;
 
   /**
-   * Retry configuration
+   * @deprecated The SDK does not implement HTTP retries. This field is accepted
+   * for backward compatibility and silently ignored. If you need retries for
+   * transient infra errors (5xx, network), wrap the SDK call in your own retry
+   * helper — but do NOT retry on `AuthenticationError`
+   * (see [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)).
+   * This field will be removed in v10.
    */
   retry?: {
     enabled: boolean;
@@ -86,6 +91,15 @@ export interface AxonFlowConfig {
   };
 }
 
+/**
+ * @deprecated The SDK does not implement HTTP retries. This type is exported
+ * for backward compatibility with code that imports it; configuring it on
+ * `AxonFlowConfig.retry` has no effect at runtime. If you need retries for
+ * transient infra errors (5xx, network), wrap the SDK call in your own retry
+ * helper — but do NOT retry on `AuthenticationError`
+ * (see [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)).
+ * This type will be removed in v10.
+ */
 export interface RetryConfig {
   enabled: boolean;
   maxAttempts: number;

--- a/tests/no-retry-on-401.test.ts
+++ b/tests/no-retry-on-401.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests that 401 is terminal across BOTH HTTP request paths in the
+ * TypeScript SDK — `orchestratorRequest` AND `portalRequest`.
+ *
+ * Regression for getaxonflow/axonflow-enterprise#2275: a customer
+ * deployment with invalid credentials caused ~30 401/hour against
+ * community-saas because something in the caller's stack was retrying
+ * on `AuthenticationError`. The TypeScript SDK is structurally safe —
+ * both request helpers issue exactly one outbound `fetch` and throw
+ * `AuthenticationError` on 401 / 403 without a retry loop — but we
+ * lock the contract in with explicit assertions on both paths so that
+ * a future change adding status-code-based retry that includes 401 in
+ * either path fails CI.
+ *
+ * The orchestrator-path companion test lives in
+ * `tests/audit-tool-call.test.ts` (`auditToolCall` → `orchestratorRequest`).
+ * This file covers `portalRequest` via `listGitProviders` (a GET that
+ * uses the portal session cookie path).
+ *
+ * Mutation-verified: injecting a 2-attempt retry into `portalRequest`
+ * makes `expect(mockFetch).toHaveBeenCalledTimes(1)` fail with
+ * `Expected number of calls: 1, Received: 2`.
+ */
+
+import { AxonFlow } from '../src/client';
+import { AuthenticationError } from '../src/errors';
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('401 is terminal — no retry on any request path (#2275)', () => {
+  let client: AxonFlow;
+
+  beforeEach(() => {
+    // mockReset clears BOTH call history AND queued
+    // `mockReturnValueOnce` responses — important here because the
+    // tests below queue 2 responses each (to ensure a retry-injected
+    // mutation fails at the call-count assertion rather than at
+    // `response.ok` of undefined). `jest.clearAllMocks()` only resets
+    // history and would leak stale queued responses across tests.
+    mockFetch.mockReset();
+    client = new AxonFlow({
+      endpoint: 'http://localhost:8080',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+      tenant: 'test-tenant',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const mockJsonResponse = (data: unknown, status = 200, headers?: Headers) => {
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      headers: headers ?? new Headers(),
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    });
+  };
+
+  // Helper: hand-roll a portal session cookie by stubbing the login
+  // response and then calling loginToPortal(). Keeps the test
+  // independent of any session-cookie helper that might be refactored
+  // away (we exercise the same public surface a customer would use).
+  async function loginAndClearFetchHistory(): Promise<void> {
+    const loginHeaders = new Headers();
+    loginHeaders.set(
+      'set-cookie',
+      'axonflow_session=test-session-cookie; HttpOnly; Path=/'
+    );
+    mockFetch.mockReturnValueOnce(
+      mockJsonResponse(
+        {
+          session_id: 'test-session-cookie',
+          org_id: 'test-org-001',
+          email: 'admin@test.org',
+          name: 'Test Admin',
+          expires_at: '2099-01-01T00:00:00Z',
+        },
+        200,
+        loginHeaders
+      )
+    );
+    await client.loginToPortal('test-org-001', 'test123');
+    expect(client.isLoggedIn()).toBe(true);
+    // Reset call history so the portalRequest-path assertion is
+    // unambiguous — exactly one fetch BELOW the login call.
+    mockFetch.mockClear();
+  }
+
+  it('portalRequest path: must not retry on 401 — regression for #2275', async () => {
+    await loginAndClearFetchHistory();
+
+    // Server returns 401 on the portal request — same shape the
+    // customer's misconfigured deployment was hitting. We queue a
+    // SECOND 401 response so a hypothetical retry-on-401 mutation
+    // would still return cleanly on the second call (and the test
+    // would fail specifically at the `toHaveBeenCalledTimes(1)`
+    // assertion below rather than blowing up on `response.ok` of
+    // undefined — the assertion failure must point cleanly at the
+    // retry contract being broken).
+    mockFetch.mockReturnValueOnce(
+      mockJsonResponse({ error: 'unauthorized' }, 401)
+    );
+    mockFetch.mockReturnValueOnce(
+      mockJsonResponse({ error: 'unauthorized' }, 401)
+    );
+
+    // `listGitProviders` goes through `portalRequest('GET', ...)` and
+    // is one of the simplest portal-path methods to exercise. The
+    // contract under test is path-level, not method-specific.
+    await expect(client.listGitProviders()).rejects.toThrow(AuthenticationError);
+
+    // Exactly one outbound fetch — no retry. If a future change to
+    // `portalRequest` or `_fetch` adds status-code-based retry that
+    // includes 401, this assertion fails with "Received: 2".
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('portalRequest path: must not retry on 403 either (same terminal-class)', async () => {
+    await loginAndClearFetchHistory();
+
+    // 403 forbidden is the sibling terminal class — the SDK throws
+    // AuthenticationError on both 401 and 403 in `portalRequest`. A
+    // hypothetical retry loop that excluded 401 but included 403
+    // would still cause the storm; lock both paths. Queue a second
+    // 403 so the mutation test fails specifically at the
+    // call-count assertion, not at downstream `response.ok` access.
+    mockFetch.mockReturnValueOnce(
+      mockJsonResponse({ error: 'forbidden' }, 403)
+    );
+    mockFetch.mockReturnValueOnce(
+      mockJsonResponse({ error: 'forbidden' }, 403)
+    );
+
+    await expect(client.listGitProviders()).rejects.toThrow(AuthenticationError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/no-retry-on-401.test.ts
+++ b/tests/no-retry-on-401.test.ts
@@ -69,10 +69,7 @@ describe('401 is terminal — no retry on any request path (#2275)', () => {
   // away (we exercise the same public surface a customer would use).
   async function loginAndClearFetchHistory(): Promise<void> {
     const loginHeaders = new Headers();
-    loginHeaders.set(
-      'set-cookie',
-      'axonflow_session=test-session-cookie; HttpOnly; Path=/'
-    );
+    loginHeaders.set('set-cookie', 'axonflow_session=test-session-cookie; HttpOnly; Path=/');
     mockFetch.mockReturnValueOnce(
       mockJsonResponse(
         {
@@ -104,12 +101,8 @@ describe('401 is terminal — no retry on any request path (#2275)', () => {
     // assertion below rather than blowing up on `response.ok` of
     // undefined — the assertion failure must point cleanly at the
     // retry contract being broken).
-    mockFetch.mockReturnValueOnce(
-      mockJsonResponse({ error: 'unauthorized' }, 401)
-    );
-    mockFetch.mockReturnValueOnce(
-      mockJsonResponse({ error: 'unauthorized' }, 401)
-    );
+    mockFetch.mockReturnValueOnce(mockJsonResponse({ error: 'unauthorized' }, 401));
+    mockFetch.mockReturnValueOnce(mockJsonResponse({ error: 'unauthorized' }, 401));
 
     // `listGitProviders` goes through `portalRequest('GET', ...)` and
     // is one of the simplest portal-path methods to exercise. The
@@ -131,12 +124,8 @@ describe('401 is terminal — no retry on any request path (#2275)', () => {
     // would still cause the storm; lock both paths. Queue a second
     // 403 so the mutation test fails specifically at the
     // call-count assertion, not at downstream `response.ok` access.
-    mockFetch.mockReturnValueOnce(
-      mockJsonResponse({ error: 'forbidden' }, 403)
-    );
-    mockFetch.mockReturnValueOnce(
-      mockJsonResponse({ error: 'forbidden' }, 403)
-    );
+    mockFetch.mockReturnValueOnce(mockJsonResponse({ error: 'forbidden' }, 403));
+    mockFetch.mockReturnValueOnce(mockJsonResponse({ error: 'forbidden' }, 403));
 
     await expect(client.listGitProviders()).rejects.toThrow(AuthenticationError);
     expect(mockFetch).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Follow-up to PR #228 ([commit f141893](https://github.com/getaxonflow/axonflow-sdk-typescript/commit/f141893)) addressing four HIGH findings from a hostile review on the day of merge (2026-05-20). PR #228 deleted the misleading `retry: { enabled, maxAttempts, delay }` example block from the README and added the canonical "A note on HTTP retries" callout — but the same lie persisted in four other doc surfaces that a typed-API customer reads BEFORE the README:

1. **`src/types/config.ts`** — IDE hover / IntelliSense (the dominant doc surface for typed APIs)
2. **`SDK_ARCHITECTURE.md`** — referenced a non-existent `src/utils/retry.ts`; canonical config interface listed `retry?: RetryConfig` with no annotation
3. **`TECHNICAL_SPECIFICATION.md`** § Retry Strategy — full fabricated `RetryConfig` interface (`maxAttempts: 3`, `backoffMultiplier: 2`, `initialDelay: 100`, `maxDelay: 5000`, `retryableErrors: ['NETWORK_ERROR','TIMEOUT']`) — NONE of those fields exist in the SDK
4. **`TEST_PLAN.md` § Reliability** — claimed "Automatic retry with exponential backoff"

## Changes per surface

| Surface | Before | After |
|---|---|---|
| `src/types/config.ts` `AxonFlowConfig.retry` | "Retry configuration" JSDoc | `@deprecated` JSDoc + #2275 link + "removed in v10" |
| `src/types/config.ts` `RetryConfig` interface | No JSDoc | `@deprecated` JSDoc + #2275 link + "removed in v10" |
| `SDK_ARCHITECTURE.md` package tree | `utils/retry.ts — Retry logic` | line deleted (file never existed) |
| `SDK_ARCHITECTURE.md` config example | `retry?: RetryConfig` listed | line deleted + added README callout |
| `TECHNICAL_SPECIFICATION.md` § Retry Strategy | fabricated `RetryConfig {...}` interface | replaced with honest prose + #2275 link. Header retained so readers searching "retry" land on the negation. |
| `TEST_PLAN.md` § Reliability | "Automatic retry with exponential backoff" | "Single-attempt HTTP semantics" + README + #2275 links |

JSDoc `@deprecated` rendering verified in emitted `dist/cjs/types/config.d.ts` after `tsc --build`. IDE tooling will now strike-through the field name and show the deprecation banner on hover.

## Test addition

PR #228's regression test only exercised `auditToolCall` → `orchestratorRequest`. The 401-is-terminal contract has TWO HTTP paths in the SDK; this PR adds `tests/no-retry-on-401.test.ts` covering the second:

- **`portalRequest` 401 path** — exercised via `client.listGitProviders()` (one of the simplest portal-path methods)
- **`portalRequest` 403 path** — sibling terminal class (`portalRequest` throws `AuthenticationError` on both 401 and 403)

Both tests queue two mocked 401/403 responses so a hypothetical retry-on-401/403 mutation fails specifically at `expect(mockFetch).toHaveBeenCalledTimes(1)` with `Expected: 1, Received: 2`, rather than incidentally throwing on `response.ok` of undefined. Used `mockFetch.mockReset()` in `beforeEach` so the queue doesn't leak across tests.

## Hostile-review finding lineage

- PR #228 deleted the README block but left the JSDoc lie on `AxonFlowConfig.retry`, fooling every typed-API customer who hovers in their IDE → THIS PR Fix 1
- PR #228 left `SDK_ARCHITECTURE.md` referencing `src/utils/retry.ts` (which never existed) and listing `retry?: RetryConfig` in the canonical config example → THIS PR Fix 2
- PR #228 left `TECHNICAL_SPECIFICATION.md` § Retry Strategy with a fabricated 5-field interface that customers might transcribe into their own retry-helper code → THIS PR Fix 3
- PR #228 left `TEST_PLAN.md` claiming retry-with-backoff as a checked-off reliability feature → THIS PR Fix 4
- PR #228's test covered only `orchestratorRequest`; `portalRequest` was unguarded → THIS PR test addition

## R3 hostile self-review

- **Grep audit**: full-repo `grep -i "retry"` ran; all remaining hits are (a) honest negation prose, (b) `@deprecated` JSDoc, (c) WCP `retry_context` (workflow-level step-gate primitives, NOT HTTP transport retry — out of scope), or (d) generic phrases like "retry safety" on the demo-video bullet.
- **JSDoc tooling check**: `tsc --build` clean; emitted `.d.ts` carries the `@deprecated` tag on both `AxonFlowConfig.retry` and `RetryConfig`.
- **Mutation test on the new `portalRequest` test**: injected `if (response.status === 401 || 403) { response = await this._fetch(url, options); }` into `portalRequest` body. Both tests fail at `Expected: 1, Received: 2`. Reverted the mutation; both tests pass on the unmodified SUT.
- **CHANGELOG cross-read**: this PR's CHANGELOG block extends the same `[Unreleased]` block PR #228 added (rather than creating a sibling block). Together they describe the full doc/config cleanup: PR #228 = README + orchestrator-path test; this PR = JSDoc + 3 internal doc files + portalRequest-path test.

## Skip-runtime-e2e justification

This PR touches `src/types/config.ts` (matches the `src/` user-facing-surface glob in `definition-of-done.yml`) but is a pure doc/typing change: the runtime behavior of `AxonFlowConfig.retry` is unchanged — the field has always been accepted on the constructor and silently ignored at runtime. The behavioral contract guarded by `tests/audit-tool-call.test.ts` (PR #228) and this PR's `tests/no-retry-on-401.test.ts` is "exactly one outbound fetch per request, no retry on 401/403" — both are exercised through real `AxonFlow` class instances with mocked `fetch`. Adding a `runtime-e2e/` harness for a `@deprecated` JSDoc tag and three internal Markdown doc-strikes would be net-negative — there's no behavior to demonstrate beyond what unit tests already cover.

The orchestrator-path companion runtime-e2e for the same contract already lives in `runtime-e2e/x-client-id/` (header surface) and `runtime-e2e/heartbeat/` (transport surface); neither adds value for a doc-strike PR.

## Test plan

- [x] `npx jest tests/no-retry-on-401.test.ts` — 2/2 pass
- [x] `npx jest` (full suite) — 31 suites, 900 tests pass (was 30/898 before this PR)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --build` — clean; verified `@deprecated` renders in `dist/cjs/types/config.d.ts`
- [x] Mutation test: injecting a retry-on-401/403 into `portalRequest` makes both new tests fail at the call-count assertion

Closes the hostile-review HIGH findings on PR #228.