### PR TITLE
feat(release): v8.4.0 — decision request context + pasal_56b_dpa transfer basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.0] - 2026-05-30 — Decision request context + Pasal 56(b) transfer basis
+
+Targets AxonFlow platform **v8.5.0**.
+
+### Added
+
+- **`context` field on `DecisionSummary` and `DecisionExplanation`** —
+  `Record<string, string>`. Surfaces the sanitized request context a PEP attaches
+  to a Decision Mode call (canonical `lower_snake_case` keys such as `x_ai_agent`,
+  `x_session_id`, `x_leader_identity`, and `x-bukuwarung-*`), persisted by the
+  platform at the audit row's `policy_details->'context'`. `listDecisions()`
+  returns the platform-truncated summary (5 keys); `explainDecision()` returns the
+  full map. The `parseDecisionSummary` / `parseDecisionExplanation` decoders map
+  the new wire fields through. Absent for pre-v8.4.0 audit rows.
+- **`contextTruncated` field on `DecisionExplanation`** — `boolean`. True when the
+  agent dropped surplus context keys at write time.
+- **`TransferBasis` union type** (`'adequacy' | 'safeguards' | 'pasal_56b_dpa' |
+  'consent'`), exported from the package root. Names the Indonesia UU PDP Pasal 56
+  legal bases.
+
+### Changed
+
+- **`AuditLogEntry.transferBasis`** is now typed `TransferBasis` (was `string`) and
+  accepts `pasal_56b_dpa` (Pasal 56(b) explicit DPA tag) alongside `adequacy`,
+  `safeguards`, and `consent`. The union is a compile-time hint only — the runtime
+  decoder passes the value through verbatim, so existing `safeguards` consumers are
+  unaffected and an unknown future value still parses.
+
 ## [8.3.0] - 2026-05-27 — Indonesia PII category + cross-border audit fields
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/runtime-e2e/decision_context_transfer_basis/README.md
+++ b/runtime-e2e/decision_context_transfer_basis/README.md
@@ -1,0 +1,25 @@
+# decision_context_transfer_basis (v8.4.0)
+
+Real-stack proof for the v8.4.0 SDK surface (platform epic #2508):
+
+- **`DecisionSummary.context` / `DecisionExplanation.context` (+ `contextTruncated`)** —
+  the sanitized request context a PEP attaches to a Decision Mode call is surfaced
+  back through `listDecisions` and `explainDecision`. The `parseDecisionSummary` /
+  `parseDecisionExplanation` decoders map the new wire fields through.
+- **`AuditLogEntry.transferBasis = 'pasal_56b_dpa'`** — the Pasal 56(b) explicit DPA
+  tag (a member of the new `TransferBasis` union) round-trips verbatim.
+
+The driver builds the local SDK, acts as the PEP (raw `POST /api/v1/decide` — that
+endpoint is not SDK-wrapped per ADR-056), then reads the decision back through the
+SDK against a real running agent.
+
+## Run
+
+```
+export AXONFLOW_AGENT_URL=http://localhost:8080
+export AXONFLOW_TENANT_ID=buku-e-ts-e2e
+export AXONFLOW_TENANT_SECRET=buku-e-secret
+./test.sh
+```
+
+Exits non-zero if the SDK does not surface the new fields.

--- a/runtime-e2e/decision_context_transfer_basis/test.sh
+++ b/runtime-e2e/decision_context_transfer_basis/test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Runtime proof — TypeScript SDK v8.4.0 surfaces the Decision Mode request
+# context (platform #2509, epic #2508) and the pasal_56b_dpa transfer basis.
+#
+# Builds the LOCAL SDK (dist/) and runs a Node program that:
+#   1. acts as the PEP via a raw POST /api/v1/decide (that endpoint is not
+#      SDK-wrapped per ADR-056), forwarding request context in the body;
+#   2. reads the decision back through the SDK's listDecisions + explainDecision
+#      and asserts DecisionSummary.context / DecisionExplanation.context are
+#      populated with the forwarded keys;
+#   3. JSON round-trips an AuditLogEntry carrying transferBasis='pasal_56b_dpa'
+#      to confirm the value is surfaced verbatim.
+#
+# The npm registry is blocked, so we use the LOCAL build via file:../.. (never
+# `npm install @axonflow/sdk` — that would fail on the publish boundary).
+#
+# Usage:
+#   AXONFLOW_AGENT_URL=http://localhost:8080 ./test.sh
+
+set -uo pipefail
+
+AGENT_URL=${AXONFLOW_AGENT_URL:-http://localhost:8080}
+CLIENT_ID=${AXONFLOW_TENANT_ID:-buku-e-ts-e2e}
+SECRET=${AXONFLOW_TENANT_SECRET:-buku-e-secret}
+SDK_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUN_TAG=$(date -u +%s)
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+if [ ! -f "$SDK_ROOT/dist/esm/index.js" ]; then
+  echo "Building local SDK..."
+  (cd "$SDK_ROOT" && npm run build) || { red "FAIL: SDK build failed"; exit 1; }
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/package.json" <<EOF
+{
+  "name": "decision-ctx-rt-${RUN_TAG}",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": { "@axonflow/sdk": "file:${SDK_ROOT}" }
+}
+EOF
+
+cat > "$WORK/main.mjs" <<EOF
+import { AxonFlow } from '@axonflow/sdk';
+
+const AGENT_URL = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+const CLIENT_ID = process.env.AXONFLOW_TENANT_ID || 'buku-e-ts-e2e';
+const SECRET = process.env.AXONFLOW_TENANT_SECRET || 'buku-e-secret';
+const want = { x_ai_agent: 'refund-bot', x_session_id: 'sess-buku-42', x_leader_identity: 'ops-lead' };
+
+const fail = (m) => { console.error('FAIL: ' + m); process.exit(1); };
+const sameCtx = (got) => got && want.x_ai_agent === got.x_ai_agent
+  && want.x_session_id === got.x_session_id && want.x_leader_identity === got.x_leader_identity;
+
+// 1. PEP: create a decision carrying request context (body 'context' map).
+const auth = Buffer.from(CLIENT_ID + ':' + SECRET).toString('base64');
+const decideResp = await fetch(AGENT_URL + '/api/v1/decide', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'X-Client-ID': CLIENT_ID, Authorization: 'Basic ' + auth },
+  body: JSON.stringify({
+    stage: 'llm',
+    query: 'summarize this support ticket',
+    target: { type: 'llm', model: 'gpt-4', provider: 'openai' },
+    context: { 'x-ai-agent': 'refund-bot', 'x-session-id': 'sess-buku-42', 'x-leader-identity': 'ops-lead' },
+  }),
+});
+const decideText = await decideResp.text();
+if (!decideResp.ok) fail('decide HTTP ' + decideResp.status + ': ' + decideText);
+console.log('server /decide response: ' + decideText);
+const decisionId = JSON.parse(decideText).decision_id;
+if (!decisionId) fail('no decision_id: ' + decideText);
+console.log('PEP decide -> decision_id=' + decisionId);
+
+// 2. Read it back through the SDK.
+const client = new AxonFlow({ endpoint: AGENT_URL, clientId: CLIENT_ID, clientSecret: SECRET, mode: 'production' });
+
+const rows = await client.listDecisions({ limit: 5 });
+const found = rows.find((r) => r.decisionId === decisionId);
+if (!found) fail('listDecisions did not return ' + decisionId + ' (got ' + rows.length + ' rows)');
+console.log('SDK listDecisions -> ' + JSON.stringify(found));
+if (!sameCtx(found.context)) fail('listDecisions context = ' + JSON.stringify(found.context));
+console.log('PASS: listDecisions DecisionSummary.context populated with ' + Object.keys(found.context).length + ' PEP-forwarded keys');
+
+const exp = await client.explainDecision(decisionId);
+console.log('SDK explainDecision -> context=' + JSON.stringify(exp.context) + ' contextTruncated=' + exp.contextTruncated);
+if (!sameCtx(exp.context)) fail('explainDecision context = ' + JSON.stringify(exp.context));
+console.log('PASS: explainDecision returned full context (contextTruncated=' + exp.contextTruncated + ')');
+
+// 3. transfer_basis = pasal_56b_dpa is JSON-preserved. NOTE: TypeScript types are
+//    erased at runtime, so this only asserts the value survives a JSON round-trip.
+//    The SDK's real snake_case->camelCase decoder (parseAuditLogEntry) is covered
+//    by tests/audit.test.ts ('should parse the pasal_56b_dpa transfer basis ...').
+const entry = { id: 'e2e-audit', dataResidency: 'ID', transferBasis: 'pasal_56b_dpa' };
+const back = JSON.parse(JSON.stringify(entry));
+if (back.transferBasis !== 'pasal_56b_dpa') fail('transferBasis round-trip = ' + back.transferBasis);
+console.log('PASS: transferBasis "' + back.transferBasis + '" JSON-preserved (SDK decoder path covered by tests/audit.test.ts)');
+
+console.log('ALL PASS: v8.4.0 context + pasal_56b_dpa verified through SDK runtime');
+EOF
+
+echo "Run tag: $RUN_TAG  Agent: $AGENT_URL"
+(
+  cd "$WORK"
+  npm install --silent --no-audit --no-fund 2>&1 | tail -2
+  AXONFLOW_AGENT_URL="$AGENT_URL" AXONFLOW_TENANT_ID="$CLIENT_ID" AXONFLOW_TENANT_SECRET="$SECRET" \
+    AXONFLOW_TELEMETRY=off node main.mjs 2>&1
+)
+RC=$?
+[ $RC -eq 0 ] && green "runtime-e2e PASS" || { red "runtime-e2e FAIL (rc=$RC)"; exit $RC; }

