### PR TITLE
feat(pep): decide -> fulfill -> forward Decision Mode PEP (#2571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.5.0] - 2026-06-09 — Decision Mode PEP: decide → fulfill → forward
+
+Adds the SDK analog of the platform PEP client (`platform/shared/pep`,
+ADR-056, epic #2563). A Policy Enforcement Point now follows one path —
+**decide → fulfill → forward** — and the SDK makes the engine-fulfillable
+obligation contract impossible to misuse: there is **no local redaction
+path**, so a `redact_pii` obligation can only be discharged by round-tripping
+content through the engine endpoint the obligation names.
+
+### Added
+
+- **`AxonFlow.decide(request)`** — the PDP step. `POST /api/v1/decide` returns a
+  `DecideResponse` whose `obligations` is an array of self-describing
+  `Obligation`s. Decision Mode auth is HTTP Basic (org:license), which the
+  client already sends; wrong/demo credentials are refused with
+  `AuthenticationError`. A deny verdict is returned in the body (HTTP 200), not
+  thrown.
+- **`AxonFlow.fulfillRequest(decision, statement)`** — discharges every
+  request-phase `redact_pii` obligation by POSTing the statement to the engine's
+  `check-input` endpoint and returning the **engine-redacted** statement as
+  `[content, didRedact]`. Fails closed with `ObligationNotFulfillableError` when
+  an obligation names no request-phase fulfillment, advertises a content-type the
+  PEP is not holding, names an endpoint the client will not call, the engine call
+  fails, or the engine reports `redaction_evaluated=false`. Never redacts locally.
+- **`AxonFlow.decideAndFulfill(request)`** — the blessed one-call path (decide,
+  then fulfill any request-phase obligation), returning
+  `[verdict, content, decision]`; fail-closed by construction.
+- **New types**: `DecideRequest`, `DecideResponse`, `Obligation`,
+  `ObligationFulfillment`, `DecisionCallerIdentity`, `DecisionTarget` (snake_case
+  wire shape).
+- **New error class**: `ObligationNotFulfillableError` (a fail-closed signal).
+- **PEP constants** + `hasRequestRedaction(obligations)` and
+  `endpointPathMatches(...)` helpers (`OBLIGATION_REDACT_PII`,
+  `PHASE_REQUEST`/`PHASE_RESPONSE`, `CONTENT_TYPE_TEXT`,
+  `VERDICT_ALLOW`/`VERDICT_DENY`/`VERDICT_NEEDS_APPROVAL`, endpoint-path
+  constants), all exported from the package root.
+- **`redacted` / `redacted_statement` / `redaction_evaluated` on
+  `MCPCheckInputResponse`** and **`redaction_evaluated` on
+  `MCPCheckOutputResponse`** — the request-redaction contract fields the agent
+  emits (ADR-056). A PEP fulfilling an obligation fails closed when
+  `redaction_evaluated` is false.
+- **`contentType` on `MCPCheckInputOptions` / `mcpCheckInput(...)`** — selects
+  the request-redaction detector (maps to the snake_case `content_type` wire
+  field; defaults to `text/plain` server-side).
+
+### Notes
+
+- SDK semver is decoupled from the platform: this is a **minor** bump from 8.4.0
+  (purely additive, optional fields backward-compatible with older platforms).
+  The wire-shape baseline records the new fields as an acknowledged SDK superset
+  pending the OpenAPI spec catching up; the pinned `openapi_specs_sha` is
+  unchanged.
+
 ## [8.4.0] - 2026-05-30 — Decision request context + Pasal 56(b) transfer basis
 
 Targets AxonFlow platform **v8.5.0**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/runtime-e2e/decide_fulfill_obligation/README.md
+++ b/runtime-e2e/decide_fulfill_obligation/README.md
@@ -1,0 +1,33 @@
+# decide_fulfill_obligation (v8.5.0)
+
+Real-stack proof for the Decision Mode PEP surface (epic #2563 / tracking #2571,
+ADR-056): **decide → fulfill → forward**.
+
+The driver builds the local SDK and, against a real running agent, proves:
+
+1. **`client.decide(...)`** on a PII-bearing request returns `verdict=allow` with a
+   self-describing `redact_pii` obligation whose `fulfillment` names the
+   `check-input` engine endpoint (request phase, `text/plain`), plus a `trace_id`.
+2. **`client.fulfillRequest(...)`** discharges that obligation by round-tripping the
+   statement through the named engine endpoint and returns **engine-redacted**
+   content — the raw email (`john.doe@example.com`) and card (`4111111111111111`)
+   do not survive, and the masking is the engine's (the SDK contains no local
+   redaction path).
+3. **`client.decideAndFulfill(...)`** does both in one call with the same masked
+   result.
+4. **Demo / wrong credentials** are refused (`401` → `AuthenticationError`).
+
+No mocks — every call hits the real agent over real `fetch` with HTTP Basic
+(org:license) auth built from `clientId` + `clientSecret`.
+
+## Run
+
+```
+source /tmp/axonflow-e2e-env.sh        # provides AXONFLOW_CLIENT_ID / _SECRET
+export AXONFLOW_AGENT_URL=http://localhost:8080
+./test.sh
+```
+
+Exits non-zero if the verdict is not `allow`, the obligation is missing/not
+engine-fulfillable, raw PII survives fulfillment, or demo credentials are not
+refused.

--- a/runtime-e2e/decide_fulfill_obligation/test.sh
+++ b/runtime-e2e/decide_fulfill_obligation/test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Runtime proof — TypeScript SDK Decision Mode PEP: decide -> fulfill -> forward
+# (epic #2563 / tracking #2571, ADR-056).
+#
+# Per CLAUDE.md HARD RULE this test MUST hit a real running AxonFlow agent — no
+# mocks. It proves the engine-fulfillable obligation contract end to end through
+# the LOCAL SDK build (dist/ via file:../..; the npm registry is blocked):
+#
+#   1. client.decide(...) on a PII-bearing request returns verdict=allow with a
+#      self-describing redact_pii obligation whose fulfillment names the
+#      check-input engine endpoint (request phase, text/plain), plus a trace_id.
+#   2. client.fulfillRequest(...) discharges it by round-tripping the statement
+#      through that engine endpoint and returns ENGINE-redacted content — the
+#      original PII (john.doe@example.com + 4111111111111111) no longer appears,
+#      and the masking is the engine's (the SDK contains no local redaction path).
+#   3. client.decideAndFulfill(...) does both in one call with the same result.
+#   4. Demo / wrong credentials are refused (401 -> AuthenticationError); the PEP
+#      cannot decide with credentials the enterprise PDP does not accept.
+#
+# Enterprise auth is HTTP Basic (org:license) — the SDK builds it from clientId +
+# clientSecret.
+#
+# Usage (after `source /tmp/axonflow-e2e-env.sh` from the enterprise setup script):
+#   AXONFLOW_AGENT_URL=http://localhost:8080 \
+#   AXONFLOW_CLIENT_ID="$AXONFLOW_CLIENT_ID" \
+#   AXONFLOW_CLIENT_SECRET="$AXONFLOW_CLIENT_SECRET" \
+#   ./runtime-e2e/decide_fulfill_obligation/test.sh
+
+set -uo pipefail
+
+AGENT_URL=${AXONFLOW_AGENT_URL:-http://localhost:8080}
+CLIENT_ID=${AXONFLOW_CLIENT_ID:-}
+SECRET=${AXONFLOW_CLIENT_SECRET:-}
+SDK_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUN_TAG=$(date -u +%s)
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+if [ -z "$CLIENT_ID" ] || [ -z "$SECRET" ]; then
+  red "FAIL: AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set (source /tmp/axonflow-e2e-env.sh)"
+  exit 2
+fi
+
+if [ ! -f "$SDK_ROOT/dist/esm/index.js" ]; then
+  echo "Building local SDK..."
+  (cd "$SDK_ROOT" && npm run build) || { red "FAIL: SDK build failed"; exit 1; }
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/package.json" <<EOF
+{
+  "name": "pep-decide-fulfill-rt-${RUN_TAG}",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": { "@axonflow/sdk": "file:${SDK_ROOT}" }
+}
+EOF
+
+cat > "$WORK/main.mjs" <<'EOF'
+import {
+  AxonFlow,
+  AuthenticationError,
+  ObligationNotFulfillableError,
+  OBLIGATION_REDACT_PII,
+  PHASE_REQUEST,
+  VERDICT_ALLOW,
+} from '@axonflow/sdk';
+
+const AGENT_URL = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+const CLIENT_ID = process.env.AXONFLOW_CLIENT_ID;
+const SECRET = process.env.AXONFLOW_CLIENT_SECRET;
+
+// The PII the request carries. The engine's redactor must mask the email +
+// credit card; neither raw value may survive into the fulfilled content.
+const RAW_EMAIL = 'john.doe@example.com';
+const RAW_CARD = '4111111111111111';
+const QUERY = `Send the receipt to ${RAW_EMAIL} and charge card ${RAW_CARD}`;
+
+const fail = (m) => { console.error('FAIL: ' + m); process.exit(1); };
+
+const client = new AxonFlow({ endpoint: AGENT_URL, clientId: CLIENT_ID, clientSecret: SECRET, mode: 'production' });
+
+try {
+  // 1. decide() surfaces the engine-fulfillable redact_pii obligation.
+  const decision = await client.decide({
+    stage: 'tool',
+    query: QUERY,
+    target: { type: 'tool', tool: 'send_receipt' },
+    caller_identity: { gateway_id: 'sdk-runtime-e2e' },
+  });
+  console.log(`decide -> verdict=${decision.verdict} obligations=${decision.obligations.length}`);
+  if (decision.verdict !== VERDICT_ALLOW) fail(`expected allow, got ${decision.verdict} (${decision.error})`);
+  if (!decision.trace_id) fail('decide response did not surface a trace_id');
+  const redact = decision.obligations.filter((o) => o.type === OBLIGATION_REDACT_PII);
+  if (redact.length === 0) fail(`no redact_pii obligation on a PII request; got ${JSON.stringify(decision.obligations)}`);
+  const ful = redact[0].fulfillment;
+  if (!ful || ful.phase !== PHASE_REQUEST) fail(`obligation not request-phase engine-fulfillable: ${JSON.stringify(ful)}`);
+  if (!ful.endpoint.includes('check-input')) fail(`fulfillment endpoint is not the request-redaction endpoint: ${ful.endpoint}`);
+  console.log(`  obligation fulfillment -> ${ful.endpoint} phase=${ful.phase} types=${JSON.stringify(ful.content_types)}`);
+
+  // 2. fulfillRequest() returns ENGINE-redacted content; raw PII is gone.
+  const [content, didRedact] = await client.fulfillRequest(decision, QUERY);
+  console.log(`fulfillRequest -> didRedact=${didRedact} content=${JSON.stringify(content)}`);
+  if (!didRedact) fail('engine reported no redaction on a request that carries PII');
+  if (content.includes(RAW_EMAIL)) fail(`raw email survived fulfillment — PII leak: ${content}`);
+  if (content.includes(RAW_CARD)) fail(`raw card survived fulfillment — PII leak: ${content}`);
+  if (content === QUERY) fail('fulfilled content is byte-identical to the unredacted query');
+
+  // 3. decideAndFulfill() one-call path yields the same masked content.
+  const [verdict, oneCall] = await client.decideAndFulfill({
+    stage: 'tool',
+    query: QUERY,
+    target: { type: 'tool', tool: 'send_receipt' },
+  });
+  console.log(`decideAndFulfill -> verdict=${verdict} content=${JSON.stringify(oneCall)}`);
+  if (verdict !== VERDICT_ALLOW) fail(`decideAndFulfill verdict ${verdict}, expected allow`);
+  if (oneCall.includes(RAW_EMAIL) || oneCall.includes(RAW_CARD)) fail(`decideAndFulfill leaked PII: ${oneCall}`);
+} catch (e) {
+  if (e instanceof ObligationNotFulfillableError) fail(`obligation unexpectedly not fulfillable against real agent: ${e.message}`);
+  throw e;
+}
+
+// 4. Demo / wrong credentials are refused by the enterprise PDP.
+const badClient = new AxonFlow({ endpoint: AGENT_URL, clientId: 'demo-org', clientSecret: 'demo-license-not-real', mode: 'production' });
+try {
+  await badClient.decide({ stage: 'tool', query: 'hi' });
+  fail('demo credentials were NOT refused by the PDP');
+} catch (e) {
+  if (e instanceof AuthenticationError) {
+    console.log('demo creds -> AuthenticationError (refused) OK');
+  } else {
+    fail(`demo creds raised ${e.constructor.name} (${e.message}), expected AuthenticationError`);
+  }
+}
+
+console.log('PASS: decide -> fulfill -> forward verified against real agent');
+EOF
+
+echo "Run tag: $RUN_TAG  Agent: $AGENT_URL"
+(
+  cd "$WORK"
+  npm install --silent --no-audit --no-fund 2>&1 | tail -2
+  AXONFLOW_AGENT_URL="$AGENT_URL" AXONFLOW_CLIENT_ID="$CLIENT_ID" AXONFLOW_CLIENT_SECRET="$SECRET" \
+    AXONFLOW_TELEMETRY=off node main.mjs 2>&1
+)
+RC=$?
+[ $RC -eq 0 ] && green "runtime-e2e PASS" || { red "runtime-e2e FAIL (rc=$RC)"; exit $RC; }

--- a/src/client.ts
+++ b/src/client.ts
@@ -185,7 +185,21 @@ import {
   RateLimitError,
   VersionConflictError,
   IdempotencyKeyMismatchError,
+  ObligationNotFulfillableError,
 } from './errors';
+import {
+  CONTENT_TYPE_TEXT,
+  DECIDE_PATH,
+  OBLIGATION_REDACT_PII,
+  PHASE_REQUEST,
+  REQUEST_REDACTION_PATH,
+  VERDICT_ALLOW,
+  endpointPathMatches,
+  stripUndefined,
+  type DecideRequest,
+  type DecideResponse,
+  type Obligation,
+} from './pep';
 import { generateRequestId, debugLog } from './utils/helpers';
 
 /**
@@ -1508,6 +1522,9 @@ export class AxonFlow {
       body.parameters = options.parameters;
     }
     body.operation = options.operation ?? 'execute';
+    if (options.contentType !== undefined) {
+      body.content_type = options.contentType;
+    }
 
     if (this.config.debug) {
       debugLog('MCP Check Input', {
@@ -2803,6 +2820,186 @@ export class AxonFlow {
     const body = (await response.json()) as { decisions?: Array<Record<string, unknown>> };
     const rows = body?.decisions ?? [];
     return rows.map(parseDecisionSummary);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Decision Mode PEP: decide -> fulfill -> forward (ADR-056, #2563)    //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Ask the PDP for a verdict on a request (`POST /api/v1/decide`).
+   *
+   * This is the PDP step of a PEP. `/decide` is a pure decision point: it NEVER
+   * mutates content. When an allow verdict carries a `redact_pii` obligation,
+   * discharge it with {@link AxonFlow.fulfillRequest} (or use the one-call
+   * {@link AxonFlow.decideAndFulfill}) — never by redacting locally.
+   *
+   * Decision Mode auth is HTTP Basic (org:license), which this client already
+   * sends; demo / wrong credentials are refused with 401 →
+   * {@link AuthenticationError}. A deny verdict is returned in the body with
+   * HTTP 200, not as an error.
+   *
+   * @param request - The {@link DecideRequest} (`stage` ∈ {"llm","tool","agent"}
+   *   and `query` are required).
+   * @returns The {@link DecideResponse} verdict, with `obligations` always a
+   *   (possibly empty) array.
+   * @throws AuthenticationError on 401 (bad / demo credentials).
+   * @throws APIError on other non-200 responses.
+   */
+  async decide(request: DecideRequest): Promise<DecideResponse> {
+    const url = `${this.config.endpoint}${DECIDE_PATH}`;
+    const headers = this.buildAuthHeaders();
+
+    // Drop undefined-valued keys so the wire body matches the spec
+    // (user_token / context omitted when empty).
+    const body = JSON.stringify(stripUndefined(request));
+
+    const response = await this._fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: AbortSignal.timeout(this.config.timeout),
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      const errorText = await response.text();
+      throw new AuthenticationError(`Decision request failed: ${errorText}`);
+    }
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new APIError(response.status, response.statusText, errorText);
+    }
+
+    const data = (await response.json()) as Partial<DecideResponse> | null;
+    const verdict = (data?.verdict as string) ?? VERDICT_ALLOW;
+    return {
+      verdict,
+      decision_id: data?.decision_id,
+      trace_id: data?.trace_id,
+      reasons: data?.reasons,
+      // Normalize obligations to an array so PEP code can iterate without a
+      // null-check (the platform always sends [], but be defensive).
+      obligations: Array.isArray(data?.obligations) ? (data!.obligations as Obligation[]) : [],
+      evaluated_policies: data?.evaluated_policies,
+      stage: data?.stage,
+      expires_at: data?.expires_at,
+      error: data?.error,
+    };
+  }
+
+  /**
+   * Discharge every request-phase `redact_pii` obligation on `decision`.
+   *
+   * For each request-phase `redact_pii` obligation, POSTs `statement` to the
+   * engine endpoint the obligation names (`check-input`) and returns the
+   * engine-redacted statement to forward.
+   *
+   * There is NO code path in which this method redacts locally — fulfillment is
+   * always the engine round-trip (ADR-056 / #2563).
+   *
+   * @param decision - The verdict returned by {@link AxonFlow.decide}.
+   * @param statement - The request content to fulfill.
+   * @returns `[content, didRedact]`. `content` is the engine-redacted statement
+   *   (or the original when no obligation mutates the request). `didRedact`
+   *   reflects whether the ENGINE actually changed the content, not merely that
+   *   an obligation was present.
+   * @throws ObligationNotFulfillableError when a `redact_pii` obligation could
+   *   not be discharged through the engine — it named no request-phase
+   *   fulfillment, advertised a content-type the PEP is not holding, named an
+   *   endpoint this client will not call, the engine call failed, or the engine
+   *   reported the redactor did not run (`redaction_evaluated=false`). The
+   *   caller MUST fail closed (block) — never forward the original `statement`.
+   */
+  async fulfillRequest(decision: DecideResponse, statement: string): Promise<[string, boolean]> {
+    let redacted = statement;
+    let didRedact = false;
+    for (const ob of decision.obligations ?? []) {
+      if (ob.type !== OBLIGATION_REDACT_PII) {
+        // redact_pii is the only content-mutating obligation today; other
+        // types are pass-through by contract.
+        continue;
+      }
+      if (!ob.fulfillment || ob.fulfillment.phase !== PHASE_REQUEST) {
+        throw new ObligationNotFulfillableError(
+          'redact_pii obligation missing request-phase fulfillment'
+        );
+      }
+      const contentTypes = ob.fulfillment.content_types ?? [];
+      if (contentTypes.length > 0 && !contentTypes.includes(CONTENT_TYPE_TEXT)) {
+        throw new ObligationNotFulfillableError(
+          `fulfillment endpoint does not advertise a ${CONTENT_TYPE_TEXT} detector`
+        );
+      }
+      if (!endpointPathMatches(ob.fulfillment.endpoint, REQUEST_REDACTION_PATH)) {
+        throw new ObligationNotFulfillableError(
+          `fulfillment endpoint ${JSON.stringify(ob.fulfillment.endpoint)} is not ` +
+            'the request-redaction endpoint'
+        );
+      }
+      redacted = await this.fulfillViaCheckInput(redacted);
+      if (redacted !== statement) {
+        didRedact = true;
+      }
+    }
+    return [redacted, didRedact];
+  }
+
+  /**
+   * POST `statement` to the request-redaction engine endpoint and return the
+   * engine-masked statement.
+   *
+   * Fails closed (throws {@link ObligationNotFulfillableError}) when the engine
+   * call errors, the engine returns non-200, or `redaction_evaluated` is
+   * false/absent — never returns unredacted content under an unfulfillable
+   * condition.
+   */
+  private async fulfillViaCheckInput(statement: string): Promise<string> {
+    let result: MCPCheckInputResponse;
+    try {
+      result = await this.mcpCheckInput({
+        connectorType: 'gateway',
+        statement,
+        operation: 'execute',
+        contentType: CONTENT_TYPE_TEXT,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ObligationNotFulfillableError(`request-redaction engine call failed: ${msg}`);
+    }
+    // FAIL CLOSED if the redactor did not actually run (#2563 B1). Without this
+    // the PEP cannot distinguish "engine looked, found nothing" (safe to
+    // forward) from "engine wasn't looking" (would leak PII).
+    if (!result.redaction_evaluated) {
+      throw new ObligationNotFulfillableError(
+        'engine reported the redactor did not run (redaction disabled)'
+      );
+    }
+    if (result.redacted && result.redacted_statement) {
+      return result.redacted_statement;
+    }
+    // Redactor ran and found nothing to mask — forward unchanged.
+    return statement;
+  }
+
+  /**
+   * One-call PEP path: decide, then fulfill any request-phase obligation
+   * (ADR-056, #2563).
+   *
+   * @param request - The {@link DecideRequest}.
+   * @returns `[verdict, content, decision]`. Branch on `verdict`: forward
+   *   `content` on `"allow"`; block on `"deny"` / `"needs_approval"`.
+   * @throws ObligationNotFulfillableError on the not-fulfillable path AFTER
+   *   discarding the unredacted content, so a caller that catches the error
+   *   cannot accidentally forward the unredacted query — fail-closed by
+   *   construction.
+   */
+  async decideAndFulfill(request: DecideRequest): Promise<[string, string, DecideResponse]> {
+    const decision = await this.decide(request);
+    if (decision.verdict !== VERDICT_ALLOW) {
+      return [decision.verdict, request.query, decision];
+    }
+    const [redacted] = await this.fulfillRequest(decision, request.query);
+    return [decision.verdict, redacted, decision];
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -2871,7 +2871,21 @@ export class AxonFlow {
     }
 
     const data = (await response.json()) as Partial<DecideResponse> | null;
-    const verdict = (data?.verdict as string) ?? VERDICT_ALLOW;
+    // FAIL CLOSED on a malformed response: `verdict` is required. A missing /
+    // empty / non-string verdict must NEVER default to allow — that would let a
+    // truncated or empty 200 body synthesize an allow with no obligations, and
+    // decideAndFulfill would then forward the original unredacted query. The
+    // contract's whole premise is "don't trust the engine's response shape"
+    // (#2563). Parity with Python/Rust (raise on the required field) and
+    // Go/Java (empty/null verdict is not-allow → block).
+    const verdict = data?.verdict;
+    if (typeof verdict !== 'string' || verdict === '') {
+      throw new APIError(
+        response.status,
+        response.statusText,
+        'decide response is missing the required "verdict" field',
+      );
+    }
     return {
       verdict,
       decision_id: data?.decision_id,
@@ -2974,7 +2988,15 @@ export class AxonFlow {
         'engine reported the redactor did not run (redaction disabled)'
       );
     }
-    if (result.redacted && result.redacted_statement) {
+    if (result.redacted) {
+      // FAIL CLOSED on a self-contradictory engine response: redacted=true with
+      // no redacted_statement means the engine claims it masked something but
+      // gave us nothing to forward — never fall back to the unredacted original.
+      if (!result.redacted_statement) {
+        throw new ObligationNotFulfillableError(
+          'engine reported redacted=true but returned no redacted_statement'
+        );
+      }
       return result.redacted_statement;
     }
     // Redactor ran and found nothing to mask — forward unchanged.

--- a/src/client.ts
+++ b/src/client.ts
@@ -2883,7 +2883,7 @@ export class AxonFlow {
       throw new APIError(
         response.status,
         response.statusText,
-        'decide response is missing the required "verdict" field',
+        'decide response is missing the required "verdict" field'
       );
     }
     return {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -145,6 +145,41 @@ export class AuthenticationError extends AxonFlowError {
 }
 
 /**
+ * Error thrown when a Decision Mode obligation cannot be discharged through
+ * the engine (the PEP fail-closed signal — ADR-056, epic #2563).
+ *
+ * Raised by the PEP fulfillment path ({@link AxonFlow.fulfillRequest} /
+ * {@link AxonFlow.decideAndFulfill}) when a `redact_pii` obligation named no
+ * request-phase fulfillment endpoint, named an endpoint the client will not
+ * call, advertised a content-type the PEP is not holding, the engine endpoint
+ * failed, or the engine reported the redactor did not run
+ * (`redaction_evaluated=false`).
+ *
+ * This is a FAIL-CLOSED signal: the caller MUST block the request, never
+ * forward the unredacted content. The PEP contains no local redaction path,
+ * so it cannot silently substitute its own masking.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const [content] = await axonflow.fulfillRequest(decision, statement);
+ *   forward(content);
+ * } catch (e) {
+ *   if (e instanceof ObligationNotFulfillableError) {
+ *     block(); // fail closed — never forward the original statement
+ *   }
+ * }
+ * ```
+ */
+export class ObligationNotFulfillableError extends AxonFlowError {
+  constructor(message: string = 'Obligation not engine-fulfillable') {
+    super(message);
+    this.name = 'ObligationNotFulfillableError';
+    Object.setPrototypeOf(this, ObligationNotFulfillableError.prototype);
+  }
+}
+
+/**
  * Error thrown when rate limit is exceeded.
  * Includes limit, remaining count, and reset time.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,35 @@ export {
   TimeoutError,
   IdempotencyKeyMismatchError,
   APIError,
+  ObligationNotFulfillableError,
 } from './errors';
 export type { UpgradeInfo } from './errors';
+
+// Export Decision Mode PEP contract: decide -> fulfill -> forward
+// (ADR-056, epic #2563). Types, constants, and the pure helpers a PEP uses
+// to branch on a verdict before fulfilling.
+export {
+  OBLIGATION_REDACT_PII,
+  PHASE_REQUEST,
+  PHASE_RESPONSE,
+  CONTENT_TYPE_TEXT,
+  VERDICT_ALLOW,
+  VERDICT_DENY,
+  VERDICT_NEEDS_APPROVAL,
+  REQUEST_REDACTION_PATH,
+  RESPONSE_REDACTION_PATH,
+  DECIDE_PATH,
+  hasRequestRedaction,
+  endpointPathMatches,
+} from './pep';
+export type {
+  DecideRequest,
+  DecideResponse,
+  Obligation,
+  ObligationFulfillment,
+  DecisionCallerIdentity,
+  DecisionTarget,
+} from './pep';
 
 // Export types for TypeScript users
 export type {

--- a/src/pep.ts
+++ b/src/pep.ts
@@ -1,0 +1,239 @@
+/**
+ * Decision Mode PEP (Policy Enforcement Point) contract: types, constants,
+ * and pure helpers.
+ *
+ * A PEP follows one path: **decide → fulfill → forward** (ADR-056, epic #2563).
+ *
+ *   - decide:  ask the PDP (`POST /api/v1/decide`) for a verdict on a request.
+ *   - fulfill: for every obligation the verdict carries, call the ENGINE
+ *     endpoint named in the obligation's `fulfillment` block to obtain
+ *     engine-redacted content.
+ *   - forward: forward the (possibly redacted) content, or block, per verdict.
+ *
+ * The structural guarantee #2563 demands: a PEP built on this SDK contains NO
+ * redaction logic of its own. The ONLY way it discharges a `redact_pii`
+ * obligation is by POSTing the source content to the engine endpoint the
+ * obligation names ({@link AxonFlow.fulfillRequest} /
+ * {@link AxonFlow.decideAndFulfill}) and forwarding what the engine returns. If
+ * an obligation arrives without a fulfillable engine endpoint — or the engine
+ * reports the redactor did not run — the helper throws
+ * {@link ObligationNotFulfillableError} and the caller MUST fail closed
+ * (block), never forward unredacted.
+ *
+ * This mirrors `platform/shared/pep` (the Go reference PEP) and the Python SDK
+ * so the SDK PEP cannot reimplement redaction the way a hand-rolled regex would.
+ */
+
+// --- Obligation contract constants (mirror platform/agent decision handler) ---
+
+/**
+ * The obligation a PEP discharges by replacing request content with
+ * engine-redacted content before forwarding.
+ */
+export const OBLIGATION_REDACT_PII = 'redact_pii';
+
+/**
+ * Fulfillment phases. `/decide` runs pre-call so it only emits request-phase
+ * obligations; the response-phase value is part of the contract for PEP helpers
+ * that fan out to the response-redaction endpoint after the backend call.
+ */
+export const PHASE_REQUEST = 'request';
+export const PHASE_RESPONSE = 'response';
+
+/**
+ * The only redaction content-type wired today. The contract is content-type
+ * agnostic — a PEP holding content of a type not advertised by an obligation's
+ * `content_types` must fail closed rather than forward it unredacted.
+ */
+export const CONTENT_TYPE_TEXT = 'text/plain';
+
+// --- Verdict values returned by the PDP ---
+export const VERDICT_ALLOW = 'allow';
+export const VERDICT_DENY = 'deny';
+export const VERDICT_NEEDS_APPROVAL = 'needs_approval';
+
+// --- Engine endpoints a PEP will POST content to for fulfillment ---
+// An obligation whose fulfillment endpoint is not one of these is rejected — a
+// PEP must not be steered into calling an arbitrary URL by a malformed verdict.
+export const REQUEST_REDACTION_PATH = '/api/v1/mcp/check-input';
+export const RESPONSE_REDACTION_PATH = '/api/v1/mcp/check-output';
+
+export const DECIDE_PATH = '/api/v1/decide';
+
+/**
+ * Names the engine call a PEP makes to discharge an obligation.
+ *
+ * Fulfillment is a property of the contract, not of PEP-author discipline: a
+ * conforming PEP POSTs the obligation's source content to `endpoint` and
+ * forwards the engine-redacted content the endpoint returns.
+ *
+ * `content_types` advertises the mime-types the endpoint's detectors can handle
+ * today. The contract is content-type-agnostic: a PEP holding content of a type
+ * NOT in this list must fail closed rather than forward it unredacted. Mirrors
+ * platform ObligationFulfillment (snake_case wire shape).
+ */
+export interface ObligationFulfillment {
+  /** Engine path, e.g. "/api/v1/mcp/check-input". */
+  endpoint: string;
+  /** HTTP method, e.g. "POST". */
+  method?: string;
+  /** "request" | "response". */
+  phase: string;
+  /** Mime-types the endpoint can redact today. */
+  content_types?: string[];
+}
+
+/**
+ * A self-describing, engine-fulfillable PEP requirement on an allow verdict.
+ *
+ * Obligations are SELF-DESCRIBING and ENGINE-FULFILLABLE (ADR-056, #2563):
+ * `/decide` is a pure PDP and never mutates content, so a `redact_pii`
+ * obligation is not "go redact this yourself with your own patterns" — it is
+ * "call the AxonFlow engine endpoint named in `fulfillment` to obtain
+ * engine-redacted content." There is no other blessed way to satisfy it;
+ * client-side redaction is forbidden. Mirrors platform DecisionObligation
+ * (snake_case wire shape).
+ */
+export interface Obligation {
+  /** Obligation type, e.g. "redact_pii". */
+  type: string;
+  /** Human-readable detail for audit logs. */
+  detail?: string;
+  /** How a PEP discharges this obligation via the engine. */
+  fulfillment?: ObligationFulfillment;
+}
+
+/**
+ * Gateway-asserted identity for a /decide request.
+ *
+ * org_id / tenant_id are optional in the body — the auth-derived identity is
+ * authoritative; body-supplied values are accepted only when they match.
+ * Mirrors platform DecisionCallerIdentity (snake_case wire shape).
+ */
+export interface DecisionCallerIdentity {
+  gateway_id?: string;
+  org_id?: string;
+  tenant_id?: string;
+}
+
+/**
+ * Describes what the gateway is about to call. Mirrors platform DecisionTarget
+ * (snake_case wire shape).
+ */
+export interface DecisionTarget {
+  /** "llm" | "tool" | "agent". */
+  type?: string;
+  /** When type=llm. */
+  model?: string;
+  /** When type=llm. */
+  provider?: string;
+  /** When type=tool. */
+  tool?: string;
+}
+
+/**
+ * Inbound contract for `POST /api/v1/decide`. Mirrors platform DecideRequest
+ * (snake_case wire shape).
+ *
+ * Required: `stage` (one of "llm" | "tool" | "agent") and `query`.
+ * `user_token` is optional — a PEP that supplies one gets the validated-user
+ * record on the audit row; one that doesn't gets a synthesized service user.
+ */
+export interface DecideRequest {
+  stage: string;
+  query: string;
+  caller_identity?: DecisionCallerIdentity;
+  target?: DecisionTarget;
+  user_token?: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * PDP verdict returned by `POST /api/v1/decide`. Mirrors platform DecideResponse
+ * (snake_case wire shape).
+ *
+ * `obligations` is normalized to an array by the client so PEP code can iterate
+ * without a null-check. `trace_id` is W3C-format (32 lowercase hex chars).
+ * `error` is set on the deny path when the request was malformed.
+ */
+export interface DecideResponse {
+  verdict: string;
+  decision_id?: string;
+  trace_id?: string;
+  reasons?: string[];
+  obligations: Obligation[];
+  evaluated_policies?: string[];
+  stage?: string;
+  expires_at?: string;
+  error?: string;
+}
+
+/**
+ * Reports whether any obligation requires request-phase PII redaction.
+ *
+ * Exposed so a PEP can branch ("does this verdict carry work for me?") before
+ * calling {@link AxonFlow.fulfillRequest}.
+ */
+export function hasRequestRedaction(obligations: Obligation[]): boolean {
+  return obligations.some(
+    o =>
+      o.type === OBLIGATION_REDACT_PII &&
+      o.fulfillment != null &&
+      o.fulfillment.phase === PHASE_REQUEST
+  );
+}
+
+/**
+ * Returns a shallow copy of `obj` with every key whose value is `undefined`
+ * removed, so a serialized `DecideRequest` omits empty optional fields
+ * (`user_token`, `context`) on the wire per the spec. Nested objects
+ * (`caller_identity`, `target`) are likewise stripped of undefined keys; a
+ * nested object that becomes empty is dropped entirely.
+ */
+export function stripUndefined(obj: object): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) {
+      continue;
+    }
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      const nested = stripUndefined(v as Record<string, unknown>);
+      if (Object.keys(nested).length > 0) {
+        out[k] = nested;
+      }
+      continue;
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Reports whether `endpoint` is the expected engine path.
+ *
+ * Tolerates an absolute URL whose path component matches (some PDPs return a
+ * fully-qualified obligation endpoint); a blank endpoint never matches. Refusing
+ * any other endpoint stops a malformed verdict from steering the PEP into
+ * calling an arbitrary URL.
+ */
+export function endpointPathMatches(endpoint: string, expected: string): boolean {
+  const e = (endpoint || '').trim();
+  if (e === expected) {
+    return true;
+  }
+  const marker = '://';
+  const idx = e.indexOf(marker);
+  if (idx >= 0) {
+    const rest = e.slice(idx + marker.length);
+    const slash = rest.indexOf('/');
+    if (slash >= 0) {
+      let path = rest.slice(slash);
+      const q = path.indexOf('?');
+      if (q >= 0) {
+        path = path.slice(0, q);
+      }
+      return path === expected;
+    }
+  }
+  return false;
+}

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -154,6 +154,15 @@ export interface MCPCheckInputOptions {
   statement: string;
   parameters?: Record<string, any>;
   operation?: string;
+  /**
+   * Selects the request-redaction detector (ADR-056 / #2563 addendum).
+   * Maps to the snake_case `content_type` field on the wire. `undefined`
+   * defaults to "text/plain" server-side. A content_type with no registered
+   * detector is rejected (415) so a PEP fulfilling a `redact_pii` obligation
+   * fails closed rather than forwarding content the engine cannot govern.
+   * Source of truth: platform/agent MCPCheckInputRequest.
+   */
+  contentType?: string;
 }
 
 /**
@@ -214,6 +223,24 @@ export interface MCPCheckInputResponse {
   policy_matches?: MCPExplainPolicy[];
   override_available?: boolean;
   override_existing_id?: string;
+  /**
+   * Request-phase redaction (ADR-056 / #2563). When an allowed statement
+   * carries PII under a redact (not block) policy, the engine returns the
+   * masked statement here so a PEP can forward redacted content WITHOUT
+   * hand-rolling its own patterns — this is what makes a /decide `redact_pii`
+   * obligation engine-fulfillable. Source of truth: platform/agent
+   * MCPCheckInputResponse.
+   */
+  redacted?: boolean;
+  redacted_statement?: string;
+  /**
+   * Reports whether the redaction detector actually RAN (regardless of whether
+   * it masked anything). A PEP fulfilling a `redact_pii` obligation MUST fail
+   * closed when this is `false`/absent — it means the redactor did not run
+   * (detection disabled), so `redacted:false` would otherwise be
+   * indistinguishable from "looked, found nothing" (#2563 B1).
+   */
+  redaction_evaluated?: boolean;
 }
 
 /**
@@ -258,6 +285,16 @@ export interface MCPCheckOutputResponse {
    */
   decision_id?: string;
   policy_matches?: MCPExplainPolicy[];
+  /**
+   * Mirrors the check-input field for the response phase (ADR-056 / #2563).
+   * A PEP fulfilling a response-phase `redact_pii` obligation MUST fail closed
+   * when this is `false`/absent — the redactor did not run, so absence of
+   * redacted output cannot be trusted as "nothing to mask". The agent does not
+   * populate this on every path today; default-absent keeps a PEP fail-closed
+   * when the platform predates the field. Source of truth: platform/agent
+   * MCPCheckOutputResponse.
+   */
+  redaction_evaluated?: boolean;
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.4.0';
+export const VERSION = '8.5.0';

--- a/tests/fixtures/wire-shape-baseline.json
+++ b/tests/fixtures/wire-shape-baseline.json
@@ -396,6 +396,20 @@
       ],
       "spec_only": []
     },
+    "MCPCheckInputResponse": {
+      "sdk_only": [
+        "redacted",
+        "redacted_statement",
+        "redaction_evaluated"
+      ],
+      "spec_only": []
+    },
+    "MCPCheckOutputResponse": {
+      "sdk_only": [
+        "redaction_evaluated"
+      ],
+      "spec_only": []
+    },
     "MarkStepCompletedRequest": {
       "sdk_only": [
         "metadata"

--- a/tests/pep.test.ts
+++ b/tests/pep.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Unit tests for the Decision Mode PEP contract (ADR-056, epic #2563).
+ *
+ * Covers decide → fulfill → forward: the decide() parsing, the fulfillRequest()
+ * fail-closed semantics, decideAndFulfill(), and the pure helpers. The
+ * load-bearing property under test is that the PEP NEVER redacts locally and
+ * fails CLOSED on every unfulfillable condition — it can only discharge a
+ * redact_pii obligation by round-tripping content through the engine.
+ */
+
+import { AxonFlow } from '../src/client';
+import { AuthenticationError, ObligationNotFulfillableError, APIError } from '../src/errors';
+import {
+  CONTENT_TYPE_TEXT,
+  OBLIGATION_REDACT_PII,
+  PHASE_REQUEST,
+  PHASE_RESPONSE,
+  VERDICT_ALLOW,
+  endpointPathMatches,
+  hasRequestRedaction,
+  stripUndefined,
+  type DecideResponse,
+  type Obligation,
+} from '../src/pep';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const ENDPOINT = 'http://localhost:8080';
+const DECIDE_URL = `${ENDPOINT}/api/v1/decide`;
+const CHECK_INPUT_URL = `${ENDPOINT}/api/v1/mcp/check-input`;
+
+// The exact obligation the real agent emits on /decide for a request carrying
+// PII under a redact policy (verified live against an enterprise agent).
+const REDACT_OBLIGATION: Obligation = {
+  type: 'redact_pii',
+  fulfillment: {
+    endpoint: '/api/v1/mcp/check-input',
+    method: 'POST',
+    phase: 'request',
+    content_types: ['text/plain'],
+  },
+};
+
+function decideAllow(obligations: Obligation[]): Record<string, unknown> {
+  return {
+    verdict: 'allow',
+    decision_id: 'dec-1',
+    trace_id: '04110a0b50577bbbdda23a00dcbaf6da',
+    obligations,
+    evaluated_policies: ['sys_pii_email'],
+    stage: 'tool',
+    expires_at: '2026-06-09T05:05:06.801139966Z',
+  };
+}
+
+const mockResponse = (data: unknown, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+
+function newClient(): AxonFlow {
+  return new AxonFlow({
+    endpoint: ENDPOINT,
+    clientId: 'test-client',
+    clientSecret: 'test-secret',
+    tenant: 'test-tenant',
+  });
+}
+
+// Find the body of the Nth fetch call (0-indexed) as a parsed object.
+function fetchBody(callIndex: number): Record<string, unknown> {
+  const init = mockFetch.mock.calls[callIndex][1] as { body: string };
+  return JSON.parse(init.body);
+}
+
+function fetchUrl(callIndex: number): string {
+  return mockFetch.mock.calls[callIndex][0] as string;
+}
+
+describe('PEP pure helpers', () => {
+  describe('hasRequestRedaction', () => {
+    it('is true for a request-phase redact_pii obligation', () => {
+      expect(hasRequestRedaction([REDACT_OBLIGATION])).toBe(true);
+    });
+
+    it('is false for a response-phase obligation', () => {
+      const ob: Obligation = {
+        type: OBLIGATION_REDACT_PII,
+        fulfillment: { endpoint: '/api/v1/mcp/check-output', phase: PHASE_RESPONSE },
+      };
+      expect(hasRequestRedaction([ob])).toBe(false);
+    });
+
+    it('is false for an empty list', () => {
+      expect(hasRequestRedaction([])).toBe(false);
+    });
+
+    it('is false for a redact_pii obligation with no fulfillment', () => {
+      expect(hasRequestRedaction([{ type: OBLIGATION_REDACT_PII }])).toBe(false);
+    });
+  });
+
+  describe('endpointPathMatches', () => {
+    it.each([
+      ['/api/v1/mcp/check-input', '/api/v1/mcp/check-input', true],
+      ['https://pdp:8443/api/v1/mcp/check-input', '/api/v1/mcp/check-input', true],
+      ['https://pdp/api/v1/mcp/check-input?x=1', '/api/v1/mcp/check-input', true],
+      ['', '/api/v1/mcp/check-input', false],
+      ['/api/v1/other', '/api/v1/mcp/check-input', false],
+      ['https://evil.example.com/steal', '/api/v1/mcp/check-input', false],
+    ])('endpointPathMatches(%s, %s) === %s', (endpoint, expected, want) => {
+      expect(endpointPathMatches(endpoint as string, expected as string)).toBe(want);
+    });
+  });
+
+  describe('stripUndefined', () => {
+    it('drops undefined keys and empty nested objects', () => {
+      const out = stripUndefined({
+        stage: 'tool',
+        query: 'hi',
+        user_token: undefined,
+        context: undefined,
+        caller_identity: { gateway_id: undefined },
+        target: { type: 'tool' },
+      });
+      expect(out).toEqual({ stage: 'tool', query: 'hi', target: { type: 'tool' } });
+      expect('user_token' in out).toBe(false);
+      expect('context' in out).toBe(false);
+      expect('caller_identity' in out).toBe(false);
+    });
+
+    it('preserves falsy non-undefined values', () => {
+      const out = stripUndefined({ a: '', b: 0, c: false, d: undefined });
+      expect(out).toEqual({ a: '', b: 0, c: false });
+    });
+  });
+});
+
+describe('AxonFlow.decide', () => {
+  let client: AxonFlow;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = newClient();
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('parses obligations from the verdict', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse(decideAllow([REDACT_OBLIGATION])));
+    const resp = await client.decide({
+      stage: 'tool',
+      query: 'Email a@b.com',
+      target: { type: 'tool' },
+    });
+    expect(resp.verdict).toBe(VERDICT_ALLOW);
+    expect(resp.trace_id).toBe('04110a0b50577bbbdda23a00dcbaf6da');
+    expect(resp.obligations).toHaveLength(1);
+    const ob = resp.obligations[0];
+    expect(ob.type).toBe(OBLIGATION_REDACT_PII);
+    expect(ob.fulfillment?.endpoint).toBe('/api/v1/mcp/check-input');
+    expect(ob.fulfillment?.phase).toBe(PHASE_REQUEST);
+    expect(ob.fulfillment?.content_types).toEqual([CONTENT_TYPE_TEXT]);
+    expect(fetchUrl(0)).toBe(DECIDE_URL);
+  });
+
+  it('normalizes a missing obligations field to an empty array', async () => {
+    const body = decideAllow([]);
+    delete body.obligations;
+    mockFetch.mockReturnValueOnce(mockResponse(body));
+    const resp = await client.decide({ stage: 'tool', query: 'hi' });
+    expect(resp.obligations).toEqual([]);
+  });
+
+  it('throws AuthenticationError on 401', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ error: 'unauthorized' }, 401));
+    await expect(client.decide({ stage: 'tool', query: 'hi' })).rejects.toThrow(
+      AuthenticationError
+    );
+  });
+
+  it('throws APIError on a 500', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ error: 'boom' }, 500));
+    await expect(client.decide({ stage: 'tool', query: 'hi' })).rejects.toThrow(APIError);
+  });
+
+  it('omits undefined optional fields on the wire', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse(decideAllow([])));
+    await client.decide({ stage: 'tool', query: 'hi' });
+    const body = fetchBody(0);
+    expect(body.stage).toBe('tool');
+    expect('user_token' in body).toBe(false);
+    expect('context' in body).toBe(false);
+  });
+
+  it('returns a deny verdict in the body (not an error)', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockResponse({ verdict: 'deny', decision_id: 'd2', obligations: [], reasons: ['blocked'] })
+    );
+    const resp = await client.decide({ stage: 'tool', query: 'leak sk-123' });
+    expect(resp.verdict).toBe('deny');
+    expect(resp.reasons).toEqual(['blocked']);
+  });
+});
+
+describe('AxonFlow.fulfillRequest — the fail-closed core', () => {
+  let client: AxonFlow;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = newClient();
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('round-trips the statement through the engine and forwards redacted content', async () => {
+    const decision = await materialize(decideAllow([REDACT_OBLIGATION]));
+    mockFetch.mockReturnValueOnce(
+      mockResponse({
+        allowed: true,
+        policies_evaluated: 1,
+        redacted: true,
+        redacted_statement: 'Email jo****om',
+        redaction_evaluated: true,
+      })
+    );
+    const [content, didRedact] = await client.fulfillRequest(decision, 'Email john@x.com');
+    expect(content).toBe('Email jo****om');
+    expect(didRedact).toBe(true);
+    // The PEP submitted the source content to the engine with text/plain.
+    expect(fetchUrl(0)).toBe(CHECK_INPUT_URL);
+    const body = fetchBody(0);
+    expect(body.statement).toBe('Email john@x.com');
+    expect(body.content_type).toBe(CONTENT_TYPE_TEXT);
+    expect(body.connector_type).toBe('gateway');
+  });
+
+  it('passes through unchanged when there are no obligations', async () => {
+    const decision = await materialize(decideAllow([]));
+    const [content, didRedact] = await client.fulfillRequest(decision, 'nothing to mask');
+    expect(content).toBe('nothing to mask');
+    expect(didRedact).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('forwards the original when the engine evaluated and found nothing to mask', async () => {
+    const decision = await materialize(decideAllow([REDACT_OBLIGATION]));
+    mockFetch.mockReturnValueOnce(
+      mockResponse({ allowed: true, redacted: false, redaction_evaluated: true })
+    );
+    const [content, didRedact] = await client.fulfillRequest(decision, 'clean text');
+    expect(content).toBe('clean text');
+    expect(didRedact).toBe(false);
+  });
+
+  it('FAILS CLOSED when redaction_evaluated is false (redactor disabled, #2563 B1)', async () => {
+    const decision = await materialize(decideAllow([REDACT_OBLIGATION]));
+    mockFetch.mockReturnValueOnce(
+      mockResponse({ allowed: true, redacted: false, redaction_evaluated: false })
+    );
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      /redactor did not run/
+    );
+  });
+
+  it('FAILS CLOSED when redaction_evaluated is absent (older platform)', async () => {
+    const decision = await materialize(decideAllow([REDACT_OBLIGATION]));
+    mockFetch.mockReturnValueOnce(
+      mockResponse({ allowed: true, redacted: true, redacted_statement: 'x' })
+    );
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      ObligationNotFulfillableError
+    );
+  });
+
+  it('FAILS CLOSED when a redact_pii obligation has no fulfillment block', async () => {
+    const decision = await materialize(decideAllow([{ type: 'redact_pii' }]));
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      /missing request-phase/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED on a response-phase fulfillment', async () => {
+    const decision = await materialize(
+      decideAllow([
+        {
+          type: 'redact_pii',
+          fulfillment: {
+            endpoint: '/api/v1/mcp/check-output',
+            phase: 'response',
+            content_types: ['text/plain'],
+          },
+        },
+      ])
+    );
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      ObligationNotFulfillableError
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED when text/plain is not in the advertised content_types', async () => {
+    const decision = await materialize(
+      decideAllow([
+        {
+          type: 'redact_pii',
+          fulfillment: {
+            endpoint: '/api/v1/mcp/check-input',
+            phase: 'request',
+            content_types: ['image/png'],
+          },
+        },
+      ])
+    );
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      /text\/plain/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED on a foreign fulfillment endpoint (no arbitrary-URL SSRF)', async () => {
+    const decision = await materialize(
+      decideAllow([
+        {
+          type: 'redact_pii',
+          fulfillment: {
+            endpoint: 'https://evil.example.com/exfil',
+            phase: 'request',
+            content_types: ['text/plain'],
+          },
+        },
+      ])
+    );
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      /not the request-redaction/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED when the engine call returns non-200', async () => {
+    const decision = await materialize(decideAllow([REDACT_OBLIGATION]));
+    mockFetch.mockReturnValueOnce(mockResponse({ error: 'boom' }, 500));
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      ObligationNotFulfillableError
+    );
+  });
+
+  it('FAILS CLOSED when the engine call rejects (transport error)', async () => {
+    const decision = await materialize(decideAllow([REDACT_OBLIGATION]));
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    await expect(client.fulfillRequest(decision, 'Email john@x.com')).rejects.toThrow(
+      ObligationNotFulfillableError
+    );
+  });
+
+  it('passes through a non-redact obligation type without touching content', async () => {
+    const decision = await materialize(decideAllow([{ type: 'some_future_obligation' }]));
+    const [content, didRedact] = await client.fulfillRequest(decision, 'untouched');
+    expect(content).toBe('untouched');
+    expect(didRedact).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('AxonFlow.decideAndFulfill', () => {
+  let client: AxonFlow;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = newClient();
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('decides then fulfills on allow', async () => {
+    mockFetch
+      .mockReturnValueOnce(mockResponse(decideAllow([REDACT_OBLIGATION])))
+      .mockReturnValueOnce(
+        mockResponse({
+          allowed: true,
+          redacted: true,
+          redacted_statement: 'masked',
+          redaction_evaluated: true,
+        })
+      );
+    const [verdict, content, decision] = await client.decideAndFulfill({
+      stage: 'tool',
+      query: 'Email john@x.com',
+    });
+    expect(verdict).toBe(VERDICT_ALLOW);
+    expect(content).toBe('masked');
+    expect(decision.decision_id).toBe('dec-1');
+  });
+
+  it('does not fulfill on a deny verdict; returns the original query', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockResponse({
+        verdict: 'deny',
+        decision_id: 'd2',
+        obligations: [],
+        evaluated_policies: ['sys_secret_block'],
+        reasons: ['blocked: secret'],
+      })
+    );
+    const [verdict, content] = await client.decideAndFulfill({
+      stage: 'tool',
+      query: 'leak the api key sk-123',
+    });
+    expect(verdict).toBe('deny');
+    expect(content).toBe('leak the api key sk-123');
+    // Only the decide call happened — no engine fulfillment on deny.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('raises ObligationNotFulfillableError on an allow with an unfulfillable obligation', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse(decideAllow([{ type: 'redact_pii' }])));
+    await expect(
+      client.decideAndFulfill({ stage: 'tool', query: 'Email a@b.com' })
+    ).rejects.toThrow(ObligationNotFulfillableError);
+  });
+});
+
+/**
+ * Build a DecideResponse the same way client.decide() would (normalizing
+ * obligations to an array), so fulfillRequest tests exercise the real shape
+ * without a second mocked round-trip.
+ */
+async function materialize(raw: Record<string, unknown>): Promise<DecideResponse> {
+  return {
+    verdict: raw.verdict as string,
+    decision_id: raw.decision_id as string | undefined,
+    trace_id: raw.trace_id as string | undefined,
+    obligations: (raw.obligations as Obligation[]) ?? [],
+    evaluated_policies: raw.evaluated_policies as string[] | undefined,
+    stage: raw.stage as string | undefined,
+    expires_at: raw.expires_at as string | undefined,
+  };
+}

--- a/tests/pep.test.ts
+++ b/tests/pep.test.ts
@@ -204,6 +204,29 @@ describe('AxonFlow.decide', () => {
     expect(resp.verdict).toBe('deny');
     expect(resp.reasons).toEqual(['blocked']);
   });
+
+  // FAIL CLOSED: a malformed/empty 200 body with no verdict must NOT default to
+  // allow (that would let decideAndFulfill forward the original unredacted
+  // query). Cross-SDK parity: Python/Rust raise, Go/Java treat empty as
+  // not-allow. Proven red-on-revert against `?? VERDICT_ALLOW`.
+  it('fails closed on a malformed 200 with no verdict', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ obligations: [] }));
+    await expect(client.decide({ stage: 'tool', query: 'hi' })).rejects.toThrow(APIError);
+  });
+
+  it('fails closed on an empty-string verdict', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ verdict: '', obligations: [] }));
+    await expect(client.decide({ stage: 'tool', query: 'hi' })).rejects.toThrow(APIError);
+  });
+
+  it('decideAndFulfill never forwards on a verdict-less 200', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ obligations: [] }));
+    await expect(
+      client.decideAndFulfill({ stage: 'tool', query: 'Email john@x.com' })
+    ).rejects.toThrow(APIError);
+    // Only the /decide call happened; no engine fulfillment, no forward.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('AxonFlow.fulfillRequest — the fail-closed core', () => {


