### PR TITLE
feat(client): add callerName to audit_tool_call, deprecate toolType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the AxonFlow TypeScript SDK will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`AuditToolCallRequest.callerName`** — identifies which client made a
+  tool call (e.g. `claude_code`, `codex`, `cursor`, `openclaw`), sent to the
+  orchestrator as `caller_name` (getaxonflow/axonflow-enterprise#2912,
+  sub-issue of epic #2905). Replaces the misleadingly-named `toolType`
+  field, which every real caller used to identify the calling client rather
+  than any property of the tool itself. `toolType` is kept as a deprecated
+  input fallback — not removed, not renamed — so existing callers keep
+  working during the deprecation window; the server resolves `callerName`
+  if supplied, else falls back to legacy `toolType`, else a default.
+
 ## [8.5.1] - 2026-07-09 — getPlanStatus auth + queryConnector user token + example fixes
 
 Hostile-testing sweep ahead of the BukuWarung integration

--- a/runtime-e2e/caller_name_audit/README.md
+++ b/runtime-e2e/caller_name_audit/README.md
@@ -1,0 +1,78 @@
+# `callerName` audit attribution — runtime-e2e
+
+Real-stack assertion for
+[getaxonflow/axonflow-enterprise#2912](https://github.com/getaxonflow/axonflow-enterprise/issues/2912)
+(sub-issue of epic #2905). Sister proof to the equivalent Go SDK
+runtime-e2e test (`axonflow-sdk-go/runtime-e2e/caller_name_audit/`).
+
+## What this proves
+
+`audit_tool_call`'s `tool_type` field was misleadingly named — every real
+caller (claude_code/codex/cursor/openclaw) used it to identify **which
+client** made the call, not any property of the tool. getaxonflow/axonflow-enterprise
+PR #2953 added a correctly-named `caller_name` field alongside the legacy
+`tool_type` (kept as a deprecated input fallback, not removed/renamed). The
+server resolves: `caller_name` if supplied -> legacy `tool_type` if
+supplied -> a default.
+
+This test drives `AxonFlow.auditToolCall({ callerName: ... })` through the
+real `fetch` transport against a real running agent + orchestrator, then
+reads the resulting `audit_logs` row back over `GET /api/v1/audit/{id}`
+and asserts `policy_details.caller_name` equals what was sent. This is the
+only way to observe `policy_details` from outside the platform — the
+SDK's typed `AuditLogEntry` does not decode that JSONB column.
+
+No mocked fetch, no jest doubles — real bytes over `node:http` to the
+live stack, enforced by `scripts/lint-no-mocks-in-runtime-e2e.sh`.
+
+## Identity header note
+
+This stack's audit-read endpoints are role-scoped (#2922): a caller with
+no per-user identity gets zero rows back, fail-closed. This test's writes
+and its verification read both carry a distinctive `X-User-Email` header,
+trusted for **attribution only** (never authz/verdicts) when the
+deployment sets `AXONFLOW_TRUST_IDENTITY_HEADERS=true` — this repo's
+documented local-dev default (see `axonflow-enterprise/.env` and
+docker-compose's `identity_header_attribution` feature, v9.9.0). The
+header is added by wrapping the real `fetch` the SDK's `_fetch()` calls,
+scoped to just the SDK call in this test — no response is faked or
+intercepted.
+
+If your stack has `AXONFLOW_TRUST_IDENTITY_HEADERS` unset (off), or runs
+in Community mode (where `isCommunityMode()` alone already grants
+tenant-wide reads), the identity header is harmless and the row is
+readable regardless.
+
+## Prerequisite: platform support is not yet on `main`
+
+`caller_name` support (axonflow-enterprise#2953) is implemented but, as of
+this writing, still an open PR on the `feat/2912-caller-name-tool-type-deprecation`
+branch — not yet merged to `axonflow-enterprise` main. Until it merges, a
+stack built from `axonflow-enterprise` main will accept `caller_name` in
+the request body (extra fields are ignored) but silently NOT write it to
+`policy_details` — this test will FAIL against such a stack, not because
+the SDK change is wrong, but because the platform side isn't deployed
+yet. Point your local `axonflow-enterprise` checkout at that branch (or a
+later commit that includes it) before running this test.
+
+## Usage
+
+```bash
+npm run build
+
+export AXONFLOW_AGENT_URL=http://localhost:8080
+export AXONFLOW_CLIENT_ID=local-dev-org
+export AXONFLOW_CLIENT_SECRET=<its secret>
+node runtime-e2e/caller_name_audit/test.mjs
+```
+
+Exits `0` on PASS, `1` on FAIL, `2` if required env vars are missing.
+
+## Companion unit coverage
+
+`tests/audit-tool-call.test.ts` exercises the wire-body serialization
+through mocked `fetch`: `callerName` sent as `caller_name`, `toolType`
+still working standalone (deprecated, backward-compatible), and both
+fields present together. The runtime proof here is the redundant
+real-stack confirmation that the value actually lands in
+`policy_details.caller_name` on a persisted audit row.

--- a/runtime-e2e/caller_name_audit/test.mjs
+++ b/runtime-e2e/caller_name_audit/test.mjs
@@ -1,0 +1,146 @@
+// runtime-e2e/caller_name_audit/test.mjs
+//
+// Real-wire test of AuditToolCallRequest.callerName (#2912, sub-issue of
+// epic #2905) against a real running agent+orchestrator stack.
+//
+// getaxonflow/axonflow-enterprise PR #2953 added a `caller_name` field to
+// the orchestrator's tool-call audit path alongside the legacy `tool_type`
+// field (kept as a deprecated input fallback). The server resolves caller
+// identity as: caller_name if supplied -> legacy tool_type if supplied ->
+// a default. This test proves the SDK's new `callerName` field on
+// AuditToolCallRequest actually reaches `policy_details.caller_name` on a
+// real audit_logs row — not just that it serializes correctly (that's
+// covered by the Jest suite in tests/audit-tool-call.test.ts).
+//
+// Steps:
+//  1. Call the real SDK's client.auditToolCall() with callerName set to a
+//     distinctive, non-default value and inspect the wire response for a
+//     real audit_id.
+//  2. The orchestrator's AuditLogger batches writes (flush every 10s), so
+//     poll GET /api/v1/audit/{audit_id} until the row lands.
+//  3. The SDK's typed AuditLogEntry does not surface policy_details (it's
+//     an internal JSONB blob never decoded client-side), so this step reads
+//     the raw JSON body directly — the only way to observe
+//     policy_details.caller_name from outside the platform — and asserts
+//     it equals what we sent.
+//
+// A caller lacking per-user read authority is fail-closed to zero rows on
+// this stack (ADR/#2922 role-scoped audit reads), so step 1's request (and
+// step 2's read) carry an `X-User-Email` identity header. This is trusted
+// for AUDIT ATTRIBUTION ONLY (never authz/verdicts) when the deployment
+// opts in via AXONFLOW_TRUST_IDENTITY_HEADERS=true — this repo's
+// documented local-dev default (axonflow-enterprise/.env, per
+// docker-compose.yml's `identity_header_attribution` feature, v9.9.0). The
+// header is added by wrapping the real `fetch` used by the SDK's _fetch —
+// no response is faked or intercepted; every request and response here
+// really crosses the wire to the live stack.
+//
+// Run via (after `npm run build`; see ../README.md for how to bring up a
+// local stack and register/derive tenant credentials):
+//
+//   export AXONFLOW_AGENT_URL=http://localhost:8080
+//   export AXONFLOW_CLIENT_ID=local-dev-org
+//   export AXONFLOW_CLIENT_SECRET=<its secret>
+//   node runtime-e2e/caller_name_audit/test.mjs
+
+import { AxonFlow } from '../../dist/esm/client.js';
+
+const endpoint = process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080';
+const clientId =
+  process.env.AXONFLOW_CLIENT_ID || process.env.AXONFLOW_TENANT_ID || 'local-dev-org';
+const clientSecret = process.env.AXONFLOW_CLIENT_SECRET || process.env.AXONFLOW_TENANT_SECRET;
+
+if (!clientSecret) {
+  console.error(
+    'AXONFLOW_CLIENT_SECRET (or AXONFLOW_TENANT_SECRET) must be set; see ../README.md'
+  );
+  process.exit(2);
+}
+
+const probeEmail = `runtime-e2e-caller-name-${Date.now()}@example.com`;
+const wantCallerName = `e2e-caller-name-probe-${Date.now()}`;
+
+// Wrap the real global fetch (what the SDK's private _fetch() calls) so
+// every outbound request also carries the trust-gated X-User-Email
+// identity header. This is the ONLY modification to the transport — no
+// mocked/stubbed responses, no intercepted body. Restored immediately
+// after the SDK call so later raw fetches in this file are unaffected.
+const realFetch = globalThis.fetch;
+function withUserEmailHeader(fn) {
+  globalThis.fetch = (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('X-User-Email', probeEmail);
+    return realFetch(input, { ...init, headers });
+  };
+  return fn().finally(() => {
+    globalThis.fetch = realFetch;
+  });
+}
+
+let exitCode = 0;
+try {
+  const client = new AxonFlow({ endpoint, clientId, clientSecret });
+
+  const result = await withUserEmailHeader(() =>
+    client.auditToolCall({
+      toolName: 'runtimeE2eCallerNameProbe',
+      callerName: wantCallerName,
+    })
+  );
+  console.log(`SDK auditToolCall recorded -> audit_id=${result.auditId} status=${result.status}`);
+
+  if (!result.auditId) {
+    throw new Error('SDK auditToolCall returned no audit_id');
+  }
+
+  const authHeader = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+  const deadline = Date.now() + 25000;
+  let policyDetails = null;
+  let lastStatus = 0;
+
+  while (Date.now() < deadline && !policyDetails) {
+    const resp = await realFetch(`${endpoint}/api/v1/audit/${encodeURIComponent(result.auditId)}`, {
+      headers: {
+        Authorization: authHeader,
+        'X-User-Email': probeEmail,
+      },
+    });
+    lastStatus = resp.status;
+    if (resp.ok) {
+      const body = await resp.json();
+      if (body.policy_details && typeof body.policy_details === 'object') {
+        policyDetails = body.policy_details;
+        break;
+      }
+    }
+    await new Promise(r => setTimeout(r, 2000));
+  }
+
+  if (!policyDetails) {
+    console.error(
+      `FAIL: audit row ${result.auditId} did not surface policy_details within 25s (last GET status=${lastStatus})`
+    );
+    exitCode = 1;
+  } else if (!('caller_name' in policyDetails)) {
+    console.error(`FAIL: policy_details missing caller_name key entirely: ${JSON.stringify(policyDetails)}`);
+    exitCode = 1;
+  } else if (policyDetails.caller_name !== wantCallerName) {
+    console.error(
+      `FAIL: policy_details.caller_name = ${JSON.stringify(policyDetails.caller_name)}, ` +
+        `want ${JSON.stringify(wantCallerName)} (full policy_details: ${JSON.stringify(policyDetails)})`
+    );
+    exitCode = 1;
+  } else {
+    console.log(
+      `PASS: policy_details.caller_name = ${JSON.stringify(policyDetails.caller_name)} reached the audit_logs row via the real agent+orchestrator stack`
+    );
+    console.log(`Wire policy_details: ${JSON.stringify(policyDetails)}`);
+  }
+} catch (err) {
+  console.error(`FAIL: unexpected exception: ${err?.stack ?? err}`);
+  exitCode = 1;
+} finally {
+  globalThis.fetch = realFetch;
+}
+
+process.exit(exitCode);

--- a/src/client.ts
+++ b/src/client.ts
@@ -2313,7 +2313,7 @@ export class AxonFlow {
    * ```typescript
    * const result = await axonflow.auditToolCall({
    *   toolName: 'search_database',
-   *   toolType: 'function',
+   *   callerName: 'claude_code',
    *   input: { query: 'SELECT * FROM users' },
    *   output: { rows: 42 },
    *   workflowId: 'wf-123',
@@ -2332,6 +2332,7 @@ export class AxonFlow {
       tool_name: request.toolName,
     };
     if (request.toolType !== undefined) body.tool_type = request.toolType;
+    if (request.callerName !== undefined) body.caller_name = request.callerName;
     if (request.input !== undefined) body.input = request.input;
     if (request.output !== undefined) body.output = request.output;
     if (request.workflowId !== undefined) body.workflow_id = request.workflowId;

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -115,6 +115,10 @@ export interface AuditToolCallRequest {
    * Name of the client/caller that made the tool call (e.g. "claude_code",
    * "codex", "cursor", "openclaw"). Replaces the misleadingly-named
    * `toolType` field (getaxonflow/axonflow-enterprise#2912).
+   *
+   * Requires a platform with caller_name support (v9.11.0+); older platforms
+   * silently drop this field, so also set `toolType` if you need attribution
+   * there.
    */
   callerName?: string;
   /** Input parameters passed to the tool */

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -101,8 +101,22 @@ export interface AuditOptions {
 export interface AuditToolCallRequest {
   /** Name of the tool that was called */
   toolName: string;
-  /** Type of tool: "function", "mcp", or "api" */
+  /**
+   * Type of tool: "function", "mcp", or "api"
+   *
+   * @deprecated Use `callerName` instead. `toolType` was misleadingly named —
+   * every real caller (claude_code/codex/cursor/openclaw) used it to identify
+   * WHICH CLIENT made the call, not any property of the tool itself. Kept as
+   * a deprecated input fallback for backward compatibility; the server
+   * resolves `callerName` if supplied, else falls back to this field.
+   */
   toolType?: string;
+  /**
+   * Name of the client/caller that made the tool call (e.g. "claude_code",
+   * "codex", "cursor", "openclaw"). Replaces the misleadingly-named
+   * `toolType` field (getaxonflow/axonflow-enterprise#2912).
+   */
+  callerName?: string;
   /** Input parameters passed to the tool */
   input?: Record<string, unknown>;
   /** Output returned by the tool */

--- a/tests/audit-tool-call.test.ts
+++ b/tests/audit-tool-call.test.ts
@@ -105,6 +105,7 @@ describe('auditToolCall', () => {
     expect(callBody.tool_name).toBe('ping');
     // Optional fields should not be present
     expect(callBody.tool_type).toBeUndefined();
+    expect(callBody.caller_name).toBeUndefined();
     expect(callBody.input).toBeUndefined();
     expect(callBody.output).toBeUndefined();
     expect(callBody.workflow_id).toBeUndefined();
@@ -151,6 +152,69 @@ describe('auditToolCall', () => {
     // `orchestratorRequest` or `_fetch` adds status-code-based retry
     // that includes 401, this assertion fails.
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // getaxonflow/axonflow-enterprise#2912: tool_type was misleadingly named —
+  // every real caller used it to identify WHICH CLIENT made the call, not any
+  // property of the tool. callerName is the new, correctly-named field;
+  // toolType is kept as a deprecated fallback (not removed, not renamed).
+  it('should send callerName as caller_name in the request body', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockResponse({
+        audit_id: 'audit-tc-004',
+        status: 'recorded',
+        timestamp: '2026-07-16T10:00:00Z',
+      })
+    );
+
+    await client.auditToolCall({
+      toolName: 'search_database',
+      callerName: 'claude_code',
+    });
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.caller_name).toBe('claude_code');
+    // Legacy field must not be invented when the caller didn't supply it.
+    expect(callBody.tool_type).toBeUndefined();
+  });
+
+  it('should still send toolType standalone (deprecated, backward-compatible)', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockResponse({
+        audit_id: 'audit-tc-005',
+        status: 'recorded',
+        timestamp: '2026-07-16T10:01:00Z',
+      })
+    );
+
+    await client.auditToolCall({
+      toolName: 'search_database',
+      toolType: 'function',
+    });
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.tool_type).toBe('function');
+    expect(callBody.caller_name).toBeUndefined();
+  });
+
+  it('should send both toolType and callerName when both are supplied', async () => {
+    mockFetch.mockReturnValueOnce(
+      mockResponse({
+        audit_id: 'audit-tc-006',
+        status: 'recorded',
+        timestamp: '2026-07-16T10:02:00Z',
+      })
+    );
+
+    await client.auditToolCall({
+      toolName: 'search_database',
+      toolType: 'function',
+      callerName: 'codex',
+    });
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.tool_type).toBe('function');
+    expect(callBody.caller_name).toBe('codex');
   });
 
   it('should include error_message for failed tool calls', async () => {

--- a/tests/fixtures/wire-shape-baseline.json
+++ b/tests/fixtures/wire-shape-baseline.json
@@ -288,6 +288,12 @@
       ],
       "spec_only": []
     },
+    "AuditToolCallRequest": {
+      "sdk_only": [
+        "caller_name"
+      ],
+      "spec_only": []
+    },
     "Budget": {
       "sdk_only": [
         "enabled"


### PR DESCRIPTION
## Summary

- Adds `AuditToolCallRequest.callerName?: string`, forwarded as `caller_name` in the outgoing request body alongside the existing `tool_type` mapping.
- `toolType` is **kept as a deprecated input fallback** — not removed, not renamed — for backward compatibility during the deprecation window. Marked `@deprecated` in JSDoc, pointing to `callerName`.
- `tool_type` was misleadingly named: every real caller (claude_code/codex/cursor/openclaw) used it to identify WHICH CLIENT made the call, not any property of the tool. The platform side (getaxonflow/axonflow-enterprise#2953 — **merged, shipped in platform v9.11.0**) resolves: `caller_name` if supplied -> legacy `tool_type` if supplied -> `"unknown"` as the default when neither is supplied (getaxonflow/axonflow-enterprise#2903, folded into the same merge — no longer defaults to the specific client `"claude_code"`).

Implements getaxonflow/axonflow-enterprise#2912 (sub-issue of epic #2905) for the TypeScript SDK.

**Update (post-merge):** see #250 for corrections to CHANGELOG placement and runtime-e2e coverage made after this PR merged and #2953/#2903 landed on `axonflow-enterprise` main.

## Changes

- `src/types/gateway.ts` — new `callerName?: string` field on `AuditToolCallRequest`; `@deprecated` note added to `toolType`.
- `src/client.ts` — `auditToolCall()` forwards `callerName` as `caller_name` when supplied; JSDoc example updated to demonstrate `callerName`.
- `tests/audit-tool-call.test.ts` — new cases: `callerName` alone, `toolType` alone (still works, deprecated), both together.
- `runtime-e2e/caller_name_audit/` — new runtime-e2e proof that `callerName` reaches `policy_details.caller_name` on a real audit_logs row, driven through the real SDK `fetch` transport against a real running agent + orchestrator (no mocks, per `scripts/lint-no-mocks-in-runtime-e2e.sh`).
- `CHANGELOG.md` — new `[Unreleased]` section with an `Added` bullet for `caller_name` (this branch's base, `origin/main`, had no pre-existing `[Unreleased]` section to extend — the #2905/#2904 tool-field-split entry referenced in the issue lives on a separate in-flight branch, `feat/2907-langgraph-server-tool-split`, not yet merged at the time this PR was opened).

## Test plan

- [x] `npm test` — all 32 suites pass (970 passed, 13 skipped, 0 failed), including the new `callerName`/`toolType` cases in `tests/audit-tool-call.test.ts`.
- [x] `npm run build` succeeds.
- [x] `node runtime-e2e/caller_name_audit/test.mjs` run against a real local `axonflow-enterprise` agent+orchestrator stack (`make start`) — PASS, confirmed `policy_details.caller_name` on the persisted audit row matches the value sent via the SDK.
- [x] `scripts/lint-no-mocks-in-runtime-e2e.sh` — clean, no forbidden mock patterns.