### PR TITLE
chore(release): v8.2.0 platform cross-ref + terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and the top-level package re-exports. The existing `getHITLRequest` /
 type is optional and absent in payloads from platforms that don't yet
 implement the field; older code parses the new shape cleanly.
 
+Requires AxonFlow platform >= 8.1.0 for `notify_url` webhook delivery
+and `Idempotency-Key` request deduplication.
+
 Cross-SDK parity sweep: getaxonflow/axonflow-enterprise#2421.
 
 ## [8.1.0] - 2026-05-22 — `X-Client-ID` header on every outbound request + `org_id` in telemetry heartbeat + single-attempt HTTP contract documented
@@ -75,7 +78,7 @@ when no `clientId` is configured.
  SDK telemetry up to parity with the platform — every heartbeat now
  identifies which deployment-organization emitted it. Two sources in
  precedence order:
- 1. The `ORG_ID` env var when set (the operator's explicit configuration
+ 1. The `ORG_ID` env var when set (the explicit configuration
     on self-hosted deployments, or the `cs_<uuid>` tenant identifier on
     Community SaaS).
  2. Otherwise the `local-dev-org` sentinel (default-config Community-mode
@@ -96,7 +99,7 @@ when no `clientId` is configured.
 
 - **Telemetry-enabled log line** softened from "Anonymous telemetry
  enabled" to "Telemetry enabled" to stay coherent with the `org_id`
- addition — the operator-supplied `ORG_ID` on self-hosted is not
+ addition — the configured `ORG_ID` on self-hosted deployments is not
  anonymized; only the `instance_id` and `cs_<uuid>` Community SaaS
  identifier remain anonymous-by-design.
 - **README "A note on HTTP retries"** clarifies that the SDK does not


### PR DESCRIPTION
## Summary

- Add platform >= 8.1.0 requirement to v8.2.0 Compatibility section
- Replace "operator" with compliant wording in unreleased v8.1.0 entry (2 occurrences)

Part of the cross-repo release-prep sweep (getaxonflow/axonflow-enterprise#2428).

## Manifest verification (no changes needed)

| File | Expected | Actual |
|------|----------|--------|
| `package.json` version | 8.2.0 | 8.2.0 |
| `package-lock.json` version | 8.2.0 | 8.2.0 |

## CHANGELOG diff

```diff
 ### Compatibility

 No breaking changes. New imports are additive in `src/types/hitl.ts`
 ...
+Requires AxonFlow platform >= 8.1.0 for `notify_url` webhook delivery
+and `Idempotency-Key` request deduplication.

 Cross-SDK parity sweep: getaxonflow/axonflow-enterprise#2421.

 ## [8.1.0] ...
 ...
- 1. The `ORG_ID` env var when set (the operator's explicit configuration
+ 1. The `ORG_ID` env var when set (the explicit configuration
     on self-hosted deployments ...
 ...
- addition — the operator-supplied `ORG_ID` on self-hosted is not
+ addition — the configured `ORG_ID` on self-hosted deployments is not
```

## Checklist

- [x] CHANGELOG entry date: `[8.2.0] - 2026-05-23` (pre-existing)
- [x] Platform cross-reference added
- [x] No "operator" in any entry
- [x] No AI attribution
- [x] DCO sign-off on commit