### PR TITLE
feat(indonesia): pii-indonesia + cross-border audit fields [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [8.3.0] - 2026-05-26 — Indonesia PII category + cross-border audit fields
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`pii-indonesia` policy category** in the `PolicyCategory` union type.
+  Enables filtering and creating policies for Indonesian PII detection
+  (NIK, KK, NPWP, BPJS) alongside the existing per-jurisdiction categories.
+- **`dataResidency` and `transferBasis` fields on `AuditLogEntry`.**
+  Optional string fields supporting cross-border data transfer logging.
+  `dataResidency` is an ISO 3166-1 alpha-2 country code;
+  `transferBasis` is one of `adequacy`, `safeguards`, or `consent`.
+  Both are optional for backward compatibility with older platform versions.
+
 ## [8.2.0] - 2026-05-23 — `createHITLRequest` for explicit HITL row creation
 
 Enables agent-framework plugins (Google ADK, n8n, OpenAI Agents SDK) to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -2971,6 +2971,8 @@ export class AxonFlow {
       latencyMs: (data.latency_ms as number) ?? 0,
       policyViolations: (data.policy_violations as string[]) ?? [],
       metadata: (data.metadata as Record<string, unknown>) ?? {},
+      ...(data.data_residency != null && { dataResidency: data.data_residency as string }),
+      ...(data.transfer_basis != null && { transferBasis: data.transfer_basis as string }),
     };
   }
 

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -296,6 +296,10 @@ export interface AuditLogEntry {
   policyViolations: string[];
   /** Additional context */
   metadata: Record<string, unknown>;
+  /** ISO 3166-1 alpha-2 country code for data residency (cross-border transfer logging). */
+  dataResidency?: string;
+  /** Legal basis for cross-border data transfer: "adequacy", "safeguards", or "consent". */
+  transferBasis?: string;
 }
 
 /**

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -20,6 +20,7 @@ export type PolicyCategory =
   | 'pii-eu'
   | 'pii-india'
   | 'pii-singapore'
+  | 'pii-indonesia'
   // Static policy categories - Code Governance
   | 'code-secrets'
   | 'code-unsafe'

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.2.0';
+export const VERSION = '8.3.0';

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -383,6 +383,34 @@ describe('Audit Log Read Methods', () => {
       expect(entry.metadata).toEqual({});
     });
 
+    it('should parse dataResidency and transferBasis from wire fields', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse([
+          {
+            ...sampleAuditEntries[0],
+            data_residency: 'ID',
+            transfer_basis: 'consent',
+          },
+        ])
+      );
+
+      const result = await client.searchAuditLogs();
+      const entry = result.entries[0];
+
+      expect(entry.dataResidency).toBe('ID');
+      expect(entry.transferBasis).toBe('consent');
+    });
+
+    it('should omit dataResidency and transferBasis when absent from wire (backward compat)', async () => {
+      mockFetch.mockReturnValueOnce(mockResponse(sampleAuditEntries));
+
+      const result = await client.searchAuditLogs();
+      const entry = result.entries[0];
+
+      expect(entry.dataResidency).toBeUndefined();
+      expect(entry.transferBasis).toBeUndefined();
+    });
+
     it('should handle missing optional fields with defaults', async () => {
       mockFetch.mockReturnValueOnce(
         mockResponse([

--- a/tests/fixtures/wire-shape-baseline.json
+++ b/tests/fixtures/wire-shape-baseline.json
@@ -269,9 +269,11 @@
   "per_type_drift": {
     "AuditLogEntry": {
       "sdk_only": [
+        "data_residency",
         "metadata",
         "model",
-        "policy_violations"
+        "policy_violations",
+        "transfer_basis"
       ],
       "spec_only": []
     },

--- a/tests/policies.test.ts
+++ b/tests/policies.test.ts
@@ -607,6 +607,60 @@ describe('Policy CRUD Methods', () => {
   });
 
   // ========================================================================
+  // PolicyCategory Union Type Tests
+  // ========================================================================
+
+  describe('PolicyCategory values', () => {
+    it('should accept pii-indonesia as a valid PolicyCategory', async () => {
+      const indonesiaPolicy: StaticPolicy = {
+        ...sampleStaticPolicy,
+        id: 'pol_indonesia',
+        name: 'Indonesia PII Detection',
+        category: 'pii-indonesia',
+      };
+      mockFetch.mockReturnValueOnce(mockResponse({ policies: [indonesiaPolicy] }));
+
+      const policies = await client.listStaticPolicies({ category: 'pii-indonesia' });
+
+      expect(policies).toHaveLength(1);
+      expect(policies[0].category).toBe('pii-indonesia');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/static-policies?category=pii-indonesia',
+        expect.any(Object)
+      );
+    });
+
+    it('should create a policy with pii-indonesia category', async () => {
+      const indonesiaPolicy: StaticPolicy = {
+        ...sampleStaticPolicy,
+        id: 'pol_indonesia_nik',
+        name: 'Indonesia NIK Detection',
+        category: 'pii-indonesia',
+      };
+      mockFetch.mockReturnValueOnce(mockResponse(indonesiaPolicy));
+
+      const request: CreateStaticPolicyRequest = {
+        name: 'Indonesia NIK Detection',
+        category: 'pii-indonesia',
+        pattern: '\\b\\d{16}\\b',
+        severity: 'high',
+        action: 'redact',
+      };
+
+      const policy = await client.createStaticPolicy(request);
+
+      expect(policy.category).toBe('pii-indonesia');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/static-policies',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"category":"pii-indonesia"'),
+        })
+      );
+    });
+  });
+
+  // ========================================================================
   // Error Handling Tests
   // ========================================================================
 


### PR DESCRIPTION
## Summary

- Add `'pii-indonesia'` to the `PolicyCategory` union type for Indonesian PII detection (NIK, KK, NPWP, BPJS)
- Add `dataResidency` and `transferBasis` optional fields to `AuditLogEntry` for cross-border data transfer logging
- Wire mapping: `data_residency` → `dataResidency`, `transfer_basis` → `transferBasis` in `parseAuditLogEntry()`

## Cross-SDK parity

Part of a 5-SDK sweep (Go/Python/TypeScript/Java/Rust). JSON wire values are identical across all SDKs:
- Policy category: `"pii-indonesia"`
- Audit fields: `data_residency` (ISO 3166-1 alpha-2), `transfer_basis` (adequacy|safeguards|consent)

## Skip-runtime-e2e justification

New fields are additive optional fields following existing patterns. No platform endpoints to test against yet.

## Test plan

- [x] `npm test` — 922 tests pass, 31 suites, 0 failures
- [x] New tests: policy category validation, audit field deserialization + backward compat
- [x] Backward compat: entries without new fields have `undefined` values

Tracking: getaxonflow/axonflow-enterprise#2478