### PR TITLE
feat(hitl): add createHITLRequest — paired SDK release for ADK plugin v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.0] - 2026-05-23 — `createHITLRequest` for explicit HITL row creation
+
+Enables agent-framework plugins (Google ADK, n8n, OpenAI Agents SDK) to
+implement the full 4-step HITL approval flow against AxonFlow:
+
+  1. Gate evaluates `require_approval` (via `pre_check` / `checkToolInput`)
+  2. Plugin calls `client.createHITLRequest(...)` to enqueue the row
+  3. Plugin polls `client.getHITLRequest(approval_id)` until terminal state
+  4. Plugin resumes the agent or denies the call based on the decision
+
+Prior to this release the SDK exposed `getHITLRequest` /
+`approveHITLRequest` / `rejectHITLRequest` (the read + review
+surface) but had no method to **create** a row. The platform's
+`POST /api/v1/hitl/queue` endpoint has existed since v6.x; only the SDK
+surface was missing.
+
+### Added
+
+- **`client.createHITLRequest(input: HITLCreateInput): Promise<HITLApprovalRequest>`.**
+  Required fields: `client_id`, `original_query`, `request_type`.
+  Optional fields cover policy attribution, severity, compliance
+  framework, an expiry override, and the new `notify_url` callback.
+  Server-side `X-Org-ID` / `X-Tenant-ID` headers are derived by the
+  platform's auth middleware from the SDK client's configured
+  credentials — callers do not pass them through this method.
+- **`HITLCreateInput` interface** in `src/types/hitl.ts` mirroring
+  `platform/agent/hitl/handler.go:86 CreateRequestInput`. Exported
+  from the top-level package alongside the existing HITL types.
+- **`notify_url` field on `HITLCreateInput` and `HITLApprovalRequest`.**
+  Opt-in webhook URL fired after the request reaches a terminal state
+  (approved / rejected / expired / overridden). Pairs with the
+  HMAC-SHA256 `X-AxonFlow-Signature` header on the receiver side.
+  Scheme allowlist (`https://`, plus `http://` for self-hosted
+  local-dev) is enforced server-side; bad schemes surface as an SDK
+  error carrying the platform's `HTTP 400`. Companion platform work in
+  getaxonflow/axonflow-enterprise#2419.
+- 8 Jest cases covering: full-fields create, minimal required-fields
+  create, bad-`notify_url`-scheme 400 propagation, 401 propagation,
+  connect failure propagation, and the three `ConfigurationError`
+  guards for missing required fields.
+
+### Compatibility
+
+No breaking changes. New imports are additive in `src/types/hitl.ts`
+and the top-level package re-exports. The existing `getHITLRequest` /
+`approveHITLRequest` / `rejectHITLRequest` / `listHITLQueue` /
+`getHITLStats` methods are unchanged. `notify_url` on the response
+type is optional and absent in payloads from platforms that don't yet
+implement the field; older code parses the new shape cleanly.
+
+Cross-SDK parity sweep: getaxonflow/axonflow-enterprise#2421.
+
 ## [8.1.0] - 2026-05-22 — `X-Client-ID` header on every outbound request + `org_id` in telemetry heartbeat + single-attempt HTTP contract documented
 
 Companion release to the v9 identity cleanup on the platform. Every

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/runtime-e2e/create_hitl_request/README.md
+++ b/runtime-e2e/create_hitl_request/README.md
@@ -1,0 +1,41 @@
+# `createHITLRequest` — runtime-e2e
+
+Real-stack assertion for the cross-SDK
+[`createHITLRequest`](https://github.com/getaxonflow/axonflow-enterprise/issues/2421)
+surface added in TypeScript SDK v8.2.0. Sister proof to the equivalent
+Python / Go / Java runtime-e2e tests shipping in the same parity sweep.
+
+## What this proves
+
+Drives `AxonFlow.createHITLRequest(...)` through the real `fetch`
+transport against a `node:http` listener that mimics the platform
+handler at `platform/agent/hitl/handler.go:177`. Captures the raw HTTP
+body, decodes it, and asserts every required field from
+`src/types/hitl.ts#HITLCreateInput` lands on the wire — including the
+new `notify_url` field added in
+[#2419](https://github.com/getaxonflow/axonflow-enterprise/issues/2419)
+— then asserts the SDK parses the platform's `APIResponse{success,
+data}` envelope back into a populated `HITLApprovalRequest`.
+
+No mocked fetch, no Jest spies, no test doubles — runs the production
+transport against an in-process HTTP server, which is what the
+`runtime-e2e/` DoD gate is asking for.
+
+## Usage
+
+```bash
+npm run build
+node runtime-e2e/create_hitl_request/test.mjs
+```
+
+Exits `0` on PASS, `1` on FAIL. Prints captured wire body + parsed
+response fields on success for human-readable confirmation.
+
+## Companion unit coverage
+
+`tests/hitl.test.ts` `describe('createHITLRequest')` exercises the
+same surface through mocked `fetch` for eight scenarios (happy path
+full-fields, minimal required-fields, bad-`notify_url`-scheme 400
+propagation, 401 propagation, connect-failure propagation, and the
+three `ConfigurationError` guards). The runtime proof here is the
+redundant real-stack confirmation.

--- a/runtime-e2e/create_hitl_request/test.mjs
+++ b/runtime-e2e/create_hitl_request/test.mjs
@@ -1,0 +1,168 @@
+// runtime-e2e/create_hitl_request/test.mjs
+//
+// Real-stack assertion: SDK posts a valid create-payload to
+// POST /api/v1/hitl/queue and parses the APIResponse envelope back
+// into a populated HITLApprovalRequest. Issue
+// getaxonflow/axonflow-enterprise#2421.
+//
+// Spins up a local node:http server that mimics the platform handler
+// at `platform/agent/hitl/handler.go:177`, drives the SDK's
+// AxonFlow.createHITLRequest against it through the real fetch
+// transport, and inspects the captured request body for every
+// required field including the new `notify_url` introduced in
+// getaxonflow/axonflow-enterprise#2419.
+//
+// No mocked fetch, no Jest spies, no MockHTTPSResponseFactory — real
+// bytes through node:http on both sides. Satisfies the
+// `runtime-e2e/` DoD gate that the unit suite under tests/ does not.
+//
+// Usage:
+//
+//   npm run build
+//   node runtime-e2e/create_hitl_request/test.mjs
+
+import { createServer } from 'node:http';
+import { AxonFlow } from '../../dist/esm/client.js';
+
+const NOTIFY_URL = 'https://workflows.example.com/hooks/runtime-e2e';
+
+let capturedBody = '';
+let capturedPath = '';
+
+const server = createServer((req, res) => {
+  if (req.method === 'POST') {
+    capturedPath = req.url ?? '';
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      capturedBody = Buffer.concat(chunks).toString('utf8');
+      let parsed;
+      try {
+        parsed = JSON.parse(capturedBody);
+      } catch {
+        res.statusCode = 400;
+        res.end('bad json');
+        return;
+      }
+      res.statusCode = 201;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          success: true,
+          data: {
+            request_id: 'hitl-req-runtime-e2e-001',
+            org_id: 'org-runtime-e2e',
+            tenant_id: 'tenant-runtime-e2e',
+            client_id: parsed.client_id ?? '',
+            user_id: parsed.user_id ?? '',
+            original_query: parsed.original_query ?? '',
+            request_type: parsed.request_type ?? '',
+            request_context: parsed.request_context ?? null,
+            triggered_policy_id: parsed.triggered_policy_id ?? '',
+            triggered_policy_name: parsed.triggered_policy_name ?? '',
+            trigger_reason: parsed.trigger_reason ?? '',
+            severity: parsed.severity ?? 'high',
+            notify_url: parsed.notify_url ?? null,
+            status: 'pending',
+            expires_at: '2026-05-23T11:00:00Z',
+            created_at: '2026-05-23T10:00:00Z',
+            updated_at: '2026-05-23T10:00:00Z',
+          },
+        })
+      );
+    });
+    return;
+  }
+  if (req.method === 'GET') {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ status: 'ok', version: 'runtime-e2e' }));
+    return;
+  }
+  res.statusCode = 405;
+  res.end();
+});
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const port = server.address().port;
+const endpoint = `http://127.0.0.1:${port}`;
+
+let exitCode = 0;
+try {
+  const client = new AxonFlow({
+    endpoint,
+    clientId: 'runtime-e2e',
+    clientSecret: 'runtime-e2e-secret',
+    tenant: 'tenant-runtime-e2e',
+  });
+
+  const result = await client.createHITLRequest({
+    client_id: 'runtime-e2e-client',
+    user_id: 'runtime-e2e-user',
+    original_query: 'disburse $50000 to cust-runtime-e2e',
+    request_type: 'adk-tool',
+    request_context: { tool_name: 'disburse_payment' },
+    triggered_policy_id: 'loan-amount-cap',
+    triggered_policy_name: 'Loan amount cap',
+    trigger_reason: 'Disbursement above $10k requires manager approval',
+    severity: 'high',
+    notify_url: NOTIFY_URL,
+  });
+
+  const expected = {
+    client_id: 'runtime-e2e-client',
+    user_id: 'runtime-e2e-user',
+    original_query: 'disburse $50000 to cust-runtime-e2e',
+    request_type: 'adk-tool',
+    triggered_policy_id: 'loan-amount-cap',
+    triggered_policy_name: 'Loan amount cap',
+    trigger_reason: 'Disbursement above $10k requires manager approval',
+    severity: 'high',
+    notify_url: NOTIFY_URL,
+  };
+
+  if (!capturedBody) {
+    process.stderr.write('FAIL: server captured no body\n');
+    exitCode = 1;
+  } else {
+    const wire = JSON.parse(capturedBody);
+    if (capturedPath !== '/api/v1/hitl/queue') {
+      process.stderr.write(`FAIL: POST path = ${capturedPath}, want /api/v1/hitl/queue\n`);
+      exitCode = 1;
+    }
+    for (const [field, expectedValue] of Object.entries(expected)) {
+      if (wire[field] !== expectedValue) {
+        process.stderr.write(
+          `FAIL: wire body field ${field} = ${JSON.stringify(wire[field])}, ` +
+            `want ${JSON.stringify(expectedValue)}\nFull body: ${capturedBody}\n`
+        );
+        exitCode = 1;
+      }
+    }
+    if (result.request_id !== 'hitl-req-runtime-e2e-001') {
+      process.stderr.write(`FAIL: parsed request_id = ${result.request_id}\n`);
+      exitCode = 1;
+    }
+    if (result.notify_url !== NOTIFY_URL) {
+      process.stderr.write(
+        `FAIL: parsed notify_url = ${result.notify_url}, want ${NOTIFY_URL}\n`
+      );
+      exitCode = 1;
+    }
+  }
+
+  if (exitCode === 0) {
+    console.log('PASS: createHITLRequest wire payload + response parsing round-trip OK');
+    console.log(`Wire body: ${capturedBody}`);
+    console.log(
+      `Parsed approval_id=${result.request_id} notify_url=${result.notify_url}`
+    );
+  }
+} catch (err) {
+  process.stderr.write(`FAIL: unexpected exception: ${err?.stack ?? err}\n`);
+  exitCode = 1;
+} finally {
+  server.close();
+}
+
+process.exit(exitCode);

--- a/src/client.ts
+++ b/src/client.ts
@@ -150,6 +150,7 @@ import {
   UnifiedListExecutionsResponse,
   // HITL Queue types
   HITLApprovalRequest,
+  HITLCreateInput,
   HITLQueueListOptions,
   HITLQueueListResponse,
   HITLReviewInput,
@@ -6909,6 +6910,73 @@ export class AxonFlow {
       has_more:
         (response.meta?.offset ?? 0) + (response.data?.length ?? 0) < (response.meta?.total ?? 0),
     };
+  }
+
+  /**
+   * Create a new HITL approval request via `POST /api/v1/hitl/queue`.
+   *
+   * Enterprise Feature: Requires AxonFlow Enterprise license. The
+   * platform's handler returns 403 with `ErrHITLApprovalDisabledByTier`
+   * when called against a community tier that hasn't enabled HITL, and
+   * 401 when credentials are invalid.
+   *
+   * This is the explicit row-creation step for callers that detect
+   * `require_approval` from a separate gate (`pre_check`,
+   * `check_tool_input`, MAP plan approvals) and want the row enqueued
+   * so a reviewer can act on it. After creating, either poll
+   * `getHITLRequest(returned.request_id)` until terminal state, or pass
+   * `notify_url` so the platform fires a signed webhook on the
+   * transition (n8n Wait-node "On Webhook Call" pattern; ADK plugin
+   * polling-free mode).
+   *
+   * @param input - Pre-populated {@link HITLCreateInput}. `client_id`,
+   *   `original_query`, and `request_type` are required; all other
+   *   fields are optional. Bad `notify_url` schemes are rejected by the
+   *   platform with HTTP 400; only `https://` (and `http://` for
+   *   self-hosted local-dev) are accepted.
+   * @returns The created {@link HITLApprovalRequest} with `request_id`
+   *   populated.
+   *
+   * @example
+   * ```typescript
+   * const req = await client.createHITLRequest({
+   *   client_id: 'loan-desk',
+   *   original_query: 'disburse $50000 to cust-001',
+   *   request_type: 'adk-tool',
+   *   triggered_policy_id: 'loan-amount-cap',
+   *   triggered_policy_name: 'Loan amount cap',
+   *   trigger_reason: 'Disbursement above $10k requires manager approval',
+   *   severity: 'high',
+   *   notify_url: 'https://workflows.example.com/hooks/loan-approve',
+   * });
+   * console.log(`Created HITL approval ${req.request_id}`);
+   * ```
+   */
+  async createHITLRequest(input: HITLCreateInput): Promise<HITLApprovalRequest> {
+    if (!input?.client_id) {
+      throw new ConfigurationError('client_id is required');
+    }
+    if (!input?.original_query) {
+      throw new ConfigurationError('original_query is required');
+    }
+    if (!input?.request_type) {
+      throw new ConfigurationError('request_type is required');
+    }
+
+    if (this.config.debug) {
+      debugLog('Creating HITL request', {
+        client_id: input.client_id,
+        request_type: input.request_type,
+        notify_url: input.notify_url,
+      });
+    }
+
+    const response = await this.orchestratorRequest<{
+      success: boolean;
+      data: HITLApprovalRequest;
+    }>('POST', '/api/v1/hitl/queue', input);
+
+    return response.data;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,7 @@ export type {
 // Export HITL Queue types (Enterprise)
 export type {
   HITLApprovalRequest,
+  HITLCreateInput,
   HITLQueueListOptions,
   HITLQueueListResponse,
   HITLReviewInput,

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -53,6 +53,18 @@ export interface HITLApprovalRequest {
   review_comment?: string;
   /** When the request was reviewed */
   reviewed_at?: string;
+  /**
+   * Optional outbound webhook URL associated with the request.
+   *
+   * Mirrors the value supplied on creation. Platforms that implement the
+   * outbound-webhook dispatcher (introduced in
+   * getaxonflow/axonflow-enterprise#2419) fire a signed POST to this URL
+   * after the request reaches a terminal state
+   * (approved/rejected/expired/overridden). Platforms that don't, simply
+   * round-trip the field. Enables webhook-driven resume (n8n Wait-node,
+   * ADK plugin polling-free mode).
+   */
+  notify_url?: string;
   /** When the request expires */
   expires_at: string;
   /** When the request was created */
@@ -85,6 +97,61 @@ export interface HITLQueueListResponse {
   total: number;
   /** Whether there are more items beyond the current page */
   has_more: boolean;
+}
+
+/**
+ * Input for creating an HITL approval request.
+ *
+ * Mirrors `platform/agent/hitl/handler.go:86 CreateRequestInput`. The
+ * platform's `POST /api/v1/hitl/queue` handler reads `X-Org-ID` and
+ * `X-Tenant-ID` from request headers (set by the auth middleware from
+ * the SDK client's credentials), and the JSON body must carry the
+ * fields below.
+ *
+ * Used by agent-framework plugins (ADK, n8n, OpenAI Agents SDK) that
+ * detect `require_approval` from `pre_check` / `check_tool_input` and
+ * want to enqueue the corresponding HITL row before polling the
+ * reviewer's decision (or before pivoting to webhook-driven resume via
+ * `notify_url`).
+ */
+export interface HITLCreateInput {
+  /** Client identifier that triggered the request. Required. */
+  client_id: string;
+  /** End-user identifier. Optional. */
+  user_id?: string;
+  /** Original query that triggered the gate. Required. */
+  original_query: string;
+  /** Request type (e.g. 'chat', 'tool', 'mcp'). Required. */
+  request_type: string;
+  /** Additional context propagated from the gated call. */
+  request_context?: Record<string, unknown>;
+  /** ID of the policy that fired require_approval. */
+  triggered_policy_id?: string;
+  /** Display name of the policy that fired require_approval. */
+  triggered_policy_name?: string;
+  /** Human-readable explanation of why approval is needed. */
+  trigger_reason?: string;
+  /** Severity level: 'critical' | 'high' | 'medium' | 'low'. Default 'high'. */
+  severity?: string;
+  /**
+   * Optional outbound webhook URL fired async after terminal state
+   * transition (approved/rejected/expired/overridden). Must be
+   * `https://` (or `http://` for self-hosted local-dev). Server-side
+   * validation rejects bad schemes with HTTP 400. Pair with the
+   * HMAC-SHA256 `X-AxonFlow-Signature` header on the receiver side;
+   * signing key is the deployment-configured
+   * `AXONFLOW_HITL_WEBHOOK_SIGNING_KEY`. Introduced in
+   * getaxonflow/axonflow-enterprise#2419.
+   */
+  notify_url?: string;
+  /** EU AI Act article reference (e.g. 'Article 14'). */
+  eu_ai_act_article?: string;
+  /** Compliance framework label (GDPR / HIPAA / RBI / ...). */
+  compliance_framework?: string;
+  /** Risk classification level. */
+  risk_classification?: string;
+  /** Optional override for the approval expiry window. */
+  expires_in_seconds?: number;
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.1.0';
+export const VERSION = '8.2.0';

--- a/tests/hitl.test.ts
+++ b/tests/hitl.test.ts
@@ -207,6 +207,184 @@ describe('HITL Queue Methods', () => {
   });
 
   // ==========================================================================
+  // createHITLRequest Tests
+  // ==========================================================================
+
+  describe('createHITLRequest', () => {
+    it('should POST a full create-input and return the created record', async () => {
+      const createResponse = {
+        success: true,
+        data: {
+          request_id: 'hitl-req-new-001',
+          org_id: 'org-1',
+          tenant_id: 'tenant-1',
+          client_id: 'loan-desk',
+          user_id: 'cust-001',
+          original_query: 'disburse $50000 to cust-001',
+          request_type: 'adk-tool',
+          request_context: { tool_name: 'disburse_payment' },
+          triggered_policy_id: 'loan-amount-cap',
+          triggered_policy_name: 'Loan amount cap',
+          trigger_reason: 'Disbursement above $10k requires manager approval',
+          severity: 'high',
+          notify_url: 'https://workflows.example.com/hooks/loan-approve',
+          status: 'pending',
+          expires_at: '2026-05-23T11:00:00Z',
+          created_at: '2026-05-23T10:00:00Z',
+          updated_at: '2026-05-23T10:00:00Z',
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce(mockResponse(createResponse, 201));
+
+      const result = await client.createHITLRequest({
+        client_id: 'loan-desk',
+        user_id: 'cust-001',
+        original_query: 'disburse $50000 to cust-001',
+        request_type: 'adk-tool',
+        request_context: { tool_name: 'disburse_payment' },
+        triggered_policy_id: 'loan-amount-cap',
+        triggered_policy_name: 'Loan amount cap',
+        trigger_reason: 'Disbursement above $10k requires manager approval',
+        severity: 'high',
+        notify_url: 'https://workflows.example.com/hooks/loan-approve',
+      });
+
+      expect(result.request_id).toBe('hitl-req-new-001');
+      expect(result.status).toBe('pending');
+      expect(result.notify_url).toBe('https://workflows.example.com/hooks/loan-approve');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/hitl/queue',
+        expect.objectContaining({ method: 'POST' })
+      );
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body.client_id).toBe('loan-desk');
+      expect(body.original_query).toBe('disburse $50000 to cust-001');
+      expect(body.request_type).toBe('adk-tool');
+      expect(body.notify_url).toBe('https://workflows.example.com/hooks/loan-approve');
+      expect(body.severity).toBe('high');
+    });
+
+    it('should accept the minimal required-field set (client_id + original_query + request_type)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          {
+            success: true,
+            data: {
+              request_id: 'hitl-req-minimal',
+              org_id: 'org-1',
+              tenant_id: 'tenant-1',
+              client_id: 'c1',
+              original_query: 'q',
+              request_type: 'chat',
+              triggered_policy_id: '',
+              triggered_policy_name: '',
+              trigger_reason: '',
+              severity: 'high',
+              status: 'pending',
+              expires_at: '2026-05-23T11:00:00Z',
+              created_at: '2026-05-23T10:00:00Z',
+              updated_at: '2026-05-23T10:00:00Z',
+            },
+          },
+          201
+        )
+      );
+
+      const result = await client.createHITLRequest({
+        client_id: 'c1',
+        original_query: 'q',
+        request_type: 'chat',
+      });
+      expect(result.request_id).toBe('hitl-req-minimal');
+      expect(result.notify_url).toBeUndefined();
+    });
+
+    it('should surface a platform 400 on bad notify_url scheme as an Error from the SDK', async () => {
+      // Mirrors `platform/agent/hitl/webhook.go:105 ValidateNotifyURL` —
+      // the SDK is a pass-through here so a tightening of the scheme
+      // allowlist on the platform doesn't require an SDK upgrade.
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          {
+            success: false,
+            error:
+              'notify_url scheme "javascript" is not allowed (use https:// or http://)',
+          },
+          400
+        )
+      );
+
+      await expect(
+        client.createHITLRequest({
+          client_id: 'loan-desk',
+          original_query: 'disburse $50000',
+          request_type: 'adk-tool',
+          notify_url: 'javascript:alert(1)',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should propagate 401 as an authentication-shaped error', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ success: false, error: 'Invalid API key' }, 401)
+      );
+
+      await expect(
+        client.createHITLRequest({
+          client_id: 'loan-desk',
+          original_query: 'disburse $50000',
+          request_type: 'adk-tool',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should propagate connect/network failure as an error', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('fetch failed: ECONNREFUSED'));
+
+      await expect(
+        client.createHITLRequest({
+          client_id: 'loan-desk',
+          original_query: 'disburse $50000',
+          request_type: 'adk-tool',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should throw ConfigurationError when client_id is missing', async () => {
+      await expect(
+        client.createHITLRequest({
+          client_id: '',
+          original_query: 'q',
+          request_type: 'chat',
+        })
+      ).rejects.toThrow(ConfigurationError);
+    });
+
+    it('should throw ConfigurationError when original_query is missing', async () => {
+      await expect(
+        client.createHITLRequest({
+          client_id: 'c1',
+          original_query: '',
+          request_type: 'chat',
+        })
+      ).rejects.toThrow(ConfigurationError);
+    });
+
+    it('should throw ConfigurationError when request_type is missing', async () => {
+      await expect(
+        client.createHITLRequest({
+          client_id: 'c1',
+          original_query: 'q',
+          request_type: '',
+        })
+      ).rejects.toThrow(ConfigurationError);
+    });
+  });
+
+  // ==========================================================================
   // getHITLRequest Tests
   // ==========================================================================
 

--- a/tests/hitl.test.ts
+++ b/tests/hitl.test.ts
@@ -310,8 +310,7 @@ describe('HITL Queue Methods', () => {
         mockResponse(
           {
             success: false,
-            error:
-              'notify_url scheme "javascript" is not allowed (use https:// or http://)',
+            error: 'notify_url scheme "javascript" is not allowed (use https:// or http://)',
           },
           400
         )

--- a/tests/hitl.test.ts
+++ b/tests/hitl.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { AxonFlow } from '../src/client';
-import { ConfigurationError } from '../src/errors';
+import { APIError, AuthenticationError, ConfigurationError } from '../src/errors';
 
 // Mock fetch globally
 const mockFetch = jest.fn();
@@ -302,7 +302,7 @@ describe('HITL Queue Methods', () => {
       expect(result.notify_url).toBeUndefined();
     });
 
-    it('should surface a platform 400 on bad notify_url scheme as an Error from the SDK', async () => {
+    it('should surface a platform 400 on bad notify_url scheme as APIError(400)', async () => {
       // Mirrors `platform/agent/hitl/webhook.go:105 ValidateNotifyURL` —
       // the SDK is a pass-through here so a tightening of the scheme
       // allowlist on the platform doesn't require an SDK upgrade.
@@ -324,10 +324,10 @@ describe('HITL Queue Methods', () => {
           request_type: 'adk-tool',
           notify_url: 'javascript:alert(1)',
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(APIError);
     });
 
-    it('should propagate 401 as an authentication-shaped error', async () => {
+    it('should propagate 401 as AuthenticationError (orchestratorRequest 401/403 path)', async () => {
       mockFetch.mockResolvedValueOnce(
         mockResponse({ success: false, error: 'Invalid API key' }, 401)
       );
@@ -338,10 +338,14 @@ describe('HITL Queue Methods', () => {
           original_query: 'disburse $50000',
           request_type: 'adk-tool',
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(AuthenticationError);
     });
 
-    it('should propagate connect/network failure as an error', async () => {
+    it('should propagate connect/network failure as the underlying fetch TypeError', async () => {
+      // orchestratorRequest does not wrap fetch's transport-layer rejection
+      // (TypeError 'fetch failed' on Node 18+) — it surfaces unchanged so
+      // callers can branch on `.cause`. Locking the contract here means a
+      // future wrapping layer must update this test too.
       mockFetch.mockRejectedValueOnce(new TypeError('fetch failed: ECONNREFUSED'));
 
       await expect(
@@ -350,7 +354,7 @@ describe('HITL Queue Methods', () => {
           original_query: 'disburse $50000',
           request_type: 'adk-tool',
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(TypeError);
     });
 
     it('should throw ConfigurationError when client_id is missing', async () => {


### PR DESCRIPTION
## Summary

Adds `client.createHITLRequest(...)` for explicit creation of HITL
approval rows via `POST /api/v1/hitl/queue`. This is the paired SDK
release that unblocks the Google ADK plugin v1 fixup
(getaxonflow/axonflow-enterprise#2410) and is the TypeScript half of
the cross-SDK parity sweep tracked at
getaxonflow/axonflow-enterprise#2421.

## Why now

The platform's `POST /api/v1/hitl/queue` endpoint has existed since
v6.x (handler at `platform/agent/hitl/handler.go:177`). The TypeScript
SDK exposed the read + review surface (`getHITLRequest`,
`approveHITLRequest`, `rejectHITLRequest`) but had no `create*`
counterpart. Agent-framework plugins detecting `require_approval` from
`pre_check` / `checkToolInput` need to create the row themselves
before polling — the gate endpoints set
`BlockReason="require_approval"` and mint a correlation ID, but do
not call `CreateApprovalRequest` themselves.

## Changes

- `src/client.ts` — `async createHITLRequest(input) -> HITLApprovalRequest`.
- `src/types/hitl.ts` — `HITLCreateInput` interface mirroring
  `platform/agent/hitl/handler.go:86 CreateRequestInput`. New
  `notify_url` field on both `HITLCreateInput` and
  `HITLApprovalRequest` (companion to platform work in
  getaxonflow/axonflow-enterprise#2419).
- `src/index.ts` — re-export `HITLCreateInput` from top-level package.
- `tests/hitl.test.ts` — 8 new Jest cases.
- `runtime-e2e/create_hitl_request/` — real-fetch + node:http proof.
- `CHANGELOG.md` + `package.json` + `src/version.ts` — bump 8.1.0 →
  8.2.0 (additive; no breaking changes).

## Test plan

- [x] `npm test -- tests/hitl.test.ts` green (31 tests, including 8 new)
- [x] `npm test` full suite green (918 passed, 13 skipped)
- [x] `npm run build` succeeds
- [x] `node runtime-e2e/create_hitl_request/test.mjs` PASS
- [x] No regression on existing HITL test cases

## Cross-SDK parity coverage

| SDK | Method name | Type name | Status |
|---|---|---|---|
| Python | `create_hitl_request` | `HITLCreateInput` | getaxonflow/axonflow-sdk-python#202 (open) |
| **TypeScript** | **`createHITLRequest`** | **`HITLCreateInput`** | **this PR** |
| Go | `CreateHITLRequest` | `HITLCreateInput` | in-flight |
| Java | `createHITLRequest` (+ async overload) | `HITLCreateInput` | in-flight |
| Rust | `create_hitl_request` (+ full HITL surface port) | `HITLCreateInput` | in-flight |

Method shape (input type, return type, validation guards, error
propagation) intentionally mirrors the existing `approveHITLRequest`
/ `rejectHITLRequest` patterns to keep cross-SDK + intra-SDK coherence
load-bearing for future ADK Java/Go/TS/Kotlin plugins.

Refs getaxonflow/axonflow-enterprise#2421 (umbrella),
getaxonflow/axonflow-enterprise#2419 (notify_url platform companion),
getaxonflow/axonflow-enterprise#2393 (driving epic),
getaxonflow/axonflow-enterprise#2410 (ADK plugin v1 fixup)