### PR TITLE
fix(langgraph): stop concatenating server+tool into connectorType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tool` on any released platform version yet (tracked by #2955, targeted for
   v9.11.0); the SDK sends it forward-compatibly and current platforms ignore
   it.
+
 ### Added
 
 - **`AuditToolCallRequest.callerName`** — identifies which client made a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+> **This release contains a breaking change and MUST be published as a major
+> version bump.** The `connectorType` wire value emitted by the LangGraph
+> adapter changes from `` `${server}.${tool}` `` to the bare server name;
+> policies matching the old concatenated value stop matching until re-scoped
+> (see the migration note below).
 
-- **LangGraph `mcpToolInterceptor()` no longer concatenates the MCP server
-  name and tool name into a single `connectorType` string.** `mcpCheckInput`
-  and `mcpCheckOutput` now accept an optional `tool` field, sent alongside
-  `connectorType` on the wire, matching the platform's two-field
-  (server, tool) identity contract (epic #2905 / #2904). The interceptor
-  sends `connectorType: request.serverName` and `tool: request.name` as two
-  distinct values instead of `` `${serverName}.${name}` ``.
+### Changed (BREAKING)
+
+- **The LangGraph adapter now reports the (server, tool) identity as two
+  separate wire fields instead of concatenating them into `connectorType`.**
+  `mcpCheckInput` and `mcpCheckOutput` gain an optional `tool` field, sent
+  alongside `connectorType` on the wire, matching the platform's two-field
+  (server, tool) identity contract (epic #2905 / #2904). `mcpToolInterceptor()`
+  now sends `connectorType: request.serverName` and `tool: request.name` as
+  two distinct values instead of `` `${serverName}.${name}` ``; the default
+  `connectorTypeFn` returns the bare `serverName`. `tool` is always sent
+  separately and is never folded into `connectorType`, even with a custom
+  `connectorTypeFn`.
+
+  **Migration.** Policies or per-connector settings matching the old
+  concatenated value — e.g. `connectorType == "filesystem.read_file"` — stop
+  matching after upgrade. Re-scope them to match `connectorType ==
+  "filesystem"` together with the `tool` field (e.g. `tool == "read_file"`).
+  The `connectorTypeFn` option is the compatibility lever: a caller can
+  restore any prior `connectorType` value (including the old concatenated
+  form, `` (req) => `${req.serverName}.${req.name}` ``) without losing the
+  separate `tool` field.
+
+  **Statement text also changed** for policies that match on the
+  human-readable `statement`: it is now `` `${connectorType}.${tool}(args)` ``
+  (built from the *resolved* connector type). With a custom `connectorTypeFn`
+  the statement shape shifts from the old `` `${custom}(args)` `` to
+  `` `${custom}.${tool}(args)` ``.
+
+  **Missing-server edge.** With the default resolver, a tool whose
+  `serverName` is empty now sends `connectorType: ''`, which the platform
+  rejects with HTTP 400 → the tool call is blocked (fail-closed), never run
+  ungoverned. Previously the concatenated value was `".tool"` (a non-empty
+  string the platform accepted). Supply a `connectorTypeFn` for server-less
+  MCP tools.
+
+  **Minimum platform.** The `tool` field is consumed on `POST
+  /api/v1/mcp/check-input` by platform **v9.10.0+** (enterprise `c8df2006b`,
+  epic #2905 / #2904). On platforms below v9.10.0 the `tool` field is silently
+  dropped and identity degrades to the bare server name — coarser than the old
+  concatenated value — so **upgrade the platform to v9.10.0+ before adopting
+  this SDK major.** The response plane (`check-output`) does **not** consume
+  `tool` on any released platform version yet (tracked by #2955, targeted for
+  v9.11.0); the SDK sends it forward-compatibly and current platforms ignore
+  it.
 
 ## [8.5.1] - 2026-07-09 — getPlanStatus auth + queryConnector user token + example fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **This release contains a breaking change and MUST be published as a major
-> version bump.** The `connectorType` wire value emitted by the LangGraph
-> adapter changes from `` `${server}.${tool}` `` to the bare server name;
-> policies matching the old concatenated value stop matching until re-scoped
-> (see the migration note below).
+## [9.0.0] - 2026-07-18
 
 ### Changed (BREAKING)
 
@@ -19,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separate wire fields instead of concatenating them into `connectorType`.**
   `mcpCheckInput` and `mcpCheckOutput` gain an optional `tool` field, sent
   alongside `connectorType` on the wire, matching the platform's two-field
-  (server, tool) identity contract (epic #2905 / #2904). `mcpToolInterceptor()`
+  (server, tool) identity contract. `mcpToolInterceptor()`
   now sends `connectorType: request.serverName` and `tool: request.name` as
   two distinct values instead of `` `${serverName}.${name}` ``; the default
   `connectorTypeFn` returns the bare `serverName`. `tool` is always sent
@@ -49,21 +45,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MCP tools.
 
   **Minimum platform.** The `tool` field is consumed on `POST
