### PR TITLE
fix(examples): connectors reports in-band failure; proxy-mode real SQL [skip-runtime-e2e]

### DIFF
--- a/examples/connectors/index.ts
+++ b/examples/connectors/index.ts
@@ -82,9 +82,17 @@ async function main() {
         userToken
       );
 
-      console.log('✓ Flight data retrieved:', result.data);
+      if (result.success) {
+        console.log('✓ Flight data retrieved:', result.data);
+      } else {
+        // queryConnector reports failures in-band, not as throws — a ✓
+        // over success:false hides auth/access errors.
+        console.log('⚠ Query failed:', result.error ?? 'unknown error');
+        process.exitCode = 1;
+      }
     } catch (error) {
       console.log('⚠ Query failed:', (error as Error).message);
+      process.exitCode = 1;
     }
   }
 

--- a/examples/connectors/index.ts
+++ b/examples/connectors/index.ts
@@ -41,6 +41,7 @@ async function main() {
     });
   } catch (error) {
     console.log('⚠ Could not list connectors:', (error as Error).message);
+    process.exitCode = 1;
   }
 
   // Install connector
@@ -63,6 +64,7 @@ async function main() {
       console.log('✓ Connector installed successfully!');
     } catch (error) {
       console.log('⚠ Install failed:', (error as Error).message);
+      process.exitCode = 1;
     }
   } else {
     console.log('⚠ Skipping (AMADEUS_API_KEY and AMADEUS_API_SECRET not set)');
@@ -96,7 +98,11 @@ async function main() {
     }
   }
 
-  console.log('\n✅ Connector examples completed');
+  if (process.exitCode === 1) {
+    console.log('\n⚠ Connector examples completed with failures');
+  } else {
+    console.log('\n✅ Connector examples completed');
+  }
 }
 
 main().catch(error => {

--- a/examples/proxy-mode/index.ts
+++ b/examples/proxy-mode/index.ts
@@ -143,7 +143,9 @@ async function main() {
   try {
     const mcpResult = await axonflow.proxyLLMCall({
       userToken,
-      query: 'Get recent orders',
+      // The postgres connector executes the statement as SQL — a
+      // natural-language string fails with a syntax error.
+      query: 'SELECT tenant_id, name FROM tenants LIMIT 5',
       requestType: 'mcp-query',
       context: {
         connector: 'postgres',

--- a/examples/proxy-mode/index.ts
+++ b/examples/proxy-mode/index.ts
@@ -47,6 +47,12 @@ async function main() {
     if (chatResult.policyInfo) {
       console.log(`   Policies Evaluated: ${chatResult.policyInfo.policiesEvaluated.length}`);
     }
+    if (!chatResult.success) {
+      // proxyLLMCall reports failures in-band (200 + success:false), not
+      // only as throws - printing "Success: false" and exiting 0 hides them.
+      console.log(`   Failure detail: ${chatResult.error ?? 'unknown error'}`);
+      process.exitCode = 1;
+    }
   } catch (error) {
     console.log(`   Error: ${error instanceof Error ? error.message : error}`);
     if (!(error instanceof PolicyViolationError)) {
@@ -72,6 +78,10 @@ async function main() {
     console.log(`   Success: ${contextResult.success}`);
     if (contextResult.metadata) {
       console.log(`   Metadata: ${JSON.stringify(contextResult.metadata)}`);
+    }
+    if (!contextResult.success) {
+      console.log(`   Failure detail: ${contextResult.error ?? 'unknown error'}`);
+      process.exitCode = 1;
     }
   } catch (error) {
     console.log(`   Error: ${error instanceof Error ? error.message : error}`);
@@ -130,6 +140,10 @@ async function main() {
     });
     console.log(`   Success: ${sqlResult.success}`);
     console.log(`   Blocked: ${sqlResult.blocked}`);
+    if (!sqlResult.success) {
+      console.log(`   Failure detail: ${sqlResult.error ?? 'unknown error'}`);
+      process.exitCode = 1;
+    }
   } catch (error) {
     console.log(`   Error: ${error instanceof Error ? error.message : error}`);
     if (!(error instanceof PolicyViolationError)) {
@@ -154,6 +168,12 @@ async function main() {
     });
     console.log(`   Success: ${mcpResult.success}`);
     console.log(`   Has Data: ${!!mcpResult.data}`);
+    if (!mcpResult.success) {
+      // Same in-band failure channel as queryConnector: a failed connector
+      // query comes back 200 + success:false, not as a throw.
+      console.log(`   Failure detail: ${mcpResult.error ?? 'unknown error'}`);
+      process.exitCode = 1;
+    }
   } catch (error) {
     console.log(`   Error: ${error instanceof Error ? error.message : error}`);
     if (!(error instanceof PolicyViolationError)) {
@@ -162,8 +182,17 @@ async function main() {
   }
 
   console.log('\n' + '='.repeat(60));
-  console.log('Example completed!');
+  if (process.exitCode === 1) {
+    console.log('Example completed with failures');
+  } else {
+    console.log('Example completed!');
+  }
   console.log('='.repeat(60));
 }
 
-main().catch(console.error);
+// catch(console.error) alone would swallow the failure and exit 0 - an
+// unreachable stack would then read as a green run.
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Two example fixes from the #2861 release-readiness smoke (live enterprise stack, local SDK 8.5.1 build):

- **connectors/index.ts** — `queryConnector` reports failures in-band (`success:false`) rather than throwing; the example printed `✓ Flight data retrieved:` over an `Unauthorized connector access` failure and exited 0 (the swallowed-error class the sweep targets). Now checks `result.success`, prints the error, and sets a non-zero exit code.
- **proxy-mode/index.ts step 7** — the postgres connector executes the query string as SQL; the natural-language `'Get recent orders'` could never succeed (`pq: syntax error at or near "Get"`). Replaced with a real SELECT.

## Testing
- `npx tsc -p tsconfig.examples.json` clean.
- `examples/proxy-mode` re-run against the live enterprise stack (axonflow-enterprise main, local SDK build): step 7 now `Success: true, Has Data: true`, exit 0 — previously `Success: false` on every run.
- connectors failure branch semantics match the live-observed `success:false` payload shape from the smoke run.

## Skip-runtime-e2e justification
Example-script-only changes (honest failure reporting + a literal query string); no library surface changed. The governed paths these demos exercise are covered by the repo's existing runtime-e2e suite; the behavior change was verified live against an enterprise stack (evidence above).

Refs getaxonflow/axonflow-enterprise#2861.