### PR TITLE
fix(changelog,docs): correct post-merge staleness in callerName follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`AuditToolCallRequest.callerName`** — identifies which client made a
+  tool call (e.g. `claude_code`, `codex`, `cursor`, `openclaw`), sent to the
+  orchestrator as `caller_name` (getaxonflow/axonflow-enterprise#2912,
+  sub-issue of epic #2905). Replaces the misleadingly-named `toolType`
+  field, which every real caller used to identify the calling client rather
+  than any property of the tool itself. `toolType` is kept as a deprecated
+  input fallback — not removed, not renamed — so existing callers keep
+  working during the deprecation window; the server resolves `callerName`
+  if supplied, else falls back to legacy `toolType`, else defaults to
+  `"unknown"` for an unidentified caller (getaxonflow/axonflow-enterprise#2903
+  — an unidentified caller is no longer silently attributed to the specific
+  client `"claude_code"`).
+
 ## [9.0.0] - 2026-07-18
 
 ### Changed (BREAKING)
@@ -52,17 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Response-plane (`check-output`) `tool` scoping requires **AxonFlow platform
   v9.11.0+**; until then the SDK sends it forward-compatibly and older
   platforms ignore it.
-
-### Added
-
-- **`AuditToolCallRequest.callerName`** — identifies which client made a
-  tool call (e.g. `claude_code`, `codex`, `cursor`, `openclaw`), sent to the
-  orchestrator as `caller_name`. Replaces the misleadingly-named `toolType`
-  field, which every real caller used to identify the calling client rather
-  than any property of the tool itself. `toolType` is kept as a deprecated
-  input fallback — not removed, not renamed — so existing callers keep
-  working during the deprecation window; the server resolves `callerName`
-  if supplied, else falls back to legacy `toolType`, else a default.
 
 ## [8.5.1] - 2026-07-09 — getPlanStatus auth + queryConnector user token + example fixes
 

--- a/runtime-e2e/caller_name_audit/README.md
+++ b/runtime-e2e/caller_name_audit/README.md
@@ -10,17 +10,28 @@ runtime-e2e test (`axonflow-sdk-go/runtime-e2e/caller_name_audit/`).
 `audit_tool_call`'s `tool_type` field was misleadingly named — every real
 caller (claude_code/codex/cursor/openclaw) used it to identify **which
 client** made the call, not any property of the tool. getaxonflow/axonflow-enterprise
-PR #2953 added a correctly-named `caller_name` field alongside the legacy
-`tool_type` (kept as a deprecated input fallback, not removed/renamed). The
-server resolves: `caller_name` if supplied -> legacy `tool_type` if
-supplied -> a default.
+PR #2953 (merged; shipped in platform v9.11.0) added a correctly-named
+`caller_name` field alongside the legacy `tool_type` (kept as a deprecated
+input fallback, not removed/renamed). The server resolves: `caller_name`
+if supplied -> legacy `tool_type` if supplied -> `"unknown"` as the
+default when neither is supplied (getaxonflow/axonflow-enterprise#2903,
+folded into the same merge — an unidentified caller is no longer silently
+attributed to the specific client `"claude_code"`, which was the default
+before #2903).
 
-This test drives `AxonFlow.auditToolCall({ callerName: ... })` through the
-real `fetch` transport against a real running agent + orchestrator, then
-reads the resulting `audit_logs` row back over `GET /api/v1/audit/{id}`
-and asserts `policy_details.caller_name` equals what was sent. This is the
-only way to observe `policy_details` from outside the platform — the
-SDK's typed `AuditLogEntry` does not decode that JSONB column.
+This test drives `AxonFlow.auditToolCall(...)` through the real `fetch`
+transport against a real running agent + orchestrator, then reads the
+resulting `audit_logs` row back over `GET /api/v1/audit/{id}` and asserts
+`policy_details.caller_name` equals what's expected, for two scenarios:
+
+1. **Explicit `callerName`** — `policy_details.caller_name` equals the
+   value sent.
+2. **Neither `callerName` nor `toolType` supplied** — `policy_details.caller_name`
+   is `"unknown"` (regression guard for #2903 — must NOT be `"claude_code"`).
+
+This is the only way to observe `policy_details` from outside the
+platform — the SDK's typed `AuditLogEntry` does not decode that JSONB
+column.
 
 No mocked fetch, no jest doubles — real bytes over `node:http` to the
 live stack, enforced by `scripts/lint-no-mocks-in-runtime-e2e.sh`.
@@ -43,17 +54,17 @@ in Community mode (where `isCommunityMode()` alone already grants
 tenant-wide reads), the identity header is harmless and the row is
 readable regardless.
 
-## Prerequisite: platform support is not yet on `main`
+## Platform prerequisite
 
-`caller_name` support (axonflow-enterprise#2953) is implemented but, as of
-this writing, still an open PR on the `feat/2912-caller-name-tool-type-deprecation`
-branch — not yet merged to `axonflow-enterprise` main. Until it merges, a
-stack built from `axonflow-enterprise` main will accept `caller_name` in
-the request body (extra fields are ignored) but silently NOT write it to
-`policy_details` — this test will FAIL against such a stack, not because
-the SDK change is wrong, but because the platform side isn't deployed
-yet. Point your local `axonflow-enterprise` checkout at that branch (or a
-later commit that includes it) before running this test.
+`caller_name` support (getaxonflow/axonflow-enterprise#2953) and the
+`"unknown"` default fallback (getaxonflow/axonflow-enterprise#2903) are
+both merged to `axonflow-enterprise` main and shipped in platform
+**v9.11.0**. Point your local `axonflow-enterprise` checkout at `main` (or
+any release >= v9.11.0) before running this test — older stacks accept
+`caller_name` in the request body (extra fields are ignored) but silently
+do not write it to `policy_details`, so this test fails against them, not
+because the SDK change is wrong, but because the platform side predates
+the feature.
 
 ## Usage
 
@@ -75,4 +86,6 @@ through mocked `fetch`: `callerName` sent as `caller_name`, `toolType`
 still working standalone (deprecated, backward-compatible), and both
 fields present together. The runtime proof here is the redundant
 real-stack confirmation that the value actually lands in
-`policy_details.caller_name` on a persisted audit row.
+`policy_details.caller_name` on a persisted audit row — including the
+platform-side `"unknown"` default resolution (#2903), which is entirely
+server-side logic the SDK's unit tests cannot observe.

--- a/runtime-e2e/caller_name_audit/test.mjs
+++ b/runtime-e2e/caller_name_audit/test.mjs
@@ -3,33 +3,39 @@
 // Real-wire test of AuditToolCallRequest.callerName (#2912, sub-issue of
 // epic #2905) against a real running agent+orchestrator stack.
 //
-// getaxonflow/axonflow-enterprise PR #2953 added a `caller_name` field to
-// the orchestrator's tool-call audit path alongside the legacy `tool_type`
-// field (kept as a deprecated input fallback). The server resolves caller
-// identity as: caller_name if supplied -> legacy tool_type if supplied ->
-// a default. This test proves the SDK's new `callerName` field on
-// AuditToolCallRequest actually reaches `policy_details.caller_name` on a
-// real audit_logs row — not just that it serializes correctly (that's
-// covered by the Jest suite in tests/audit-tool-call.test.ts).
+// getaxonflow/axonflow-enterprise PR #2953 (merged; shipped in platform
+// v9.11.0) added a `caller_name` field to the orchestrator's tool-call
+// audit path alongside the legacy `tool_type` field (kept as a deprecated
+// input fallback). The server resolves caller identity as: caller_name if
+// supplied -> legacy tool_type if supplied -> "unknown" as the default
+// when neither is supplied (#2903, folded into the same merge — an
+// unidentified caller is no longer silently attributed to the specific
+// client "claude_code", which was the pre-#2903 default). This test
+// proves both halves of that contract land on a real audit_logs row —
+// not just that the SDK serializes callerName correctly (that's covered
+// by the Jest suite in tests/audit-tool-call.test.ts):
 //
-// Steps:
-//  1. Call the real SDK's client.auditToolCall() with callerName set to a
-//     distinctive, non-default value and inspect the wire response for a
-//     real audit_id.
+//   1. Explicit callerName -> policy_details.caller_name equals it.
+//   2. Neither callerName nor toolType supplied -> policy_details.caller_name
+//      is "unknown" (regression guard for #2903 — must NOT be "claude_code").
+//
+// Steps per scenario:
+//  1. Call the real SDK's client.auditToolCall() and inspect the wire
+//     response for a real audit_id.
 //  2. The orchestrator's AuditLogger batches writes (flush every 10s), so
 //     poll GET /api/v1/audit/{audit_id} until the row lands.
 //  3. The SDK's typed AuditLogEntry does not surface policy_details (it's
 //     an internal JSONB blob never decoded client-side), so this step reads
 //     the raw JSON body directly — the only way to observe
 //     policy_details.caller_name from outside the platform — and asserts
-//     it equals what we sent.
+//     it equals what's expected.
 //
 // A caller lacking per-user read authority is fail-closed to zero rows on
-// this stack (ADR/#2922 role-scoped audit reads), so step 1's request (and
-// step 2's read) carry an `X-User-Email` identity header. This is trusted
-// for AUDIT ATTRIBUTION ONLY (never authz/verdicts) when the deployment
-// opts in via AXONFLOW_TRUST_IDENTITY_HEADERS=true — this repo's
-// documented local-dev default (axonflow-enterprise/.env, per
+// this stack (ADR/#2922 role-scoped audit reads), so every write and its
+// verification read carry an `X-User-Email` identity header. This is
+// trusted for AUDIT ATTRIBUTION ONLY (never authz/verdicts) when the
+// deployment opts in via AXONFLOW_TRUST_IDENTITY_HEADERS=true — this
+// repo's documented local-dev default (axonflow-enterprise/.env, per
 // docker-compose.yml's `identity_header_attribution` feature, v9.9.0). The
 // header is added by wrapping the real `fetch` used by the SDK's _fetch —
 // no response is faked or intercepted; every request and response here
@@ -57,19 +63,19 @@ if (!clientSecret) {
   process.exit(2);
 }
 
-const probeEmail = `runtime-e2e-caller-name-${Date.now()}@example.com`;
-const wantCallerName = `e2e-caller-name-probe-${Date.now()}`;
+const client = new AxonFlow({ endpoint, clientId, clientSecret });
+const authHeader = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+const realFetch = globalThis.fetch;
 
 // Wrap the real global fetch (what the SDK's private _fetch() calls) so
 // every outbound request also carries the trust-gated X-User-Email
 // identity header. This is the ONLY modification to the transport — no
 // mocked/stubbed responses, no intercepted body. Restored immediately
 // after the SDK call so later raw fetches in this file are unaffected.
-const realFetch = globalThis.fetch;
-function withUserEmailHeader(fn) {
+function withUserEmailHeader(email, fn) {
   globalThis.fetch = (input, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('X-User-Email', probeEmail);
+    headers.set('X-User-Email', email);
     return realFetch(input, { ...init, headers });
   };
   return fn().finally(() => {
@@ -77,34 +83,39 @@ function withUserEmailHeader(fn) {
   });
 }
 
-let exitCode = 0;
-try {
-  const client = new AxonFlow({ endpoint, clientId, clientSecret });
+// Runs one auditToolCall() through the real SDK, polls the row back, and
+// asserts policy_details.caller_name === want. Returns true on PASS.
+async function runScenario(name, { toolName, callerName, toolType }, want) {
+  const probeEmail = `runtime-e2e-caller-name-${name}-${Date.now()}@example.com`;
 
-  const result = await withUserEmailHeader(() =>
-    client.auditToolCall({
-      toolName: 'runtimeE2eCallerNameProbe',
-      callerName: wantCallerName,
-    })
+  const request = { toolName };
+  if (callerName !== undefined) request.callerName = callerName;
+  if (toolType !== undefined) request.toolType = toolType;
+
+  const result = await withUserEmailHeader(probeEmail, () => client.auditToolCall(request));
+  console.log(
+    `[${name}] SDK auditToolCall recorded -> audit_id=${result.auditId} status=${result.status}`
   );
-  console.log(`SDK auditToolCall recorded -> audit_id=${result.auditId} status=${result.status}`);
 
   if (!result.auditId) {
-    throw new Error('SDK auditToolCall returned no audit_id');
+    console.error(`FAIL [${name}]: SDK auditToolCall returned no audit_id`);
+    return false;
   }
 
-  const authHeader = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
   const deadline = Date.now() + 25000;
   let policyDetails = null;
   let lastStatus = 0;
 
   while (Date.now() < deadline && !policyDetails) {
-    const resp = await realFetch(`${endpoint}/api/v1/audit/${encodeURIComponent(result.auditId)}`, {
-      headers: {
-        Authorization: authHeader,
-        'X-User-Email': probeEmail,
-      },
-    });
+    const resp = await realFetch(
+      `${endpoint}/api/v1/audit/${encodeURIComponent(result.auditId)}`,
+      {
+        headers: {
+          Authorization: authHeader,
+          'X-User-Email': probeEmail,
+        },
+      }
+    );
     lastStatus = resp.status;
     if (resp.ok) {
       const body = await resp.json();
@@ -118,23 +129,51 @@ try {
 
   if (!policyDetails) {
     console.error(
-      `FAIL: audit row ${result.auditId} did not surface policy_details within 25s (last GET status=${lastStatus})`
+      `FAIL [${name}]: audit row ${result.auditId} did not surface policy_details within 25s (last GET status=${lastStatus})`
     );
-    exitCode = 1;
-  } else if (!('caller_name' in policyDetails)) {
-    console.error(`FAIL: policy_details missing caller_name key entirely: ${JSON.stringify(policyDetails)}`);
-    exitCode = 1;
-  } else if (policyDetails.caller_name !== wantCallerName) {
+    return false;
+  }
+  if (!('caller_name' in policyDetails)) {
     console.error(
-      `FAIL: policy_details.caller_name = ${JSON.stringify(policyDetails.caller_name)}, ` +
-        `want ${JSON.stringify(wantCallerName)} (full policy_details: ${JSON.stringify(policyDetails)})`
+      `FAIL [${name}]: policy_details missing caller_name key entirely: ${JSON.stringify(policyDetails)}`
     );
+    return false;
+  }
+  if (policyDetails.caller_name !== want) {
+    console.error(
+      `FAIL [${name}]: policy_details.caller_name = ${JSON.stringify(policyDetails.caller_name)}, ` +
+        `want ${JSON.stringify(want)} (full policy_details: ${JSON.stringify(policyDetails)})`
+    );
+    return false;
+  }
+
+  console.log(
+    `PASS [${name}]: policy_details.caller_name = ${JSON.stringify(policyDetails.caller_name)} reached the audit_logs row via the real agent+orchestrator stack`
+  );
+  console.log(`[${name}] Wire policy_details: ${JSON.stringify(policyDetails)}`);
+  return true;
+}
+
+let exitCode = 0;
+try {
+  const wantCallerName = `e2e-caller-name-probe-${Date.now()}`;
+
+  const explicitOk = await runScenario(
+    'explicit-caller-name',
+    { toolName: 'runtimeE2eCallerNameProbe', callerName: wantCallerName },
+    wantCallerName
+  );
+
+  // #2903 regression guard: neither callerName nor toolType supplied must
+  // default to "unknown", NOT the specific client "claude_code".
+  const defaultOk = await runScenario(
+    'neither-supplied-defaults-to-unknown',
+    { toolName: 'runtimeE2eCallerNameDefaultProbe' },
+    'unknown'
+  );
+
+  if (!explicitOk || !defaultOk) {
     exitCode = 1;
-  } else {
-    console.log(
-      `PASS: policy_details.caller_name = ${JSON.stringify(policyDetails.caller_name)} reached the audit_logs row via the real agent+orchestrator stack`
-    );
-    console.log(`Wire policy_details: ${JSON.stringify(policyDetails)}`);
   }
 } catch (err) {
   console.error(`FAIL: unexpected exception: ${err?.stack ?? err}`);


### PR DESCRIPTION
## Summary

Follow-up to #249 (`feat(client): add callerName to audit_tool_call, deprecate toolType`), which has already merged. getaxonflow/axonflow-enterprise PR #2953 (the platform side of #2912) has since merged and shipped in platform **v9.11.0**, folding in #2903's default-fallback fix: the resolution chain is now `caller_name` -> legacy `tool_type` -> `"unknown"` (not `"claude_code"`). Three things went stale / wrong in the interim:

- **`CHANGELOG.md`** — the merge of #249 landed its `### Added` bullet nested *inside* the `## [9.0.0]` langgraph release section instead of under `## [Unreleased]` (which the following langgraph PR's entry expected to find empty). This made it look like the `callerName` addition shipped as part of the 9.0.0 breaking release, which it didn't. Moved the bullet back under `[Unreleased]` and added an explicit note about the `"unknown"` default (#2903).
- **`runtime-e2e/caller_name_audit/README.md`** — dropped the "platform support is not yet on `main`" disclaimer (stale now that #2953 is merged) and corrected the default-fallback description to `"unknown"`.
- **`runtime-e2e/caller_name_audit/test.mjs`** — added a second scenario asserting that when neither `callerName` nor `toolType` is supplied, `policy_details.caller_name` resolves to `"unknown"` on a real `audit_logs` row (regression guard for #2903), alongside the existing explicit-`callerName` scenario.

No `src/` changes — `AuditToolCallRequest.callerName` and `auditToolCall()` from #249 are unaffected; this is purely a docs/changelog/e2e-test correction.

## Test plan

- [x] `npm test` — 32 suites pass (976 passed, 13 skipped, 0 failed).
- [x] `npm run lint` — clean.
- [x] `npm run build` succeeds.
- [x] `scripts/lint-no-mocks-in-runtime-e2e.sh` — clean, no forbidden mock patterns.
- [x] Wire-shape contract gate (`scripts/wire-shape/validate.js`) run genuinely against the pinned OpenAPI spec SHA (not skipped) — no new drift.
- [x] `node runtime-e2e/caller_name_audit/test.mjs` run against a freshly rebuilt local `axonflow-enterprise` stack on real merged `main` (v9.11.0, not the old feature branch) — both scenarios PASS:
  - explicit `callerName` -> `policy_details.caller_name` matches.
  - neither field supplied -> `policy_details.caller_name === "unknown"`.

Refs getaxonflow/axonflow-enterprise#2912, #2903, #2953