-  /api/v1/mcp/check-input` by platform **v9.10.0+** (enterprise `c8df2006b`,
-  epic #2905 / #2904). On platforms below v9.10.0 the `tool` field is silently
-  dropped and identity degrades to the bare server name — coarser than the old
-  concatenated value — so **upgrade the platform to v9.10.0+ before adopting
-  this SDK major.** The response plane (`check-output`) does **not** consume
-  `tool` on any released platform version yet (tracked by #2955, targeted for
-  v9.11.0); the SDK sends it forward-compatibly and current platforms ignore
-  it.
+  /api/v1/mcp/check-input` by **AxonFlow platform v9.10.0+**. On platforms
+  below v9.10.0 the `tool` field is silently dropped and identity degrades to
+  the bare server name — coarser than the old concatenated value — so
+  **upgrade the platform to v9.10.0+ before adopting this SDK major.**
+  Response-plane (`check-output`) `tool` scoping requires **AxonFlow platform
+  v9.11.0+**; until then the SDK sends it forward-compatibly and older
+  platforms ignore it.
 
 ### Added
 
 - **`AuditToolCallRequest.callerName`** — identifies which client made a
   tool call (e.g. `claude_code`, `codex`, `cursor`, `openclaw`), sent to the
-  orchestrator as `caller_name` (getaxonflow/axonflow-enterprise#2912,
-  sub-issue of epic #2905). Replaces the misleadingly-named `toolType`
+  orchestrator as `caller_name`. Replaces the misleadingly-named `toolType`
   field, which every real caller used to identify the calling client rather
   than any property of the tool itself. `toolType` is kept as a deprecated
   input fallback — not removed, not renamed — so existing callers keep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **LangGraph `mcpToolInterceptor()` no longer concatenates the MCP server
+  name and tool name into a single `connectorType` string.** `mcpCheckInput`
+  and `mcpCheckOutput` now accept an optional `tool` field, sent alongside
+  `connectorType` on the wire, matching the platform's two-field
+  (server, tool) identity contract (epic #2905 / #2904). The interceptor
+  sends `connectorType: request.serverName` and `tool: request.name` as two
+  distinct values instead of `` `${serverName}.${name}` ``.
+
 ## [8.5.1] - 2026-07-09 — getPlanStatus auth + queryConnector user token + example fixes
 
 Hostile-testing sweep ahead of the BukuWarung integration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.5.1",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "8.5.1",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "8.5.1",
+  "version": "9.0.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/runtime-e2e/2907_langgraph_server_tool_split/README.md
+++ b/runtime-e2e/2907_langgraph_server_tool_split/README.md
@@ -1,0 +1,44 @@
+# 2907_langgraph_server_tool_split
+
+Real-stack proof for #2907: `mcpToolInterceptor()` (LangGraph adapter) no
+longer concatenates the MCP server name and tool name into a single
+`connectorType` string. Server and tool identity now travel as two distinct
+wire fields, matching the platform's two-field `(server, tool)` identity
+contract added by epic #2905 / #2904 (`MCPCheckInputRequest`/
+`MCPCheckOutputRequest` gained an optional `tool` field alongside
+`connector_type`).
+
+The driver, against a real running agent:
+
+1. Calls `client.mcpCheckInput({ connectorType, tool, statement })` — the new
+   two-field shape — and asserts it is accepted, and that `connector_type`
+   and `tool` genuinely arrive on the wire as two separate fields (not
+   `"weather-mcp.get_forecast"` concatenated into one).
+2. Calls `client.mcpCheckInput({ connectorType, statement })` — the old
+   single-field shape, no `tool` — and asserts it still works, proving
+   backward compatibility for callers who haven't adopted the `tool` field.
+3. Drives `AxonFlowLangGraphAdapter.mcpToolInterceptor()` — the actual call
+   site that had the bug — with a fake MCP request (`serverName`, `name`,
+   `args`) and asserts it sends `connector_type: serverName` and
+   `tool: name` as separate fields.
+
+No mocks — every assertion is driven by a real `fetch` from the compiled SDK
+(`dist/esm/index.js`) against a real running AxonFlow agent. The only stand-in
+is `fakeRequest` in step 3, which shapes an MCP tool-call object the way
+`MultiServerMCPClient` would hand one to the interceptor — the interceptor,
+the SDK client, and the HTTP call to the agent are all real.
+
+## Run
+
+```
+npm run build   # if dist/ is stale
+AXONFLOW_AGENT_URL=http://localhost:8080 node runtime-e2e/2907_langgraph_server_tool_split/test.mjs
+```
+
+Uses tenant id `ts-sdk-2907-runtime-e2e` (override with `AXONFLOW_TENANT_ID`)
+to avoid colliding with other tests against the same shared agent. No
+`AXONFLOW_CLIENT_SECRET` is required — the target agent runs in community
+mode.
+
+Exits non-zero if either check-input call errors, or if `connector_type`
+and `tool` don't arrive on the wire as distinct fields.

--- a/runtime-e2e/2907_langgraph_server_tool_split/test.mjs
+++ b/runtime-e2e/2907_langgraph_server_tool_split/test.mjs
@@ -1,0 +1,152 @@
+// runtime-e2e/2907_langgraph_server_tool_split/test.mjs
+//
+// Real-stack assertion: the MCP server and tool identity travel as two
+// DISTINCT wire fields — connector_type and tool — instead of being
+// concatenated into a single connectorType string (the pre-fix behavior of
+// `${request.serverName}.${request.name}`). Matches the platform's
+// two-field (server, tool) identity contract (epic #2905 / #2904).
+//
+// Proves, against a real running agent:
+//   1. client.mcpCheckInput({ connectorType, tool, statement }) — the new
+//      two-field shape — is accepted and processed.
+//   2. client.mcpCheckInput({ connectorType, statement }) — the old
+//      single-field shape, no `tool` — still works (backward compat).
+//   3. AxonFlowLangGraphAdapter.mcpToolInterceptor(), the actual call site
+//      that motivated this fix, sends connector_type=serverName and
+//      tool=name as two distinct fields (not concatenated) when wired
+//      through a fake MCP request.
+//
+// Per CLAUDE.md HARD RULE #0 — this test MUST hit a real agent, no mocks.
+//
+// Run (npm run build first):
+//
+//   AXONFLOW_AGENT_URL=http://localhost:8080 node runtime-e2e/2907_langgraph_server_tool_split/test.mjs
+
+import { AxonFlow, AxonFlowLangGraphAdapter } from '../../dist/esm/index.js';
+
+const endpoint = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+// Unique tenant id so this test can't collide with other tests hitting the
+// same shared community agent concurrently.
+const tenantId = process.env.AXONFLOW_TENANT_ID || 'ts-sdk-2907-runtime-e2e';
+
+const client = new AxonFlow({ endpoint, clientId: tenantId });
+
+let total = 0;
+let failures = 0;
+const check = (name, ok, detail = '') => {
+  total += 1;
+  console.log(`${ok ? 'PASS' : 'FAIL'} [${name}] ${detail}`);
+  if (!ok) failures += 1;
+};
+
+// Capture what actually leaves the process on the wire so we can assert
+// connector_type and tool arrive as two separate fields, not one
+// concatenated string. This wraps the real global fetch and always calls
+// through to it — it is an observation point, not a fake response.
+let capturedBody = null;
+const origFetch = globalThis.fetch;
+globalThis.fetch = async (url, init = {}) => {
+  const urlStr = typeof url === 'string' ? url : url?.url ?? '';
+  if (urlStr.includes('/mcp/check-input') && init?.body) {
+    try {
+      capturedBody = JSON.parse(init.body);
+    } catch {
+      capturedBody = null;
+    }
+  }
+  return origFetch(url, init);
+};
+
+// 1. Direct client.mcpCheckInput with the new two-field (server, tool) shape.
+try {
+  capturedBody = null;
+  const result = await client.mcpCheckInput({
+    connectorType: 'weather-mcp',
+    tool: 'get_forecast',
+    statement: 'weather-mcp.get_forecast({"city":"nyc"})',
+  });
+  check(
+    'two-field-check-input-accepted',
+    typeof result.allowed === 'boolean',
+    `allowed=${result.allowed} policies_evaluated=${result.policies_evaluated}`
+  );
+  check(
+    'wire-sends-tool-separate-from-connector-type',
+    capturedBody?.connector_type === 'weather-mcp' && capturedBody?.tool === 'get_forecast',
+    `wire body=${JSON.stringify(capturedBody)}`
+  );
+} catch (e) {
+  check('two-field-check-input-accepted', false, e.message);
+  check('wire-sends-tool-separate-from-connector-type', false, 'skipped: request errored');
+}
+
+// 2. Backward compatibility: old single-field shape (no `tool`) still works.
+try {
+  capturedBody = null;
+  const result = await client.mcpCheckInput({
+    connectorType: 'postgres',
+    statement: 'SELECT 1',
+  });
+  check(
+    'single-field-backward-compat-accepted',
+    typeof result.allowed === 'boolean',
+    `allowed=${result.allowed} policies_evaluated=${result.policies_evaluated}`
+  );
+  check(
+    'wire-omits-tool-when-not-provided',
+    capturedBody !== null && !Object.prototype.hasOwnProperty.call(capturedBody, 'tool'),
+    `wire body=${JSON.stringify(capturedBody)}`
+  );
+} catch (e) {
+  check('single-field-backward-compat-accepted', false, e.message);
+  check('wire-omits-tool-when-not-provided', false, 'skipped: request errored');
+}
+
+// 3. Through the actual public surface that motivated #2907:
+//    AxonFlowLangGraphAdapter.mcpToolInterceptor(). Pre-fix this built
+//    connectorType as `${serverName}.${name}`, collapsing server+tool into
+//    one field. Post-fix it sends serverName as connector_type and name as
+//    a separate tool field.
+try {
+  const adapter = new AxonFlowLangGraphAdapter(client, 'runtime-e2e-2907-workflow');
+  const interceptor = adapter.mcpToolInterceptor();
+
+  const fakeRequest = {
+    serverName: 'weather-mcp',
+    name: 'get_forecast',
+    args: { city: 'nyc' },
+  };
+  const handlerResult = { forecast: 'sunny' };
+
+  capturedBody = null;
+  try {
+    const result = await interceptor(fakeRequest, async () => handlerResult);
+    check('interceptor-passthrough-result', result === handlerResult, `result=${JSON.stringify(result)}`);
+  } catch (e) {
+    // A policy block would still be a valid outcome for this assertion —
+    // the precheck fires (and we captured its wire body) before any block
+    // is raised. Only fail this specific check if it wasn't a policy block.
+    check(
+      'interceptor-passthrough-result',
+      /policy|block/i.test(e.message),
+      `interceptor raised: ${e.message}`
+    );
+  }
+  check(
+    'interceptor-sends-two-field-identity-not-concatenated',
+    capturedBody?.connector_type === 'weather-mcp' &&
+      capturedBody?.tool === 'get_forecast' &&
+      capturedBody?.connector_type !== 'weather-mcp.get_forecast',
+    `wire body=${JSON.stringify(capturedBody)}`
+  );
+} catch (e) {
+  check('interceptor-sends-two-field-identity-not-concatenated', false, e.message);
+}
+
+globalThis.fetch = origFetch;
+
+if (failures > 0) {
+  console.log(`RESULT: FAIL (${failures}/${total})`);
+  process.exit(1);
+}
+console.log(`RESULT: PASS (${total}/${total})`);

--- a/src/adapters/langgraph.ts
+++ b/src/adapters/langgraph.ts
@@ -76,8 +76,15 @@ export class WorkflowApprovalRequiredError extends AxonFlowError {
  */
 export interface MCPInterceptorOptions {
   /**
-   * Optional function that maps an MCP request to a connector type string.
-   * Defaults to `${request.serverName}.${request.name}`.
+   * Optional function that maps an MCP request to a connector type string
+   * identifying the MCP server. Defaults to `request.serverName`.
+   *
+   * This identifies the server only — the tool name is reported
+   * separately via the `tool` field on `mcpCheckInput`/`mcpCheckOutput`
+   * (epic #2905 / #2904 two-field identity contract). Do not concatenate
+   * server and tool name into this string; use a custom `connectorTypeFn`
+   * only if you need to override how the server identity itself is
+   * derived.
    */
   connectorTypeFn?: (request: any) => string;
   /**
@@ -483,13 +490,14 @@ export class AxonFlowLangGraphAdapter {
     const operation = opts?.operation ?? 'execute';
 
     const defaultConnectorType = (request: any): string => {
-      return `${request.serverName}.${request.name}`;
+      return request.serverName;
     };
 
     const resolveConnectorType = opts?.connectorTypeFn ?? defaultConnectorType;
 
     return async (request: any, handler: (request: any) => Promise<any>): Promise<any> => {
       const connectorType = resolveConnectorType(request);
+      const tool = request.name;
       let argsStr = '{}';
       if (request.args) {
         try {
@@ -498,10 +506,11 @@ export class AxonFlowLangGraphAdapter {
           argsStr = String(request.args);
         }
       }
-      const statement = `${connectorType}(${argsStr})`;
+      const statement = `${connectorType}.${tool}(${argsStr})`;
 
       const preCheck = await this.client.mcpCheckInput({
         connectorType,
+        tool,
         statement,
         operation,
         parameters: request.args,
@@ -522,6 +531,7 @@ export class AxonFlowLangGraphAdapter {
 
       const outputCheck = await this.client.mcpCheckOutput({
         connectorType,
+        tool,
         message: resultStr,
       });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1521,6 +1521,9 @@ export class AxonFlow {
       connector_type: options.connectorType,
       statement: options.statement,
     };
+    if (options.tool) {
+      body.tool = options.tool;
+    }
     if (options.parameters) {
       body.parameters = options.parameters;
     }
@@ -1600,6 +1603,9 @@ export class AxonFlow {
     const body: Record<string, any> = {
       connector_type: options.connectorType,
     };
+    if (options.tool) {
+      body.tool = options.tool;
+    }
     if (options.responseData !== undefined) {
       body.response_data = options.responseData;
     }

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -151,6 +151,16 @@ export interface ConnectorResponse {
  */
 export interface MCPCheckInputOptions {
   connectorType: string;
+  /**
+   * Optional tool identity, distinct from `connectorType`. Maps to the
+   * `tool` field on the wire (epic #2905 / #2904 two-field identity
+   * contract). Use this to carry the specific tool/operation name (e.g.
+   * an MCP tool name) while `connectorType` identifies the server or
+   * connector it belongs to — do not concatenate the two into a single
+   * string. Omitted from the request body when empty/undefined.
+   * Source of truth: platform/agent MCPCheckInputRequest.
+   */
+  tool?: string;
   statement: string;
   parameters?: Record<string, any>;
   operation?: string;
@@ -250,6 +260,19 @@ export interface MCPCheckInputResponse {
  */
 export interface MCPCheckOutputOptions {
   connectorType: string;
+  /**
+   * Optional tool identity, distinct from `connectorType`. Mirrors
+   * {@link MCPCheckInputOptions.tool} for the response-phase check.
+   * Omitted from the request body when empty/undefined. **Note:** unlike
+   * `MCPCheckInputRequest`, the platform's `MCPCheckOutputRequest`
+   * (`platform/agent/mcp_handler.go`) does not yet have a matching `tool`
+   * field (epic #2905 / #2904 only added the input-phase field) — sending
+   * this is forward-compatible and harmless (the platform's JSON decoder
+   * silently ignores unrecognized keys), but it is not yet consumed
+   * server-side. Wire it up for real once/if a future sub-issue adds
+   * response-phase tool identity.
+   */
+  tool?: string;
   responseData?: Record<string, any>[];
   message?: string;
   metadata?: Record<string, any>;

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '8.5.1';
+export const VERSION = '9.0.0';

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -3100,6 +3100,92 @@ describe('AxonFlow Client Unit Tests', () => {
         const body = JSON.parse(callArgs[1].body);
         expect(body.operation).toBe('query');
       });
+
+      it('should include tool field on the wire when provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              allowed: true,
+              policies_evaluated: 1,
+            }),
+        });
+
+        await client.mcpCheckInput({
+          connectorType: 'weather-mcp',
+          tool: 'get_forecast',
+          statement: 'weather-mcp.get_forecast({})',
+        });
+
+        const callArgs = mockFetch.mock.calls[0];
+        const body = JSON.parse(callArgs[1].body);
+        expect(body.connector_type).toBe('weather-mcp');
+        expect(body.tool).toBe('get_forecast');
+      });
+
+      it('should omit tool field when not provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              allowed: true,
+              policies_evaluated: 1,
+            }),
+        });
+
+        await client.mcpCheckInput({
+          connectorType: 'postgres',
+          statement: 'SELECT 1',
+        });
+
+        const callArgs = mockFetch.mock.calls[0];
+        const body = JSON.parse(callArgs[1].body);
+        expect(body.tool).toBeUndefined();
+      });
+    });
+
+    describe('mcpCheckOutput', () => {
+      it('should include tool field on the wire when provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              allowed: true,
+              policies_evaluated: 1,
+            }),
+        });
+
+        await client.mcpCheckOutput({
+          connectorType: 'weather-mcp',
+          tool: 'get_forecast',
+          message: '{"temp": 72}',
+        });
+
+        const callArgs = mockFetch.mock.calls[0];
+        const body = JSON.parse(callArgs[1].body);
+        expect(body.connector_type).toBe('weather-mcp');
+        expect(body.tool).toBe('get_forecast');
+      });
+
+      it('should omit tool field when not provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              allowed: true,
+              policies_evaluated: 1,
+            }),
+        });
+
+        await client.mcpCheckOutput({
+          connectorType: 'postgres',
+          message: 'result',
+        });
+
+        const callArgs = mockFetch.mock.calls[0];
+        const body = JSON.parse(callArgs[1].body);
+        expect(body.tool).toBeUndefined();
+      });
     });
   });
 });