### PR DESCRIPTION
Ports the Decision Mode PEP (decide → fulfill → forward) contract into the TypeScript SDK — the analog of `platform/shared/pep` (the Go reference PEP) and the canonical Python SDK PR. Epic getaxonflow/axonflow-enterprise#2563, tracking #2571.

## What this adds

- **`AxonFlow.decide(request)`** — `POST /api/v1/decide`, the PDP step. Returns a `DecideResponse` whose `obligations` is always an array. HTTP Basic (org:license) auth, which the client already sends; 401 → `AuthenticationError`. A deny verdict is returned in the body (HTTP 200), not thrown.
- **`AxonFlow.fulfillRequest(decision, statement) → [content, didRedact]`** — discharges every request-phase `redact_pii` obligation by POSTing the statement to the engine's `check-input` endpoint (`contentType: "text/plain"`, `connectorType: "gateway"`) and returning the **engine-redacted** content. **Fails closed** with `ObligationNotFulfillableError` (never the original statement) on: no request-phase fulfillment; `text/plain` not in advertised `content_types`; a foreign fulfillment endpoint; engine call error / non-200; or `redaction_evaluated` false/absent. **No local redaction anywhere.**
- **`AxonFlow.decideAndFulfill(request) → [verdict, content, decision]`** — the one-call path; fail-closed by construction (discards content before throwing).
- **New types**: `DecideRequest`, `DecideResponse`, `Obligation`, `ObligationFulfillment`, `DecisionCallerIdentity`, `DecisionTarget` (snake_case wire shape). **New error**: `ObligationNotFulfillableError`. **Constants + helpers**: `hasRequestRedaction`, `endpointPathMatches`, verdict/phase/path/content-type constants — all exported from the package root.
- **Check-input/output contract fields**: `redacted` / `redacted_statement` / `redaction_evaluated` on `MCPCheckInputResponse`; `redaction_evaluated` on `MCPCheckOutputResponse`; `contentType` (→ wire `content_type`) on `MCPCheckInputOptions` / `mcpCheckInput(...)`.

