### PR TITLE
chore(release): v9.1.0 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0] - 2026-08-04
+
 ### Added
 
 - masfeat real wire fields (#3254 pin-advance batch): `orgId`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axonflow/sdk",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axonflow/sdk",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "openai": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axonflow/sdk",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "AxonFlow SDK - Add invisible AI governance to your applications in 3 lines of code",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,4 +8,4 @@
  * this value matches package.json.
  */
 // AUTO-GENERATED — do not edit. Run `npm run stamp-version` to update.
-export const VERSION = '9.0.0';
+export const VERSION = '9.1.0';


### PR DESCRIPTION
## Release v9.1.0

This is a version-bump + CHANGELOG release PR only. No code changes here - the entire 9.1.0 payload is already merged to main across the #3254 pin-advance batch and the caller_name work:

- **Additive audit read-model wire fields.** `policy_decision`, `policy_details`, `response_time_ms` on the audit read model, and `action` on audit search. `request_type` is deprecated (never read on the 9.x line). All additive and absence-tolerant.
- **masfeat/OJK model extension** (#3254 pin-advance batch). Real wire fields added; the never-served fiction fields deprecated. No field removed.
- **OpenAPI spec pin advanced to community v9.13.0.**

No field or public API name was removed, so this is a proper **MINOR** (fields added, some deprecated). Platform v9.14.0 is released and `/health` advertises SDK 9.1.0, so this must ship.

The CHANGELOG `[Unreleased]` section was moved wholesale under a new `## [9.1.0] - 2026-08-04` header, leaving a fresh empty `[Unreleased]` above it. The version-alignment gate and the release preflight both pass locally against 9.1.0.

### Version files bumped
- `package.json` -> `"version": "9.1.0"`
- `package-lock.json` (top-level + `packages[""]`) -> `9.1.0`
- `src/version.ts` -> `VERSION = '9.1.0'` (regenerated by `npm run stamp-version`)

### Verification
- `npm ci` + `npm run build` clean; built `dist/**/version.js` emits `9.1.0`
- `validate-version-alignment.sh` passes (all four version sites aligned)

### After merge (master runs the tag; this triggers the **npm** publish)
```
git tag v9.1.0 <merge-commit> && git push origin v9.1.0
```

## Skip-runtime-e2e justification

This is a mechanical release version bump: it changes only the version file(s) and the CHANGELOG (retitling the Unreleased section to [9.1.0]). No runtime surface changes. The code shipped in 9.1.0 (the additive audit read-model wire fields, the masfeat/OJK model extension, and the OpenAPI spec pin) landed in prior PRs that each exercised the runtime-e2e suite; a version stamp has no new user-facing behavior to demonstrate. Skip applied under the v9.14.0 release-train execution.