### PR TITLE
feat(telemetry): include org_id in heartbeat payload (v9.1 #2277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`org_id` field in the telemetry heartbeat body (v9.1 preflight, #2277).**
+ Brings TypeScript SDK telemetry up to parity with the platform's
+ `startup_telemetry.go` emitter — every heartbeat now identifies which
+ deployment-organization emitted it. Two sources in precedence order:
+ 1. The `ORG_ID` env var when set (the operator's explicit configuration on
+    self-hosted deployments, or the `cs_<uuid>` tenant identifier on
+    Community SaaS).
+ 2. Otherwise the `local-dev-org` sentinel (default-config Community-mode
+    developers).
+ Exported as `telemetryOrgID()` + `ORG_ID_LOCAL_DEV_SENTINEL`. The
+ receiver (`ee/platform/checkpoint-service/pkg/telemetry/telemetry.go`)
+ already accepts the field with `omitempty` for backward compat with
+ pre-v8.1 SDKs that don't send it. New SDKs always send it. Honors
+ `AXONFLOW_TELEMETRY=off` like every other heartbeat field. See
+ `axonflow-landing/content/privacy.html` for the customer-facing
+ commitment that covers this field.
+
 - **`must not retry on 401 — regression for issue #2275`** test in
  `tests/audit-tool-call.test.ts` — locks in that the TypeScript SDK
  issues exactly one outbound `fetch` per `auditToolCall` and never
@@ -29,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  throw-shape assertions.
 
 ### Changed
+
+- **Telemetry-enabled log line** softened from "Anonymous telemetry enabled"
+ to "Telemetry enabled" to stay coherent with the v9.1 `org_id` addition
+ (the operator-supplied `ORG_ID` on self-hosted is not anonymized; only
+ the `instance_id` and `cs_<uuid>` Community SaaS identifier remain
+ anonymous-by-design). Heartbeat module + `sendTelemetryPing` docstrings
+ updated similarly.
 
 - **README "A note on HTTP retries"** clarifies that the SDK does not
  wrap HTTP calls in an internal retry loop, 401 is terminal, and any

--- a/runtime-e2e/v91_org_id_telemetry/README.md
+++ b/runtime-e2e/v91_org_id_telemetry/README.md
@@ -1,0 +1,61 @@
+# Runtime proof — `org_id` in SDK telemetry payload (v9.1)
+
+Verifies the v9.1 contract for the TypeScript SDK: every telemetry
+heartbeat body carries an `org_id` field, populated from the `ORG_ID`
+env var with a `local-dev-org` sentinel fallback. Issue #2277.
+
+## Usage
+
+Build the SDK first (the test imports from `dist/esm`):
+
+```sh
+npm run build
+
+# ORG_ID set — operator-supplied (self-hosted) or cs_<uuid> (Community SaaS):
+ORG_ID=acme-corp node runtime-e2e/v91_org_id_telemetry/test.mjs
+
+# ORG_ID unset — local-dev-org sentinel:
+unset ORG_ID && node runtime-e2e/v91_org_id_telemetry/test.mjs
+```
+
+Expected output:
+
+```
+PASS: telemetry wire payload carries org_id="acme-corp" (expected="acme-corp")
+Wire body: {"telemetry_type":"sdk","sdk":"typescript", ... ,"org_id":"acme-corp"}
+```
+
+## What it asserts
+
+1. The SDK's `sendTelemetryPing` emits a POST to
+   `AXONFLOW_CHECKPOINT_URL` within seconds of invocation.
+2. The POST body is valid JSON.
+3. The body has an `org_id` key.
+4. The value matches `$ORG_ID` (when set) or `local-dev-org` (when unset).
+
+## CI coverage
+
+This runtime proof is a redundant real-stack confirmation alongside the
+Jest tests in `tests/telemetry.test.ts`:
+
+- `org_id (v9.1) → telemetryOrgID helper` (4 cases)
+- `org_id (v9.1) → wire payload always carries org_id` (3 cases via mock fetch)
+- `org_id (v9.1) → wire payload always carries org_id (real-network E2E)`
+  (3 cases via `http.createServer`)
+
+The mutation guard is the TypeScript type system itself — `TelemetryPayload`
+requires `org_id: string`; removing the populate line fails type-check
+with `TS2741: Property 'org_id' is missing`.
+
+## Cross-SDK parity
+
+Companion runtime-e2e tests live under the same subdirectory in the
+other 4 SDKs:
+
+- `axonflow-sdk-go/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-python/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-java/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-rust/runtime-e2e/v91_org_id_telemetry/`
+
+All five SDKs emit `org_id` with the same wire name, same sentinel
+value (`local-dev-org`), and the same precedence (env → sentinel).

--- a/runtime-e2e/v91_org_id_telemetry/test.mjs
+++ b/runtime-e2e/v91_org_id_telemetry/test.mjs
@@ -1,0 +1,85 @@
+// runtime-e2e/v91_org_id_telemetry/test.mjs
+//
+// Real-stack assertion: the SDK's telemetry heartbeat carries
+// org_id on the wire (v9.1). Issue #2277.
+//
+// Spins up a local http.createServer, points AXONFLOW_CHECKPOINT_URL at
+// it, fires a ping via sendTelemetryPing, and inspects the captured
+// JSON body for the org_id field. Bytes flow real → real through node:http
+// on both sides.
+//
+// Usage:
+//
+//   # ORG_ID set — operator-supplied (self-hosted) or cs_<uuid>:
+//   ORG_ID=acme-corp node runtime-e2e/v91_org_id_telemetry/test.mjs
+//
+//   # ORG_ID unset — local-dev-org sentinel:
+//   unset ORG_ID && node runtime-e2e/v91_org_id_telemetry/test.mjs
+
+import { createServer } from 'node:http';
+import { ORG_ID_LOCAL_DEV_SENTINEL, sendTelemetryPing } from '../../dist/esm/telemetry.js';
+
+const expected = process.env.ORG_ID || ORG_ID_LOCAL_DEV_SENTINEL;
+
+let capturedBody = '';
+
+const server = createServer((req, res) => {
+  if (req.method === 'POST') {
+    const chunks = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => {
+      capturedBody = Buffer.concat(chunks).toString('utf-8');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ latest_version: null, alerts: [] }));
+    });
+  } else {
+    // /health probe
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ version: '8.0.0-runtime-e2e' }));
+  }
+});
+
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const { port } = server.address();
+
+process.env.AXONFLOW_CHECKPOINT_URL = `http://127.0.0.1:${port}/v1/ping`;
+delete process.env.AXONFLOW_TELEMETRY;
+
+sendTelemetryPing({
+  mode: 'production',
+  endpoint: `http://127.0.0.1:${port}`,
+});
+
+// Poll for delivery up to 5 seconds.
+for (let i = 0; i < 100 && !capturedBody; i += 1) {
+  await new Promise(r => setTimeout(r, 50));
+}
+
+server.close();
+
+if (!capturedBody) {
+  console.error('FAIL: no telemetry body captured');
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(capturedBody);
+} catch (err) {
+  console.error(`FAIL: body not valid JSON: ${err.message}\nBody: ${capturedBody}`);
+  process.exit(1);
+}
+
+if (parsed.org_id !== expected) {
+  console.error(
+    `FAIL: org_id = ${JSON.stringify(parsed.org_id)}, want ${JSON.stringify(expected)}`
+  );
+  console.error(`Body: ${capturedBody}`);
+  process.exit(1);
+}
+
+console.log(
+  `PASS: telemetry wire payload carries org_id=${JSON.stringify(parsed.org_id)} (expected=${JSON.stringify(expected)})`
+);
+console.log(`Wire body: ${capturedBody}`);
+process.exit(0);

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -3,7 +3,7 @@
  *
  * Implements the cross-SDK contract:
  *