## Cross-SDK parity

JSON wire field names and constant values are byte-identical to the spec and the Go/Python PEPs (`redact_pii`, `request`/`response`, `text/plain`, `allow`/`deny`/`needs_approval`, `/api/v1/decide`, `/api/v1/mcp/check-input`). Method names are idiomatic camelCase.

## Verification

- **Unit**: 33 new tests in `tests/pep.test.ts` (decide parse + 401/500 + wire-omit; every fail-closed branch incl. `redaction_evaluated` false/absent, response-phase, unadvertised content-type, foreign endpoint, engine non-200, transport error; passthrough; decide+deny+unfulfillable). `src/pep.ts` 100% covered.
- **Full suite**: 32 suites, 961 passed / 13 skipped, 0 failures (was 928). Global coverage 86.6% stmts / 72.2% branch — thresholds met.
- **runtime-e2e** (`runtime-e2e/decide_fulfill_obligation/`, no mocks, real agent): decide → allow + redact_pii obligation; `fulfillRequest` → `Send the receipt to jo****************om and charge card 4**************1` (neither `john.doe@example.com` nor `4111111111111111` survives); `decideAndFulfill` → same; demo creds → `AuthenticationError`.
- **Wire-shape gate**: baseline regenerated via `refresh.js`; only the two intended drift entries added; pinned `openapi_specs_sha` **unchanged** (no SHA-bump label needed). Lint, transformer-coverage, version-alignment all green.

Minor bump 8.4.0 → 8.5.0 (additive; SDK semver decoupled from platform). npm publish is blocked for local testing — built locally only.

Part of #2563 / #2571.