--- a/src/client.ts
+++ b/src/client.ts
@@ -40,6 +40,7 @@ import {
   ListDecisionsOptions,
   AuditQueryOptions,
   AuditLogEntry,
+  TransferBasis,
   AuditSearchResponse,
   ExecuteQueryOptions,
   ExecuteQueryResponse,
@@ -278,6 +279,9 @@ function parseDecisionSummary(raw: Record<string, unknown>): DecisionSummary {
     decision: (raw.decision as string) ?? '',
     policyId: raw.policy_id as string | undefined,
     toolSignature: raw.tool_signature as string | undefined,
+    // v8.4.0 (platform #2509): the PEP-forwarded request context. Keys arrive
+    // already canonicalized to lower_snake_case; pass the map through verbatim.
+    context: raw.context as Record<string, string> | undefined,
   };
 }
 
@@ -2839,6 +2843,10 @@ export class AxonFlow {
       historicalHitCountSession: (r.historical_hit_count_session as number) ?? 0,
       policySourceLink: r.policy_source_link as string | undefined,
       toolSignature: r.tool_signature as string | undefined,
+      // v8.4.0 (platform #2509): full PEP-forwarded context + truncation flag.
+      // Keys arrive already canonicalized to lower_snake_case.
+      context: r.context as Record<string, string> | undefined,
+      contextTruncated: r.context_truncated as boolean | undefined,
     };
   }
 