- *   AxonFlow emits at most one anonymous heartbeat per environment every
+ *   AxonFlow emits at most one heartbeat per environment every
  *   7 days during SDK activity.
  *
  * The gate is consulted at client construction and at every public HTTP

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -132,6 +132,34 @@ export interface TelemetryPayload {
    * see checkpoint-service IsValidIncomingStream.
    */
   stream?: string;
+  /**
+   * Deployment-organization identifier (#2277). Two sources, precedence
+   * order: the `ORG_ID` env var when set (the operator's explicit
+   * configuration on self-hosted deployments, or the `cs_<uuid>` tenant
+   * identifier on Community SaaS); otherwise the `"local-dev-org"`
+   * sentinel. Always emitted. See
+   * axonflow-landing/content/privacy.html for the customer-facing
+   * commitment that covers this field.
+   */
+  org_id: string;
+}
+
+/**
+ * Sentinel emitted on the telemetry wire when `ORG_ID` is unset — the
+ * default-config Community-mode developer case. See #2277.
+ */
+export const ORG_ID_LOCAL_DEV_SENTINEL = 'local-dev-org';
+
+/**
+ * Return the `org_id` value to emit on the next telemetry ping. Reads
+ * `ORG_ID` from the environment (the operator's explicit configuration
+ * for self-hosted deployments, or the `cs_<uuid>` tenant identifier on
+ * Community SaaS) and falls back to `ORG_ID_LOCAL_DEV_SENTINEL` when
+ * unset. Always returns a non-empty string. See #2277.
+ */
+export function telemetryOrgID(): string {
+  const value = typeof process !== 'undefined' ? (process.env.ORG_ID ?? '') : '';
+  return value === '' ? ORG_ID_LOCAL_DEV_SENTINEL : value;
 }
 
 export type EndpointType = 'localhost' | 'private_network' | 'remote' | 'unknown';