--- a/tests/langgraph-adapter.test.ts
+++ b/tests/langgraph-adapter.test.ts
@@ -737,9 +737,12 @@ describe('AxonFlowLangGraphAdapter', () => {
       expect(result).toEqual({ results: ['a', 'b'] });
       expect(handler).toHaveBeenCalledWith(makeRequest());
 
-      // Verify input check
+      // Verify input check - server and tool are sent as two separate
+      // fields (epic #2905 / #2904 two-field identity contract), not
+      // concatenated into a single connectorType string.
       expect(mockClient.mcpCheckInput).toHaveBeenCalledWith({
-        connectorType: 'my-server.search',
+        connectorType: 'my-server',
+        tool: 'search',
         statement: 'my-server.search({"query":"test"})',
         operation: 'execute',
         parameters: { query: 'test' },
@@ -747,9 +750,37 @@ describe('AxonFlowLangGraphAdapter', () => {
 
       // Verify output check
       expect(mockClient.mcpCheckOutput).toHaveBeenCalledWith({
-        connectorType: 'my-server.search',
+        connectorType: 'my-server',
+        tool: 'search',
         message: '{"results":["a","b"]}',
       });
+    });
+
+    it('should send server name and tool name as two distinct fields, never concatenated', async () => {
+      (mockClient.mcpCheckInput as jest.Mock).mockResolvedValue({
+        allowed: true,
+        policies_evaluated: 1,
+      } as MCPCheckInputResponse);
+      (mockClient.mcpCheckOutput as jest.Mock).mockResolvedValue({
+        allowed: true,
+        policies_evaluated: 1,
+      } as MCPCheckOutputResponse);
+
+      const handler = jest.fn().mockResolvedValue('ok');
+      const interceptor = adapter.mcpToolInterceptor();
+      const request = makeRequest({ serverName: 'weather-mcp', name: 'get_forecast' });
+
+      await interceptor(request, handler);
+
+      const inputCall = (mockClient.mcpCheckInput as jest.Mock).mock.calls[0][0];
+      expect(inputCall.connectorType).toBe('weather-mcp');
+      expect(inputCall.tool).toBe('get_forecast');
+      expect(inputCall.connectorType).not.toContain('get_forecast');
+
+      const outputCall = (mockClient.mcpCheckOutput as jest.Mock).mock.calls[0][0];
+      expect(outputCall.connectorType).toBe('weather-mcp');
+      expect(outputCall.tool).toBe('get_forecast');
+      expect(outputCall.connectorType).not.toContain('get_forecast');
     });
 
     it('should throw PolicyViolationError when input is blocked', async () => {
@@ -867,15 +898,16 @@ describe('AxonFlowLangGraphAdapter', () => {
 
       const handler = jest.fn().mockResolvedValue('ok');
       const interceptor = adapter.mcpToolInterceptor({
-        connectorTypeFn: (req: any) => req.serverName,
+        connectorTypeFn: (req: any) => `custom-${req.serverName}`,
       });
 
       await interceptor(makeRequest(), handler);
 
       expect(mockClient.mcpCheckInput).toHaveBeenCalledWith(
         expect.objectContaining({
-          connectorType: 'my-server',
-          statement: 'my-server({"query":"test"})',
+          connectorType: 'custom-my-server',
+          tool: 'search',
+          statement: 'custom-my-server.search({"query":"test"})',
         })
       );
     });
@@ -920,6 +952,8 @@ describe('AxonFlowLangGraphAdapter', () => {
 
       expect(mockClient.mcpCheckInput).toHaveBeenCalledWith(
         expect.objectContaining({
+          connectorType: 'my-server',
+          tool: 'search',
           statement: 'my-server.search({})',
           parameters: null,
         })
@@ -949,7 +983,8 @@ describe('AxonFlowLangGraphAdapter', () => {
       // The output check should have received String(circular) as message
       expect(mockClient.mcpCheckOutput).toHaveBeenCalledWith(
         expect.objectContaining({
-          connectorType: 'my-server.search',
+          connectorType: 'my-server',
+          tool: 'search',
           message: '[object Object]',
         })
       );

--- a/tests/langgraph-adapter.test.ts
+++ b/tests/langgraph-adapter.test.ts
@@ -783,6 +783,38 @@ describe('AxonFlowLangGraphAdapter', () => {
       expect(outputCall.connectorType).not.toContain('get_forecast');
     });
 
+    it('sends an empty connectorType (with tool) when serverName is empty (missing-server edge)', async () => {
+      // Missing-server edge (epic #2905): with the default resolver,
+      // connectorType is the server name, so an empty serverName sends
+      // connectorType="" while tool still carries the tool name.
+      //
+      // Documented behavior: a real platform rejects an empty connectorType
+      // with HTTP 400, which the client surfaces as an error — the tool call
+      // is blocked (fail-closed), never run ungoverned. Callers whose MCP
+      // tools have no server must supply a connectorTypeFn. Before the
+      // de-concatenation the old value was ".tool" (a non-empty string the
+      // platform accepted), so this is a deliberate, surfaced change for
+      // server-less tools.
+      (mockClient.mcpCheckInput as jest.Mock).mockResolvedValue({
+        allowed: true,
+        policies_evaluated: 1,
+      } as MCPCheckInputResponse);
+      (mockClient.mcpCheckOutput as jest.Mock).mockResolvedValue({
+        allowed: true,
+        policies_evaluated: 1,
+      } as MCPCheckOutputResponse);
+
+      const handler = jest.fn().mockResolvedValue('ok');
+      const interceptor = adapter.mcpToolInterceptor();
+      const request = makeRequest({ serverName: '', name: 'tool' });
+
+      await interceptor(request, handler);
+
+      const inputCall = (mockClient.mcpCheckInput as jest.Mock).mock.calls[0][0];
+      expect(inputCall.connectorType).toBe('');
+      expect(inputCall.tool).toBe('tool');
+    });
+
     it('should throw PolicyViolationError when input is blocked', async () => {
       (mockClient.mcpCheckInput as jest.Mock).mockResolvedValue({
         allowed: false,


### PR DESCRIPTION
## Summary

`AxonFlowLangGraphAdapter.mcpToolInterceptor()` collapsed the MCP server name and tool name into a single `connectorType` string (`` `${request.serverName}.${request.name}` ``) before sending it to `mcpCheckInput`/`mcpCheckOutput`. Policies keyed on `connectorType` could never distinguish "which server" from "which tool" was invoked.

The platform's `MCPCheckInputRequest` schema now carries a genuine two-field (server, tool) identity — `connector_type` plus a new optional `tool` field (epic #2905 / #2904, R3-approved, CI-green, schema finalized but not yet merged to `axonflow-enterprise`).

## Changes

- `src/types/connector.ts`: added optional `tool?: string` to `MCPCheckInputOptions` and `MCPCheckOutputOptions`.
- `src/client.ts`: `mcpCheckInput`/`mcpCheckOutput` now send `tool` on the wire body when non-empty (same pattern as the existing `contentType` → `content_type` optional-field handling).
- `src/adapters/langgraph.ts`:
  - `mcpToolInterceptor()` no longer concatenates; it now sends `connectorType: request.serverName` and `tool: request.name` as two distinct values.
  - Default `connectorTypeFn` now returns just `request.serverName` (was `` `${serverName}.${name}` ``).
  - Updated `MCPInterceptorOptions.connectorTypeFn` JSDoc to describe the two-field contract.
- `CHANGELOG.md`: added a `### Fixed` entry under the current unreleased section.

### Checked but not changed

- `src/adapters/governed-tool.ts` (`GovernedTool` / `governTools`) — verified it has **no server concept**: `connectorTypeFn?: (name: string) => string` maps a flat tool name straight to `connectorType`, with nothing analogous to `serverName` to split out. Not applicable to this fix.
- No generic "tool output wrapper" (analogous to the Python SDK's `tool_output_wrapper()`) exists in this SDK — `governed-tool.ts` and `langgraph.ts` are the only two adapters that call `mcpCheckInput`/`mcpCheckOutput`.
- `axonflow-docs`' `docs/orchestration/wcp/langgraph-wrapper.md` (~line 454) only name-drops `mcp_tool_interceptor()` in passing (Python SDK naming), with no code sample showing the old concatenation pattern — spot-checked, not stale, no follow-up needed there.

## Test plan

- [x] Added/updated unit tests in `tests/langgraph-adapter.test.ts` asserting `connectorType` and `tool` are sent as two separate, non-concatenated values (including a dedicated regression test with distinct server/tool names and a custom `connectorTypeFn` override).
- [x] Added unit tests in `test/client.test.ts` for `mcpCheckInput`/`mcpCheckOutput` proving `tool` is included on the wire when provided and omitted when absent.
- [x] `npx jest` (full suite, excluding integration/e2e which require a live stack): 32 suites / 972 passed, 13 skipped (unaffected).
- [x] `npx tsc --noEmit`: clean.
- [x] `npm run lint` / `npm run format:check`: clean.
- [x] `node scripts/transformer-coverage/check.js --baseline .lint_baselines/transformer_coverage.json`: 2 findings, both pre-existing/baselined — no new drift from this change.

Refs #2907, epic #2905.