### PR TITLE
fix(security): bump fast-xml-builder + least-privilege workflow permissions

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -19,6 +19,12 @@ concurrency:
 env:
   AXONFLOW_TELEMETRY: 'off'
 
+# Least-privilege token: this workflow only checks out the repo and runs
+# tests. No write access to repo contents, packages, or pull requests is
+# required.
+permissions:
+  contents: read
+
 jobs:
   real-stack:
     name: real-stack ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4237,9 +4237,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -4249,7 +4249,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -6770,6 +6771,22 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## Summary
Clears all three open security alerts on this repo (epic getaxonflow/axonflow-enterprise#2711).

| Alert | Sev | What | Fix |
|-------|-----|------|-----|
| Dependabot #32 | high | `fast-xml-builder` attribute-value quote bypass (patched 1.1.7) | lockfile `1.1.5` -> `1.2.0` |
| Dependabot #31 | medium | `fast-xml-builder` comment-value regex bypass (patched 1.1.6) | lockfile `1.1.5` -> `1.2.0` |
| CodeQL #8 | medium | `actions/missing-workflow-permissions` on `heartbeat-real-stack.yml` | top-level `permissions: contents: read` |

## fast-xml-builder is a DEV-only transitive dependency -> no republish
Chain: `@aws-sdk/client-bedrock-runtime` (devDependency) -> `@aws-sdk/core` -> `@aws-sdk/xml-builder` -> `fast-xml-parser@5.7.2` -> `fast-xml-builder`. Every node is marked `"dev": true` in `package-lock.json`, so it does **not** ship to consumers of `@axonflow/sdk`. The lockfile bump requires **no npm republish** and `package.json` is intentionally untouched. `1.2.0` satisfies `fast-xml-parser`'s `^1.1.5` constraint.

## Workflow permissions
`heartbeat-real-stack.yml` only checks out the repo and runs tests (no release, artifact-publish, or PR-comment steps), so `contents: read` is sufficient. The block is kept **byte-identical** to the axonflow-sdk-java heartbeat fix for canonical coherence.

## Tests
- `npm run build` green
- `npm test` green (32 suites, 964 passed)

Refs getaxonflow/axonflow-enterprise#2711

## Transitive dependency disclosure
Bumping `fast-xml-builder` 1.1.5 -> 1.2.0 changes its declared deps from
`{ path-expression-matcher: ^1.1.3 }` to `{ path-expression-matcher: ^1.5.0, xml-naming: ^0.1.0 }`
(verified via `npm view fast-xml-builder@1.2.0 dependencies`). Effect on `package-lock.json`:

- **`xml-naming@0.1.0`** is added (new transitive, absent on `origin/main`). It is a 0.x package; flagged for visibility. Dev-only (`"dev": true`).
- **`path-expression-matcher`** constraint moves `^1.1.3` -> `^1.5.0`, but the resolved version was **already `1.5.0` on `origin/main`** (pulled by other dev tooling), so the installed tree does not change for it. Dev-only (`"dev": true`).

Both are intended upstream transitives of `fast-xml-builder@1.2.0` and are dev-only (the whole chain hangs off the `@aws-sdk/client-bedrock-runtime` devDependency), so there is no consumer or runtime exposure and no npm republish is needed.