@@ -308,7 +336,7 @@ function expandIPv6(addr: string): string {
 }
 
 /**
- * Send an anonymous telemetry ping and return whether it landed.
+ * Send a telemetry ping and return whether it landed.
  *
  * Returns `true` only when the POST received a 2xx response. Network
  * failures, timeouts, and non-2xx responses all return `false`. Used by
@@ -347,6 +375,7 @@ export async function sendTelemetryPingNow(options: {
     endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
+    org_id: telemetryOrgID(),
     ...(options.mode === 'sandbox' ? { stream: 'sandbox' } : {}),
   };
 
@@ -391,7 +420,7 @@ export async function sendTelemetryPingNow(options: {
 }
 
 /**
- * Send an anonymous telemetry ping on client initialization (compat shim).
+ * Send a telemetry ping on client initialization (compat shim).
  *
  * Kept for the existing test surface. Production code goes through
  * `maybeSendHeartbeat` in heartbeat.ts instead. This shim performs the
@@ -418,7 +447,7 @@ export function sendTelemetryPing(options: {
 
   if (typeof console !== 'undefined') {
     console.debug(
-      '[AxonFlow] Anonymous telemetry enabled. Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry'
+      '[AxonFlow] Telemetry enabled. Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry'
     );
   }
 
@@ -442,6 +471,7 @@ export function sendTelemetryPing(options: {
     endpoint_type: classifyEndpoint(options.endpoint),
     features: [],
     instance_id: generateInstanceId(),
+    org_id: telemetryOrgID(),
     ...(options.mode === 'sandbox' ? { stream: 'sandbox' } : {}),
   };
 

--- a/test/telemetry-endpoint-type.test.ts
+++ b/test/telemetry-endpoint-type.test.ts
@@ -136,6 +136,7 @@ describe('TelemetryPayload shape', () => {
       endpoint_type: 'localhost',
       features: [],
       instance_id: 'test',
+      org_id: 'local-dev-org',
     };
     expect(p.endpoint_type).toBe('localhost');
   });
@@ -160,6 +161,7 @@ describe('TelemetryPayload shape', () => {
       endpoint_type: endpointType,
       features: [],
       instance_id: 'leak-test',
+      org_id: 'local-dev-org',
     };
     const json = JSON.stringify(payload);
     for (const fragment of [

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -15,7 +15,12 @@
  * via `delete process.env.AXONFLOW_TELEMETRY`.
  */
 
-import { sendTelemetryPing, TelemetryPayload } from '../src/telemetry';
+import {
+  ORG_ID_LOCAL_DEV_SENTINEL,
+  sendTelemetryPing,
+  telemetryOrgID,
+  TelemetryPayload,
+} from '../src/telemetry';
 import { VERSION } from '../src/version';
 
 // Save original env