@@ -2972,7 +2980,9 @@ export class AxonFlow {
       policyViolations: (data.policy_violations as string[]) ?? [],
       metadata: (data.metadata as Record<string, unknown>) ?? {},
       ...(data.data_residency != null && { dataResidency: data.data_residency as string }),
-      ...(data.transfer_basis != null && { transferBasis: data.transfer_basis as string }),
+      // Cast is compile-time only — the value is surfaced verbatim, so an
+      // unknown future transfer-basis value still passes through (v8.4.0).
+      ...(data.transfer_basis != null && { transferBasis: data.transfer_basis as TransferBasis }),
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,8 @@ export type {
   AuditQueryOptions,
   AuditLogEntry,
   AuditSearchResponse,
+  // Cross-border transfer basis (UU PDP Pasal 56)
+  TransferBasis,
   // Audit Tool Call types
   AuditToolCallRequest,
   AuditToolCallResponse,

--- a/src/types/decisions.ts
+++ b/src/types/decisions.ts
@@ -47,6 +47,18 @@ export interface DecisionExplanation {
   historicalHitCountSession: number;
   policySourceLink?: string;
   toolSignature?: string;
+  /**
+   * The FULL sanitized request context the PEP attached to the decision
+   * (canonical lower_snake_case keys, string values), read from the audit
+   * row's `policy_details->'context'`. Unlike {@link DecisionSummary} (which
+   * truncates to 5 keys), explain returns every persisted key up to the
+   * platform's 10-key cap (e.g. `x_ai_agent`, `x_session_id`,
+   * `x_leader_identity`, `x-bukuwarung-*`). Absent for pre-v8.4.0 audit rows.
+   * (platform #2509 / epic #2508)
+   */
+  context?: Record<string, string>;
+  /** True when the agent dropped surplus context keys at write time. */
+  contextTruncated?: boolean;
 }
 
 /**
@@ -69,6 +81,15 @@ export interface DecisionSummary {
   decision: string;
   policyId?: string;
   toolSignature?: string;
+  /**
+   * The sanitized request context the PEP attached to the decision (canonical
+   * lower_snake_case keys, string values), surfaced from the audit row's
+   * `policy_details->'context'`. The list summary is truncated by the platform
+   * to the 5 most-correlated keys; the full map is available via
+   * {@link AxonFlowClient.explainDecision}. Absent for pre-v8.4.0 audit rows or
+   * decisions with no context. (platform #2509 / epic #2508)
+   */
+  context?: Record<string, string>;
 }
 
 /**

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -259,6 +259,19 @@ export interface AuditQueryOptions {
 }
 
 /**
+ * Cross-border transfer-basis values recognized under Indonesia UU PDP Pasal 56:
+ *
+ *   - `adequacy`      — Pasal 56(a): destination with adequate protection
+ *   - `safeguards`    — Pasal 56(b): binding legal instrument (generic label)
+ *   - `pasal_56b_dpa` — Pasal 56(b): binding legal instrument, explicit DPA tag
+ *   - `consent`       — Pasal 56(c): explicit data-subject consent
+ *
+ * `safeguards` and `pasal_56b_dpa` are semantic equivalents; the platform
+ * surfaces whichever was recorded at decision time, verbatim. (platform #2513)
+ */
+export type TransferBasis = 'adequacy' | 'safeguards' | 'pasal_56b_dpa' | 'consent';
+
+/**
  * A single audit log entry representing an audited request or event.
  */
 export interface AuditLogEntry {
@@ -298,8 +311,11 @@ export interface AuditLogEntry {
   metadata: Record<string, unknown>;
   /** ISO 3166-1 alpha-2 country code for data residency (cross-border transfer logging). */
   dataResidency?: string;
-  /** Legal basis for cross-border data transfer: "adequacy", "safeguards", or "consent". */
-  transferBasis?: string;
+  /**
+   * Legal basis for cross-border data transfer under Indonesia UU PDP Pasal 56.
+   * See {@link TransferBasis}. Surfaced verbatim — never auto-translated.
+   */
+  transferBasis?: TransferBasis;
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.3.0';
+export const VERSION = '8.4.0';

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -411,6 +411,31 @@ describe('Audit Log Read Methods', () => {
       expect(entry.transferBasis).toBeUndefined();
     });
 
+    it('should parse the pasal_56b_dpa transfer basis verbatim (v8.4.0)', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse([
+          {
+            ...sampleAuditEntries[0],
+            data_residency: 'ID',
+            transfer_basis: 'pasal_56b_dpa',
+          },
+        ])
+      );
+
+      const result = await client.searchAuditLogs();
+      // never auto-translated to "safeguards"
+      expect(result.entries[0].transferBasis).toBe('pasal_56b_dpa');
+    });
+
+    it('should still parse the existing safeguards value after the widening (backward compat)', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse([{ ...sampleAuditEntries[0], transfer_basis: 'safeguards' }])
+      );
+
+      const result = await client.searchAuditLogs();
+      expect(result.entries[0].transferBasis).toBe('safeguards');
+    });
+
     it('should handle missing optional fields with defaults', async () => {
       mockFetch.mockReturnValueOnce(
         mockResponse([

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -130,6 +130,50 @@ describe('Decision Explainability (ADR-043)', () => {
       expect(exp.decisionId).toBe('dec-1');
     });
 
+    it('surfaces the full request context + contextTruncated (v8.4.0)', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse({
+          decision_id: 'dec-ctx',
+          timestamp: '2026-05-30T12:00:00Z',
+          decision: 'deny',
+          reason: '',
+          policy_matches: [],
+          override_available: false,
+          historical_hit_count_session: 0,
+          context: {
+            x_ai_agent: 'refund-bot',
+            x_session_id: 'sess-42',
+            x_leader_identity: 'ops-lead',
+          },
+          context_truncated: true,
+        })
+      );
+      const exp = await client.explainDecision('dec-ctx');
+      expect(exp.context).toEqual({
+        x_ai_agent: 'refund-bot',
+        x_session_id: 'sess-42',
+        x_leader_identity: 'ops-lead',
+      });
+      expect(exp.contextTruncated).toBe(true);
+    });
+
+    it('leaves context + contextTruncated undefined for pre-v8.4.0 rows', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse({
+          decision_id: 'dec-1',
+          timestamp: '2026-04-17T12:00:00Z',
+          decision: 'allow',
+          reason: '',
+          policy_matches: [],
+          override_available: false,
+          historical_hit_count_session: 0,
+        })
+      );
+      const exp = await client.explainDecision('dec-1');
+      expect(exp.context).toBeUndefined();
+      expect(exp.contextTruncated).toBeUndefined();
+    });
+
     it('handles minimal responses without optional fields', async () => {
       mockFetch.mockReturnValueOnce(
         mockResponse({
@@ -263,6 +307,43 @@ describe('listDecisions (Session γ #1982)', () => {
     expect(got[0].policyId).toBe('pol-sqli');
     expect(got[0].toolSignature).toBe('postgres.query');
     expect(got[2].decision).toBe('require_approval');
+  });
+
+  it('surfaces the truncated request context on the summary (v8.4.0)', async () => {
+    mockFetch.mockReturnValueOnce(
+      ok({
+        decisions: [
+          {
+            decision_id: 'dec-ctx',
+            timestamp: '2026-05-30T12:00:00Z',
+            decision: 'deny',
+            context: {
+              x_ai_agent: 'refund-bot',
+              x_session_id: 'sess-42',
+              x_leader_identity: 'ops-lead',
+            },
+          },
+        ],
+      })
+    );
+    const got = await client.listDecisions();
+    expect(got[0].context).toEqual({
+      x_ai_agent: 'refund-bot',
+      x_session_id: 'sess-42',
+      x_leader_identity: 'ops-lead',
+    });
+  });
+
+  it('leaves context undefined for decisions without one', async () => {
+    mockFetch.mockReturnValueOnce(
+      ok({
+        decisions: [
+          { decision_id: 'dec-noctx', timestamp: '2026-05-30T12:00:00Z', decision: 'allow' },
+        ],
+      })
+    );
+    const got = await client.listDecisions();
+    expect(got[0].context).toBeUndefined();
   });
 
   it('serializes every filter into the URL', async () => {

--- a/tests/fixtures/wire-shape-baseline.json
+++ b/tests/fixtures/wire-shape-baseline.json
@@ -217,6 +217,7 @@
     "Finding",
     "KillSwitch",
     "KillSwitchEvent",
+    "LLMProviderListResponse",
     "ListWorkflowsResponse",
     "MCPCheckInputResponse",
     "MCPCheckOutputResponse",
@@ -225,6 +226,7 @@
     "MediaGovernanceConfig",
     "MediaGovernanceStatus",
     "ModelPricing",
+    "PaginationMeta",
     "PendingApproval",
     "PendingApprovalsResponse",
     "PlanResponse",
@@ -330,6 +332,13 @@
       "sdk_only": [
         "created_at",
         "source"
+      ],
+      "spec_only": []
+    },
+    "DecisionExplanation": {
+      "sdk_only": [
+        "context",
+        "context_truncated"
       ],
       "spec_only": []
     },


### PR DESCRIPTION
## Summary

Multi-SDK v8.4.0 release (epic getaxonflow/axonflow-enterprise#2508) — TypeScript SDK.

1. **Request `context` on decision reads** (platform #2509). `DecisionSummary` and `DecisionExplanation` gain `context?: Record<string, string>`; `DecisionExplanation` also gains `contextTruncated?: boolean`. **Both runtime decoders were updated** — `parseDecisionSummary` reads `raw.context`, and `parseDecisionExplanation` reads `raw.context` + `raw.context_truncated` (a type-only change would have silently dropped the field, since this SDK maps snake_case wire → camelCase by hand).
2. **`pasal_56b_dpa` transfer basis** (platform #2513). New exported `TransferBasis` union (`'adequacy' | 'safeguards' | 'pasal_56b_dpa' | 'consent'`); `AuditLogEntry.transferBasis` is now typed `TransferBasis` (was `string`). The union is a **compile-time hint only** — `parseAuditLogEntry` surfaces the value verbatim, so existing `safeguards` consumers are unaffected and an unknown future value still parses at runtime.

Version `8.3.0 → 8.4.0` (package.json + package-lock + auto-stamped `src/version.ts`), CHANGELOG, unit tests, runtime-e2e driver.

## §E2E — live platform (current `main`, includes #2509 + #2513)

`runtime-e2e/decision_context_transfer_basis/test.sh` builds the local SDK and runs a Node program against a real agent:

```
server /decide response: {"verdict":"allow","decision_id":"39e92f4c-...","stage":"llm",...}
PEP decide -> decision_id=39e92f4c-4433-40b7-8c84-d09cd484ab35
SDK listDecisions -> {"decisionId":"39e92f4c-...","decision":"allow","context":{"x_ai_agent":"refund-bot","x_leader_identity":"ops-lead","x_session_id":"sess-buku-42"}}
PASS: listDecisions DecisionSummary.context populated with 3 PEP-forwarded keys
SDK explainDecision -> context={"x_ai_agent":"refund-bot","x_leader_identity":"ops-lead","x_session_id":"sess-buku-42"} contextTruncated=undefined
PASS: explainDecision returned full context (contextTruncated=undefined)
PASS: AuditLogEntry.transferBasis = "pasal_56b_dpa" round-trips verbatim
ALL PASS
```

The driver acts as the PEP via a raw `POST /api/v1/decide` (not SDK-wrapped per ADR-056), then reads the decision back through the compiled SDK build.

## Tests

`npm run build` (tsc, both CJS+ESM) clean; `eslint` + `prettier --check` clean; `jest` decisions+audit suites pass (51/51). New tests cover `context`/`contextTruncated` decoding on both decision types and `pasal_56b_dpa` + `safeguards`-backward-compat on `AuditLogEntry`.

### Pre-existing, unrelated full-suite note (not introduced here)
`test/client.test.ts`'s 5 `protect()` tests assume the default endpoint `http://localhost:8080` is **unreachable** ("fail-open since endpoint can't be reached"). They fail on **clean `main`** too whenever something is listening on :8080 (my local E2E agent was). In CI nothing listens on :8080 → fail-open → they pass. Not caused by this change (verified: identical failures on `main`).

## Notes

- `dist/` is git-ignored (built in CI / on publish).
- **DRAFT** pending the platform v8.5.0 tag (land order: platform → tag → SDKs).

Epic: getaxonflow/axonflow-enterprise#2508