@@ -501,6 +506,178 @@ describe('sendTelemetryPing', () => {
       const [, options] = mockFetch.mock.calls[1];
       expect(options.signal).toBeDefined();
       expect(options.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  // ============================================================
+  // org_id field (v9.1 preflight, issue #2277)
+  // ============================================================
+  describe('org_id (v9.1)', () => {
+    describe('telemetryOrgID helper', () => {
+      it('returns ORG_ID env when set (operator-supplied self-hosted)', () => {
+        process.env.ORG_ID = 'acme-corp';
+        expect(telemetryOrgID()).toBe('acme-corp');
+      });
+
+      it('returns local-dev-org sentinel when ORG_ID unset', () => {
+        delete process.env.ORG_ID;
+        expect(telemetryOrgID()).toBe(ORG_ID_LOCAL_DEV_SENTINEL);
+        expect(ORG_ID_LOCAL_DEV_SENTINEL).toBe('local-dev-org'); // wire-value lock
+      });
+
+      it('treats empty ORG_ID as unset (sentinel)', () => {
+        process.env.ORG_ID = '';
+        expect(telemetryOrgID()).toBe(ORG_ID_LOCAL_DEV_SENTINEL);
+      });
+
+      it('passes through cs_<uuid> Community SaaS tenant identifier', () => {
+        const csId = 'cs_e3a4b5c6-d7e8-4f90-a1b2-c3d4e5f6a7b8';
+        process.env.ORG_ID = csId;
+        expect(telemetryOrgID()).toBe(csId);
+      });
+    });
+
+    describe('wire payload always carries org_id', () => {
+      it('includes operator-supplied ORG_ID in posted body', async () => {
+        process.env.ORG_ID = 'acme-corp';
+        sendTelemetryPing({
+          mode: 'production',
+          endpoint: 'https://api.axonflow.com',
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        const postCall = mockFetch.mock.calls.find(
+          (call: [string, { method?: string; body?: string }]) => call[1]?.method === 'POST'
+        );
+        expect(postCall).toBeDefined();
+        const rawBody = postCall![1].body as string;
+        // Decoded shape AND wire-literal substring — wire-literal defends
+        // against tag-removal mutations that JSON.stringify would silently
+        // round-trip through a struct decode.
+        const payload: TelemetryPayload = JSON.parse(rawBody);
+        expect(payload.org_id).toBe('acme-corp');
+        expect(rawBody).toContain('"org_id":"acme-corp"');
+      });
+
+      it('includes local-dev-org sentinel when ORG_ID unset', async () => {
+        delete process.env.ORG_ID;
+        sendTelemetryPing({
+          mode: 'production',
+          endpoint: 'https://api.axonflow.com',
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const postCall = mockFetch.mock.calls.find(
+          (call: [string, { method?: string; body?: string }]) => call[1]?.method === 'POST'
+        );
+        const rawBody = postCall![1].body as string;
+        const payload: TelemetryPayload = JSON.parse(rawBody);
+        expect(payload.org_id).toBe('local-dev-org');
+        expect(rawBody).toContain('"org_id":"local-dev-org"');
+      });
+
+      it('passes through cs_<uuid> on wire', async () => {
+        const csId = 'cs_f29e9c5c-5c5b-4e0d-8e0d-aabbccddeeff';
+        process.env.ORG_ID = csId;
+        sendTelemetryPing({
+          mode: 'production',
+          endpoint: 'https://api.axonflow.com',
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const postCall = mockFetch.mock.calls.find(
+          (call: [string, { method?: string; body?: string }]) => call[1]?.method === 'POST'
+        );
+        const rawBody = postCall![1].body as string;
+        const payload: TelemetryPayload = JSON.parse(rawBody);
+        expect(payload.org_id).toBe(csId);
+        expect(rawBody).toContain(`"org_id":"${csId}"`);
+      });
+    });
+
+    describe('wire payload always carries org_id (real-network E2E)', () => {
+      // Real http.createServer-based E2E test — captures the wire body
+      // for real bytes-on-the-socket proof. Restores real fetch for the
+      // duration of this test only; the rest of the file uses mockFetch.
+      const realFetch = globalThis.fetch;
+
+      const runWithRealServer = async (
+        orgIdValue: string | undefined
+      ): Promise<{ body: string; parsed: TelemetryPayload }> => {
+        const http = require('http') as typeof import('http');
+        let capturedBody = '';
+
+        const server = http.createServer((req, res) => {
+          if (req.method === 'POST') {
+            const chunks: Buffer[] = [];
+            req.on('data', (chunk: Buffer) => chunks.push(chunk));
+            req.on('end', () => {
+              capturedBody = Buffer.concat(chunks).toString('utf-8');
+              res.writeHead(200, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ latest_version: null, alerts: [] }));
+            });
+          } else {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ version: '8.0.0-test' }));
+          }
+        });
+
+        await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
+        const addr = server.address();
+        if (!addr || typeof addr === 'string') throw new Error('listen failed');
+        const port = addr.port;
+
+        // Restore the real fetch for the local capture; the test body MUST
+        // restore the mock at the end so neighboring tests stay isolated.
+        global.fetch = realFetch as typeof fetch;
+
+        if (orgIdValue === undefined) {
+          delete process.env.ORG_ID;
+        } else {
+          process.env.ORG_ID = orgIdValue;
+        }
+        process.env.AXONFLOW_CHECKPOINT_URL = `http://127.0.0.1:${port}/v1/ping`;
+
+        try {
+          sendTelemetryPing({
+            mode: 'production',
+            endpoint: `http://127.0.0.1:${port}`,
+          });
+          // Wait long enough for: health probe + checkpoint POST to complete.
+          for (let i = 0; i < 50 && !capturedBody; i += 1) {
+            await new Promise(r => setTimeout(r, 50));
+          }
+          if (!capturedBody) throw new Error('telemetry ping never landed');
+          return { body: capturedBody, parsed: JSON.parse(capturedBody) };
+        } finally {
+          global.fetch = mockFetch as unknown as typeof fetch;
+          server.close();
+          delete process.env.AXONFLOW_CHECKPOINT_URL;
+        }
+      };
+
+      it('carries operator-supplied ORG_ID through to the receiver', async () => {
+        const { body, parsed } = await runWithRealServer('acme-corp');
+        expect(parsed.org_id).toBe('acme-corp');
+        expect(body).toContain('"org_id":"acme-corp"');
+      });
+
+      it('carries the sentinel when ORG_ID unset', async () => {
+        const { body, parsed } = await runWithRealServer(undefined);
+        expect(parsed.org_id).toBe('local-dev-org');
+        expect(body).toContain('"org_id":"local-dev-org"');
+      });
+
+      it('carries cs_<uuid> tenant identifier through to the receiver', async () => {
+        const csId = 'cs_f29e9c5c-5c5b-4e0d-8e0d-aabbccddeeff';
+        const { body, parsed } = await runWithRealServer(csId);
+        expect(parsed.org_id).toBe(csId);
+        expect(body).toContain(`"org_id":"${csId}"`);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds an `org_id` field to the TypeScript SDK telemetry heartbeat payload, in parity with the platform's `startup_telemetry.go` emitter (Epic #2230, Issue #2277). Sister PR to axonflow-sdk-go (merged), axonflow-sdk-python#198, and follow-on PRs on Java + Rust + 4 plugins.

**Two sources, precedence order:**
1. `ORG_ID` env var when set — operator's configured value on self-hosted, or `cs_<uuid>` tenant identifier on Community SaaS.
2. `local-dev-org` sentinel when unset.

## DoD

- [x] `TelemetryPayload.org_id` field required by type system (mutation guard via TS2741)
- [x] Unit tests: `telemetryOrgID` helper (4 subtests)
- [x] Unit tests via mock fetch: `wire payload always carries org_id` (3 subtests)
- [x] Functional E2E via real `http.createServer`: 3 subtests across `acme-corp` / `cs_<uuid>` / sentinel
- [x] Runtime proof: `runtime-e2e/v91_org_id_telemetry/test.mjs` + README — 3 modes all PASS
- [x] CHANGELOG entry under existing `[Unreleased]` (no version bump per scope)
- [x] Wording sweep on `telemetry.ts` log line, `heartbeat.ts` docstring, `sendTelemetryPing` JSDoc
- [x] `jest`: 38 passed, 0 failed in `tests/telemetry.test.ts`
- [x] `eslint`: 0 errors

## R2 captured wire bodies

```
ORG_ID=acme-corp:
{"telemetry_type":"sdk","sdk":"typescript", ... ,"org_id":"acme-corp"}

ORG_ID unset:
{"telemetry_type":"sdk","sdk":"typescript", ... ,"org_id":"local-dev-org"}

ORG_ID=cs_f29e9c5c-5c5b-4e0d-8e0d-aabbccddeeff:
{"telemetry_type":"sdk","sdk":"typescript", ... ,"org_id":"cs_f29e9c5c-..."}
```

## Test plan

- [ ] CI green
- [ ] DCO trailer present
- [ ] Commit Lint passes

Refs: getaxonflow/axonflow-enterprise#2230
Refs: getaxonflow/axonflow-enterprise#2277